### PR TITLE
Fix Apple targets: embed static library in klib for consumer linking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,9 @@ fun KotlinNativeTarget.configureSocketWrapperCinterop(libSubdir: String) {
         create("SocketWrapper") {
             defFile("src/nativeInterop/cinterop/SocketWrapper.def")
             includeDirs(swiftHeaderDir)
+            // Embed the static library in the klib so consumers link it automatically
             extraOpts("-libraryPath", libPath)
+            extraOpts("-staticLibrary", "libSocketWrapper.a")
             tasks.named(interopProcessingTaskName) {
                 dependsOn(buildSwiftTask)
             }
@@ -81,11 +83,9 @@ fun KotlinNativeTarget.configureSocketWrapperCinterop(libSubdir: String) {
     compilations["main"].compileTaskProvider.configure {
         dependsOn(buildSwiftTask)
     }
-    // Link the Swift static library for all binaries (main and test)
+    // Link Swift runtime libraries (platform-specific) for all binaries
+    // Note: libSocketWrapper.a is now embedded in the klib via -staticLibrary
     binaries.all {
-        // Link our Swift wrapper library
-        linkerOpts("-L$libPath", "-lSocketWrapper")
-        // Link Swift runtime libraries (platform-specific)
         linkerOpts(
             "-L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$swiftPlatform",
             "-L/usr/lib/swift",

--- a/src/nativeInterop/cinterop/SocketWrapper.def
+++ b/src/nativeInterop/cinterop/SocketWrapper.def
@@ -7,5 +7,19 @@ headerFilter = SocketWrapper-Swift.h
 # Framework dependencies for the Swift wrapper
 linkerOpts = -framework Network -framework Foundation
 
+# Swift runtime library paths - needed for consumers to link the embedded Swift code
+# These paths work for Xcode installations on macOS
+linkerOpts.macos_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -L/usr/lib/swift
+linkerOpts.macos_x64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -L/usr/lib/swift
+linkerOpts.ios_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos -L/usr/lib/swift
+linkerOpts.ios_simulator_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator -L/usr/lib/swift
+linkerOpts.ios_x64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator -L/usr/lib/swift
+linkerOpts.tvos_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos -L/usr/lib/swift
+linkerOpts.tvos_simulator_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator -L/usr/lib/swift
+linkerOpts.tvos_x64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator -L/usr/lib/swift
+linkerOpts.watchos_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos -L/usr/lib/swift
+linkerOpts.watchos_simulator_arm64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator -L/usr/lib/swift
+linkerOpts.watchos_x64 = -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator -L/usr/lib/swift
+
 # Note: libSocketWrapper.a is embedded in the klib via -staticLibrary in build.gradle.kts
 # Consumers automatically link it when using this library.

--- a/src/nativeInterop/cinterop/SocketWrapper.def
+++ b/src/nativeInterop/cinterop/SocketWrapper.def
@@ -7,5 +7,5 @@ headerFilter = SocketWrapper-Swift.h
 # Framework dependencies for the Swift wrapper
 linkerOpts = -framework Network -framework Foundation
 
-# Note: The libSocketWrapper.a static library must be linked by consuming projects.
-# Consumers need to add linkerOpts pointing to the library location.
+# Note: libSocketWrapper.a is embedded in the klib via -staticLibrary in build.gradle.kts
+# Consumers automatically link it when using this library.


### PR DESCRIPTION
## Summary
- Embed `libSocketWrapper.a` static library directly in the klib using cinterop's `-staticLibrary` option
- Consumers no longer need to manually link the library - it's automatically linked when using the socket library

## Problem
Previously, consumers of the socket library got linker errors like:
```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$__TtC13SocketWrapper19ClientSocketWrapper", referenced from:
```

This happened because `libSocketWrapper.a` was built locally but not included in the published klib.

## Solution
Use cinterop's `-staticLibrary` option to embed the static library in the klib. The library is now at `included/libSocketWrapper.a` inside the klib, and consumers automatically link it.

## Test plan
- [x] Build socket library with `./gradlew macosArm64Test` - passes
- [x] Verify static library is embedded: `find build/classes/kotlin/macosArm64/main/cinterop/ -name "*.a"` shows `included/libSocketWrapper.a`
- [ ] Test with websocket library as consumer after publishing snapshot