### PR TITLE
Fix Dokka API docs showing SNAPSHOT version

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use for API docs (e.g. 2.0.1). Leave empty for default.'
+        required: false
 
 permissions:
   contents: read
@@ -36,8 +40,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Determine version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate API Documentation with Dokka
-        run: ./gradlew copyDokkaToDocusaurus
+        run: ./gradlew copyDokkaToDocusaurus ${{ steps.version.outputs.version && format('-Pversion={0}', steps.version.outputs.version) || '' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Pass the release tag version via `-Pversion` when the docs workflow is triggered by a release event, so Dokka generates docs with the correct release version instead of a computed SNAPSHOT
- Add a `version` input to `workflow_dispatch` so docs can be manually rebuilt with a specific version without needing a new release

## Manual fix
After merging, go to **Actions > Deploy Documentation > Run workflow** and enter the current release version (e.g. `2.0.1`) to immediately fix the live site.

## Test plan
- [ ] Merge and trigger workflow_dispatch with a version (e.g. `2.0.1`) — verify the deployed API docs show that version
- [ ] Create a test release — verify the docs workflow picks up the tag version automatically