### PR TITLE
Use macOS runner for publishing to include Apple targets

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -75,7 +75,7 @@ jobs:
     name: Dry-run Build (skip-release)
     needs: check-release
     if: needs.check-release.outputs.skip_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -84,6 +84,12 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
+      - name: Cache Konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Run all checks and tests
@@ -105,7 +111,7 @@ jobs:
     name: Draft Release (staging only)
     needs: check-release
     if: needs.check-release.outputs.draft_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -120,6 +126,12 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
+      - name: Cache Konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Get version (Major)
@@ -163,11 +175,11 @@ jobs:
               --title="v${version}" \
               --notes="## [${PR_TITLE}](${PR_URL})"$'\n\n'"**Status:** Awaiting validation in [Maven Central Staging](${staging_url})"$'\n\n'"### To complete release:"$'\n'"1. Validate artifacts in Maven Central staging area"$'\n'"2. Run the 'Complete Release' workflow, or"$'\n'"3. Publish this draft release (will create tag and release to Maven Central)"$'\n\n'"### To cancel:"$'\n'"1. Drop the staging repository in Maven Central"$'\n'"2. Delete this draft release"$'\n'"   No tag or Maven Central artifacts will remain."
 
-  deploy:
-    name: Build & Deploy to Maven Central
+  macos:
+    name: MacOS Build & Deploy to Maven Central
     needs: check-release
     if: needs.check-release.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -182,6 +194,12 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
+      - name: Cache Konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Get version (Major)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,107 @@
+name: "Complete or Cancel Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.2.3 - without v prefix)'
+        required: true
+        type: string
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - complete
+          - cancel
+
+permissions:
+  contents: write
+
+jobs:
+  complete-release:
+    name: Complete Release
+    if: github.event.inputs.action == 'complete'
+    runs-on: macos-latest
+    env:
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: gradle
+
+      - name: Release from Maven Central staging
+        run: |
+          # The vanniktech plugin's releaseToMavenCentral task releases the staging repo
+          # This only works if there's a staging repo from a previous publishToMavenCentral
+          echo "Releasing version ${{ github.event.inputs.version }} from Maven Central staging..."
+          ./gradlew releaseToMavenCentral --no-configuration-cache
+
+      - name: Publish draft release (creates tag)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ github.event.inputs.version }}"
+          tag="v${version}"
+          maven_url="https://central.sonatype.com/artifact/com.ditchoom/socket/${version}"
+
+          # Get the draft release and update its notes
+          echo "Publishing draft release ${tag}..."
+
+          # Update the release notes and publish (removes draft status, creates tag)
+          gh release edit "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --draft=false \
+              --notes="$(gh release view "$tag" --repo="$GITHUB_REPOSITORY" --json body -q .body | sed "s|Awaiting validation.*|Released to Maven Central|" | sed "s|### To complete release:.*||" | sed "s|### To cancel:.*||")"$'\n\n'"**Maven Central:** [com.ditchoom:buffer:${version}](${maven_url})"
+
+          echo "✅ Release ${tag} published!"
+          echo "   Tag created: ${tag}"
+          echo "   Maven Central: ${maven_url}"
+
+  cancel-release:
+    name: Cancel Release
+    if: github.event.inputs.action == 'cancel'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ github.event.inputs.version }}"
+          tag="v${version}"
+
+          echo "Cancelling release ${tag}..."
+
+          # Check if the release exists and is a draft
+          release_info=$(gh release view "$tag" --repo="$GITHUB_REPOSITORY" --json isDraft,tagName 2>/dev/null || echo "not_found")
+
+          if [ "$release_info" = "not_found" ]; then
+            echo "⚠️  Release ${tag} not found. Nothing to delete."
+            exit 0
+          fi
+
+          is_draft=$(echo "$release_info" | jq -r .isDraft)
+
+          if [ "$is_draft" != "true" ]; then
+            echo "❌ Release ${tag} is not a draft. Cannot cancel a published release."
+            echo "   If you need to remove this release, do so manually."
+            exit 1
+          fi
+
+          # Delete the draft release (no tag exists for drafts)
+          gh release delete "$tag" --repo="$GITHUB_REPOSITORY" --yes
+
+          echo "✅ Draft release ${tag} deleted!"
+          echo ""
+          echo "⚠️  IMPORTANT: You must also drop the staging repository in Maven Central:"
+          echo "   https://central.sonatype.com/publishing/deployments"
+          echo ""
+          echo "   No git tag was created. No artifacts were published to Maven Central."

--- a/src/commonMain/kotlin/com/ditchoom/socket/ClientSocket.kt
+++ b/src/commonMain/kotlin/com/ditchoom/socket/ClientSocket.kt
@@ -8,6 +8,10 @@ import com.ditchoom.data.Writer
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+/**
+ * A client socket that can connect to a remote server.
+ * Provides both reading and writing capabilities with suspend functions.
+ */
 interface ClientSocket :
     SocketController,
     Reader,


### PR DESCRIPTION
## Summary
- Change all deploy jobs from `ubuntu-latest` to `macos-latest`
- Add Konan cache for faster Kotlin/Native builds
- Add `release.yaml` workflow for manual release completion (copied from buffer)
- Include KDoc comment on ClientSocket to trigger automatic release

## Problem
Socket 1.2.2 was published without iOS, macOS, tvOS, and watchOS targets because:
- Kotlin/Native for Apple platforms can only be compiled on macOS
- The CI was running on Ubuntu which cannot build these targets

## Solution
Match the buffer module's CI configuration which successfully publishes all targets by running deploy jobs on `macos-latest`.

## Test plan
- [ ] CI passes
- [ ] After merge, verify Apple native artifacts are published to Maven Central