### PR TITLE
Stability improvements: resource leak fixes and stress tests

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -11,6 +11,7 @@ jobs:
   check:
     name: "JVM/JS/Android Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -29,6 +30,7 @@ jobs:
   apple:
     name: "Apple Target Tests"
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,10 @@ val isMacOS = System.getProperty("os.name").lowercase().contains("mac")
 val getNextVersion = project.extra["getNextVersion"] as (Boolean) -> Any
 project.version = getNextVersion(!isRunningOnGithub).toString()
 
-println("Version: ${project.version}\nisRunningOnGithub: $isRunningOnGithub\nisMainBranchGithub: $isMainBranchGithub")
+// Only print version info when not in quiet mode (avoids polluting CI output)
+if (gradle.startParameter.logLevel != LogLevel.QUIET) {
+    println("Version: ${project.version}\nisRunningOnGithub: $isRunningOnGithub\nisMainBranchGithub: $isMainBranchGithub")
+}
 
 repositories {
     google()

--- a/src/commonJvmMain/kotlin/com/ditchoom/socket/nio2/AsyncClientSocket.kt
+++ b/src/commonJvmMain/kotlin/com/ditchoom/socket/nio2/AsyncClientSocket.kt
@@ -18,7 +18,18 @@ class AsyncClientSocket(
         hostname: String?,
     ) = withTimeout(timeout) {
         val asyncSocket = asyncSocket()
+        // Assign socket immediately so close() can clean it up if connect fails
         this@AsyncClientSocket.socket = asyncSocket
-        asyncSocket.aConnect(buildInetAddress(port, hostname), timeout)
+        try {
+            asyncSocket.aConnect(buildInetAddress(port, hostname), timeout)
+        } catch (e: Throwable) {
+            // Ensure socket is closed on any failure during open
+            try {
+                asyncSocket.close()
+            } catch (_: Throwable) {
+                // Ignore close errors
+            }
+            throw e
+        }
     }
 }

--- a/src/commonTest/kotlin/com/ditchoom/socket/SimpleSocketTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/socket/SimpleSocketTests.kt
@@ -22,7 +22,8 @@ class SimpleSocketTests {
     fun connectTimeoutWorks() =
         runTest {
             try {
-                ClientSocket.connect(3, hostname = "example.com", timeout = 1.seconds)
+                // Use non-routable IP address to test connection timeout without external network
+                ClientSocket.connect(80, hostname = "10.255.255.1", timeout = 1.seconds)
                 fail("should not have reached this")
             } catch (_: TimeoutCancellationException) {
             } catch (_: SocketException) {
@@ -38,7 +39,8 @@ class SimpleSocketTests {
     fun invalidHost() =
         runTestNoTimeSkipping {
             try {
-                ClientSocket.connect(3, hostname = "example234asdfa.com", timeout = 1.seconds)
+                // Use .invalid TLD which is reserved per RFC 2606 and should never resolve
+                ClientSocket.connect(80, hostname = "nonexistent.invalid", timeout = 1.seconds)
                 fail("should not have reached this")
             } catch (e: SocketException) {
                 // expected
@@ -49,8 +51,9 @@ class SimpleSocketTests {
     fun closeWorks() =
         runTest {
             try {
-                ClientSocket.connect(3, hostname = "example.com", timeout = 1.seconds)
-                fail("the port is invalid, so this line should never hit")
+                // Use non-routable IP address to test without external network
+                ClientSocket.connect(80, hostname = "10.255.255.1", timeout = 1.seconds)
+                fail("the connection should timeout, so this line should never hit")
             } catch (t: TimeoutCancellationException) {
                 // expected
             } catch (s: SocketException) {
@@ -98,6 +101,10 @@ class SimpleSocketTests {
             serverJob.cancel()
         }
 
+    /**
+     * Integration tests that require external network access.
+     * These verify real-world HTTP/HTTPS connectivity.
+     */
     @Test
     fun httpRawSocketExampleDomain() = readHttp("example.com", false)
 

--- a/src/commonTest/kotlin/com/ditchoom/socket/TlsErrorTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/socket/TlsErrorTests.kt
@@ -8,6 +8,9 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Tests for TLS/SSL error handling.
  *
+ * NOTE: These tests require external network access to verify TLS behavior
+ * with real certificates and SNI. They connect to well-known HTTPS sites.
+ *
  * Exception hierarchy:
  * - SocketException (base)
  *   - SSLSocketException


### PR DESCRIPTION
## Summary

This PR improves the stability and reliability of the socket library by fixing resource leaks, adding comprehensive stress tests, and fixing the Maven Central deploy.

### Bug Fixes
- **JVM socket resource leaks**: Fixed `NioClientSocket.open()` and `AsyncClientSocket.open()` to properly close socket channels if connection fails partway through. Previously, if `aConfigureBlocking()` or `connect()` threw an exception, the socket channel would leak.
- **Maven Central deploy**: Fixed the `nextVersion` task output being polluted by debug println, which caused GitHub Actions to fail parsing the version. Debug info now only prints when not in quiet mode.

### Test Improvements
- **Removed external network dependencies**: Basic socket tests (`connectTimeoutWorks`, `closeWorks`, `invalidHost`) now use non-routable IPs (10.255.255.1) or reserved TLDs (.invalid) instead of connecting to external domains.
- **Documented integration tests**: HTTP/HTTPS and TLS tests that require external network are clearly documented as integration tests.

### New Stress Tests
- `rapidConnectDisconnectCycles`: Rapidly connects and disconnects 20 times to catch resource leaks
- `failedConnectionsCleanup`: Verifies failed connection attempts don't leak resources
- `serverRestartCycle`: Tests that servers can restart and reuse ports

## Test plan
- [x] JVM tests pass
- [x] ktlint passes
- [ ] JS/Browser tests pass
- [ ] Apple tests pass
- [ ] Android tests pass