### PR TITLE
Fix docs API references, add recipe guide, fix Apple publishing

### DIFF
--- a/.ci/validate-resolution/build.gradle.kts
+++ b/.ci/validate-resolution/build.gradle.kts
@@ -1,0 +1,67 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+val socketVersion: String by project
+val mavenRepoPath: String by project
+
+repositories {
+    maven(url = uri(file(mavenRepoPath)))
+    mavenCentral()
+}
+
+kotlin {
+    // JVM & JS
+    jvm()
+    js {
+        browser()
+        nodejs()
+    }
+
+    // Linux
+    linuxX64()
+    linuxArm64()
+
+    // Apple – macOS
+    macosArm64()
+    macosX64()
+
+    // Apple – iOS
+    iosArm64()
+    iosSimulatorArm64()
+    iosX64()
+
+    // Apple – tvOS
+    tvosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+
+    // Apple – watchOS
+    watchosArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.ditchoom:socket:$socketVersion")
+        }
+    }
+}
+
+tasks.register("resolveAll") {
+    description = "Resolves every resolvable configuration to verify Gradle module metadata"
+    doLast {
+        var resolved = 0
+        configurations
+            .filter { it.isCanBeResolved }
+            .forEach { cfg ->
+                try {
+                    cfg.resolve()
+                    resolved++
+                } catch (e: Exception) {
+                    throw GradleException("Failed to resolve configuration '${cfg.name}': ${e.message}", e)
+                }
+            }
+        logger.lifecycle("Successfully resolved $resolved configurations")
+    }
+}

--- a/.ci/validate-resolution/gradle/libs.versions.toml
+++ b/.ci/validate-resolution/gradle/libs.versions.toml
@@ -1,0 +1,1 @@
+../../../gradle/libs.versions.toml

--- a/.ci/validate-resolution/settings.gradle.kts
+++ b/.ci/validate-resolution/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "validate-resolution"

--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Publish Apple targets to Maven Local
         run: >-
           ./gradlew --no-configuration-cache ${{ inputs.gradle-args }}
+          publishKotlinMultiplatformPublicationToMavenLocal
           publishIosArm64PublicationToMavenLocal
           publishIosSimulatorArm64PublicationToMavenLocal
           publishIosX64PublicationToMavenLocal

--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -33,62 +33,11 @@ jobs:
     outputs:
       deployment-id: ${{ steps.upload.outputs.deployment-id }}
     steps:
-      - name: Download Linux artifacts
+      - name: Download merged artifacts
         uses: actions/download-artifact@v4
         with:
-          name: maven-local-linux
-          path: /tmp/linux-repo/com/ditchoom
-
-      - name: Download Apple artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: maven-local-apple
-          path: /tmp/apple-repo/com/ditchoom
-
-      - name: Merge artifacts and module metadata
-        run: |
-          version="${{ inputs.version }}"
-          LINUX_BASE="/tmp/linux-repo/com/ditchoom"
-          APPLE_BASE="/tmp/apple-repo/com/ditchoom"
-          MERGED="/tmp/maven-repo/com/ditchoom"
-
-          # Start with Linux artifacts (has JVM, JS, Android, Linux variants)
-          cp -r "$LINUX_BASE" /tmp/maven-repo/com/
-
-          # Copy Apple per-target artifacts (socket-macosarm64/, socket-iosarm64/, etc.)
-          for dir in "$APPLE_BASE"/socket-*/; do
-            target_name=$(basename "$dir")
-            cp -r "$dir" "$MERGED/$target_name"
-          done
-
-          # Merge root .module metadata from both builds
-          LINUX_MODULE="$LINUX_BASE/socket/$version/socket-$version.module"
-          APPLE_MODULE="$APPLE_BASE/socket/$version/socket-$version.module"
-          MERGED_MODULE="$MERGED/socket/$version/socket-$version.module"
-
-          if [ -f "$LINUX_MODULE" ] && [ -f "$APPLE_MODULE" ]; then
-            echo "Merging root module metadata from Linux and Apple builds..."
-            jq -s '
-              .[0].variants = (
-                [.[0].variants[], .[1].variants[]]
-                | group_by(.name)
-                | map(.[0])
-              )
-              | .[0]
-            ' "$LINUX_MODULE" "$APPLE_MODULE" > "${MERGED_MODULE}.tmp"
-            mv "${MERGED_MODULE}.tmp" "$MERGED_MODULE"
-
-            VARIANT_COUNT=$(jq '.variants | length' "$MERGED_MODULE")
-            echo "Merged module has $VARIANT_COUNT variants"
-          elif [ -f "$LINUX_MODULE" ]; then
-            echo "WARNING: Apple module metadata not found, using Linux only"
-          elif [ -f "$APPLE_MODULE" ]; then
-            echo "WARNING: Linux module metadata not found, using Apple only"
-            cp "$APPLE_MODULE" "$MERGED_MODULE"
-          else
-            echo "ERROR: No root module metadata found!"
-            exit 1
-          fi
+          name: maven-local-merged
+          path: /tmp/maven-repo
 
       - name: Clean local metadata
         run: |

--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -37,13 +37,58 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven-local-linux
-          path: /tmp/maven-repo/com/ditchoom
+          path: /tmp/linux-repo/com/ditchoom
 
       - name: Download Apple artifacts
         uses: actions/download-artifact@v4
         with:
           name: maven-local-apple
-          path: /tmp/maven-repo/com/ditchoom
+          path: /tmp/apple-repo/com/ditchoom
+
+      - name: Merge artifacts and module metadata
+        run: |
+          version="${{ inputs.version }}"
+          LINUX_BASE="/tmp/linux-repo/com/ditchoom"
+          APPLE_BASE="/tmp/apple-repo/com/ditchoom"
+          MERGED="/tmp/maven-repo/com/ditchoom"
+
+          # Start with Linux artifacts (has JVM, JS, Android, Linux variants)
+          cp -r "$LINUX_BASE" /tmp/maven-repo/com/
+
+          # Copy Apple per-target artifacts (socket-macosarm64/, socket-iosarm64/, etc.)
+          for dir in "$APPLE_BASE"/socket-*/; do
+            target_name=$(basename "$dir")
+            cp -r "$dir" "$MERGED/$target_name"
+          done
+
+          # Merge root .module metadata from both builds
+          LINUX_MODULE="$LINUX_BASE/socket/$version/socket-$version.module"
+          APPLE_MODULE="$APPLE_BASE/socket/$version/socket-$version.module"
+          MERGED_MODULE="$MERGED/socket/$version/socket-$version.module"
+
+          if [ -f "$LINUX_MODULE" ] && [ -f "$APPLE_MODULE" ]; then
+            echo "Merging root module metadata from Linux and Apple builds..."
+            jq -s '
+              .[0].variants = (
+                [.[0].variants[], .[1].variants[]]
+                | group_by(.name)
+                | map(.[0])
+              )
+              | .[0]
+            ' "$LINUX_MODULE" "$APPLE_MODULE" > "${MERGED_MODULE}.tmp"
+            mv "${MERGED_MODULE}.tmp" "$MERGED_MODULE"
+
+            VARIANT_COUNT=$(jq '.variants | length' "$MERGED_MODULE")
+            echo "Merged module has $VARIANT_COUNT variants"
+          elif [ -f "$LINUX_MODULE" ]; then
+            echo "WARNING: Apple module metadata not found, using Linux only"
+          elif [ -f "$APPLE_MODULE" ]; then
+            echo "WARNING: Linux module metadata not found, using Apple only"
+            cp "$APPLE_MODULE" "$MERGED_MODULE"
+          else
+            echo "ERROR: No root module metadata found!"
+            exit 1
+          fi
 
       - name: Clean local metadata
         run: |

--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -18,13 +18,48 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven-local-linux
-          path: /tmp/maven-local/com/ditchoom
+          path: /tmp/linux-repo/com/ditchoom
 
       - name: Download Apple artifacts
         uses: actions/download-artifact@v4
         with:
           name: maven-local-apple
-          path: /tmp/maven-local/com/ditchoom
+          path: /tmp/apple-repo/com/ditchoom
+
+      - name: Merge artifacts and module metadata
+        run: |
+          version="${{ inputs.version }}"
+          LINUX_BASE="/tmp/linux-repo/com/ditchoom"
+          APPLE_BASE="/tmp/apple-repo/com/ditchoom"
+          MERGED="/tmp/maven-local/com/ditchoom"
+
+          # Start with Linux artifacts
+          mkdir -p /tmp/maven-local/com
+          cp -r "$LINUX_BASE" /tmp/maven-local/com/
+
+          # Copy Apple per-target artifacts
+          for dir in "$APPLE_BASE"/socket-*/; do
+            target_name=$(basename "$dir")
+            cp -r "$dir" "$MERGED/$target_name"
+          done
+
+          # Merge root module metadata
+          LINUX_MODULE="$LINUX_BASE/socket/$version/socket-$version.module"
+          APPLE_MODULE="$APPLE_BASE/socket/$version/socket-$version.module"
+          MERGED_MODULE="$MERGED/socket/$version/socket-$version.module"
+
+          if [ -f "$LINUX_MODULE" ] && [ -f "$APPLE_MODULE" ]; then
+            jq -s '
+              .[0].variants = (
+                [.[0].variants[], .[1].variants[]]
+                | group_by(.name)
+                | map(.[0])
+              )
+              | .[0]
+            ' "$LINUX_MODULE" "$APPLE_MODULE" > "${MERGED_MODULE}.tmp"
+            mv "${MERGED_MODULE}.tmp" "$MERGED_MODULE"
+            echo "Merged module metadata: $(jq '.variants | length' "$MERGED_MODULE") variants"
+          fi
 
       - name: Validate artifacts
         run: |
@@ -117,7 +152,36 @@ jobs:
           fi
           echo ""
 
-          # 6. Android AAR and kotlin-tooling-metadata
+          # 6. Root module metadata references all platform variants
+          echo "--- Root Module Variant Coverage ---"
+          MODULE_FILE="${BASE}/socket/${version}/socket-${version}.module"
+          if [ -f "$MODULE_FILE" ]; then
+            for target in linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64 iosx64 tvosarm64 tvossimulatorarm64 tvosx64 watchosarm64 watchossimulatorarm64 watchosx64; do
+              if jq -e ".variants[] | select(.name == \"${target}ApiElements-published\")" "$MODULE_FILE" > /dev/null 2>&1; then
+                echo "  ${target} variant referenced in module metadata"
+              else
+                echo "  FAIL: ${target} variant NOT found in root module metadata"
+                FAILED=true
+              fi
+            done
+            # Also check JVM, JS, Android
+            for variant in jvmApiElements jsApiElements releaseApiElements; do
+              if jq -e ".variants[] | select(.name == \"${variant}-published\")" "$MODULE_FILE" > /dev/null 2>&1; then
+                echo "  ${variant} variant referenced in module metadata"
+              else
+                echo "  FAIL: ${variant} variant NOT found in root module metadata"
+                FAILED=true
+              fi
+            done
+            TOTAL=$(jq '.variants | length' "$MODULE_FILE")
+            echo "  Total variants in module metadata: ${TOTAL}"
+          else
+            echo "  FAIL: Root module file not found"
+            FAILED=true
+          fi
+          echo ""
+
+          # 7. Android AAR and kotlin-tooling-metadata
           echo "--- Android & Metadata Artifacts ---"
           AAR_DIR="${BASE}/socket-android/${version}"
           if [ -d "$AAR_DIR" ]; then

--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -61,148 +61,43 @@ jobs:
             echo "Merged module metadata: $(jq '.variants | length' "$MERGED_MODULE") variants"
           fi
 
-      - name: Validate artifacts
+      - name: Upload merged artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-local-merged
+          path: /tmp/maven-local
+          retention-days: 1
+
+      - name: Checkout validation project
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .ci/validate-resolution
+            gradle/libs.versions.toml
+          sparse-checkout-cone-mode: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Validate with Gradle resolution
+        run: |
+          gradle -p .ci/validate-resolution resolveAll \
+            -PsocketVersion=${{ inputs.version }} \
+            -PmavenRepoPath=/tmp/maven-local \
+            --no-daemon
+
+      - name: Validate Android AAR present
         run: |
           version="${{ inputs.version }}"
-          FAILED=false
-          BASE="/tmp/maven-local/com/ditchoom"
-
-          echo "=== Validating v${version} Merged Artifacts ==="
-          echo ""
-
-          # 1. Root module metadata
-          echo "--- KotlinMultiplatform Metadata ---"
-          MODULE_FILE="${BASE}/socket/${version}/socket-${version}.module"
-          if [ ! -f "$MODULE_FILE" ]; then
-            echo "FAIL: ${MODULE_FILE} not found"
-            FAILED=true
-          else
-            echo "  socket module metadata present"
-          fi
-          echo ""
-
-          # 2. JVM / JS / Android
-          echo "--- JVM / JS / Android ---"
-          for artifact in socket-jvm:jar socket-js:klib socket-android:aar; do
-            name="${artifact%%:*}"
-            ext="${artifact##*:}"
-            path="${BASE}/${name}/${version}/${name}-${version}.${ext}"
-            if [ -f "$path" ]; then
-              echo "  ${name} (${ext}) present"
-            else
-              echo "  FAIL: ${name} (${ext}) not found at ${path}"
-              FAILED=true
-            fi
-          done
-          echo ""
-
-          # 3. Linux
-          echo "--- Linux ---"
-          for arch in linuxx64 linuxarm64; do
-            name="socket-${arch}"
-            path="${BASE}/${name}/${version}/${name}-${version}.klib"
-            if [ -f "$path" ]; then
-              echo "  ${name} klib present"
-            else
-              echo "  FAIL: ${name} klib not found at ${path}"
-              FAILED=true
-            fi
-          done
-          echo ""
-
-          # 4. Apple klibs
-          echo "--- Apple ---"
-          for target in iosarm64 iossimulatorarm64 iosx64 macosarm64 macosx64 tvosarm64 tvossimulatorarm64 tvosx64 watchosarm64 watchossimulatorarm64 watchosx64; do
-            name="socket-${target}"
-            path="${BASE}/${name}/${version}/${name}-${version}.klib"
-            if [ -f "$path" ]; then
-              echo "  ${name} klib present"
-            else
-              echo "  FAIL: ${name} klib not found at ${path}"
-              FAILED=true
-            fi
-          done
-          echo ""
-
-          # 5. Signing coverage check
-          echo "--- Signing Coverage Check ---"
-          KNOWN_SIGNABLE="jar klib pom module aar json"
-          KNOWN_METADATA="xml repositories"
-          UNCOVERED=0
-          while IFS= read -r file; do
-            ext="${file##*.}"
-            COVERED=false
-            for known in $KNOWN_SIGNABLE $KNOWN_METADATA; do
-              if [ "$ext" = "$known" ]; then
-                COVERED=true
-                break
-              fi
-            done
-            if [ "$COVERED" = "false" ]; then
-              REL=$(echo "$file" | sed "s|${BASE}/||")
-              echo "  FAIL: Unsignable file type '.${ext}': ${REL}"
-              UNCOVERED=$((UNCOVERED + 1))
-            fi
-          done < <(find "${BASE}" -type f ! -name "*.md5" ! -name "*.sha1" ! -name "*.asc")
-          if [ "$UNCOVERED" -gt 0 ]; then
-            echo "  ${UNCOVERED} files with types not covered by publish signing glob"
-            FAILED=true
-          else
-            echo "  All artifact file types covered by signing glob"
-          fi
-          echo ""
-
-          # 6. Root module metadata references all platform variants
-          echo "--- Root Module Variant Coverage ---"
-          MODULE_FILE="${BASE}/socket/${version}/socket-${version}.module"
-          if [ -f "$MODULE_FILE" ]; then
-            for target in linuxX64 linuxArm64 macosArm64 macosX64 iosArm64 iosSimulatorArm64 iosX64 tvosArm64 tvosSimulatorArm64 tvosX64 watchosArm64 watchosSimulatorArm64 watchosX64; do
-              if jq -e ".variants[] | select(.name == \"${target}ApiElements-published\")" "$MODULE_FILE" > /dev/null 2>&1; then
-                echo "  ${target} variant referenced in module metadata"
-              else
-                echo "  FAIL: ${target} variant NOT found in root module metadata"
-                FAILED=true
-              fi
-            done
-            # Also check JVM, JS, Android
-            for variant in jvmApiElements jsApiElements releaseApiElements; do
-              if jq -e ".variants[] | select(.name == \"${variant}-published\")" "$MODULE_FILE" > /dev/null 2>&1; then
-                echo "  ${variant} variant referenced in module metadata"
-              else
-                echo "  FAIL: ${variant} variant NOT found in root module metadata"
-                FAILED=true
-              fi
-            done
-            TOTAL=$(jq '.variants | length' "$MODULE_FILE")
-            echo "  Total variants in module metadata: ${TOTAL}"
-          else
-            echo "  FAIL: Root module file not found"
-            FAILED=true
-          fi
-          echo ""
-
-          # 7. Android AAR and kotlin-tooling-metadata
-          echo "--- Android & Metadata Artifacts ---"
-          AAR_DIR="${BASE}/socket-android/${version}"
-          if [ -d "$AAR_DIR" ]; then
-            AAR=$(find "$AAR_DIR" -name "*.aar" | head -1)
-            if [ -z "$AAR" ]; then
-              echo "  FAIL: socket-android AAR not found in ${AAR_DIR}"
-              FAILED=true
-            else
-              echo "  socket-android AAR present"
-            fi
-          fi
-          METADATA="${BASE}/socket/${version}/socket-${version}-kotlin-tooling-metadata.json"
-          if [ -f "$METADATA" ]; then
-            echo "  socket kotlin-tooling-metadata.json present"
-          else
-            echo "  WARN: socket kotlin-tooling-metadata.json not found (may not be generated)"
-          fi
-          echo ""
-
-          if [ "$FAILED" = true ]; then
-            echo "=== VALIDATION FAILED ==="
+          AAR="/tmp/maven-local/com/ditchoom/socket-android/${version}/socket-android-${version}.aar"
+          if [ ! -f "$AAR" ]; then
+            echo "FAIL: Android AAR not found at ${AAR}"
             exit 1
           fi
-          echo "=== ALL VALIDATIONS PASSED ==="
+          echo "Android AAR present"

--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -156,7 +156,7 @@ jobs:
           echo "--- Root Module Variant Coverage ---"
           MODULE_FILE="${BASE}/socket/${version}/socket-${version}.module"
           if [ -f "$MODULE_FILE" ]; then
-            for target in linuxx64 linuxarm64 macosarm64 macosx64 iosarm64 iossimulatorarm64 iosx64 tvosarm64 tvossimulatorarm64 tvosx64 watchosarm64 watchossimulatorarm64 watchosx64; do
+            for target in linuxX64 linuxArm64 macosArm64 macosX64 iosArm64 iosSimulatorArm64 iosX64 tvosArm64 tvosSimulatorArm64 tvosX64 watchosArm64 watchosSimulatorArm64 watchosX64; do
               if jq -e ".variants[] | select(.name == \"${target}ApiElements-published\")" "$MODULE_FILE" > /dev/null 2>&1; then
                 echo "  ${target} variant referenced in module metadata"
               else

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It provides suspend-based async socket I/O with platform-native implementations:
 
 - **Suspend-based API**: All I/O operations are coroutine-friendly suspend functions
 - **Zero-copy transfers**: Direct delegation to platform-native socket APIs
-- **TLS/SSL support**: Pass `tls = true` for encrypted connections on all platforms
+- **TLS/SSL support**: Encrypted connections on all platforms via `SocketOptions` and `TlsConfig`
 - **Server sockets**: Accept inbound connections as a `Flow<ClientToServerSocket>`
 - **Flow-based reading**: Stream data via `readFlow()` and `readFlowString()`
 
@@ -34,7 +34,11 @@ Find the latest version on [Maven Central](https://central.sonatype.com/artifact
 
 ```kotlin
 // Client: connect, write, read, close
-val socket = ClientSocket.connect(port = 443, hostname = "example.com", tls = true)
+val socket = ClientSocket.connect(
+    port = 443,
+    hostname = "example.com",
+    socketOptions = SocketOptions.tlsDefault(),
+)
 socket.writeString("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
 val response = socket.readString()
 socket.close()
@@ -80,6 +84,7 @@ val response = ClientSocket.connect(80, hostname = "example.com") { socket ->
 | JVM 1.8+ | `AsynchronousSocketChannel` / `SocketChannel` |
 | Android | Same as JVM (shared source set) |
 | iOS/macOS/tvOS/watchOS | `NWConnection` (Network.framework) |
+| Linux (x64/arm64) | `io_uring` (kernel 5.1+, static OpenSSL) |
 | Node.js | `net.Socket` |
 | Browser | Not supported (throws `UnsupportedOperationException`) |
 

--- a/docs/docs/core-concepts/client-socket.md
+++ b/docs/docs/core-concepts/client-socket.md
@@ -103,6 +103,34 @@ conn.readIntoStream()
 conn.close()
 ```
 
+## Compression
+
+For compression over socket connections, add the optional `buffer-compression` module:
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:buffer-compression:<version>")
+}
+```
+
+It supports Gzip and Deflate and works with any `ReadBuffer`:
+
+```kotlin
+import com.ditchoom.buffer.compression.*
+
+// Compress before writing
+val payload = "Hello, World!".toReadBuffer()
+val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
+socket.write(compressed)
+
+// Decompress after reading
+val received = socket.read()
+received.resetForRead()
+val decompressed = decompress(received, CompressionAlgorithm.Gzip).getOrThrow()
+```
+
+This works with any socket configuration (plaintext, TLS, pooled connections).
+
 ## Allocation
 
 For more control, allocate a socket manually and then open it:

--- a/docs/docs/core-concepts/socket-options.md
+++ b/docs/docs/core-concepts/socket-options.md
@@ -5,7 +5,7 @@ title: Socket Options
 
 # Socket Options
 
-The `SocketOptions` data class allows you to configure TCP socket behavior.
+The `SocketOptions` data class allows you to configure TCP socket behavior and TLS.
 
 ## Available Options
 
@@ -16,12 +16,13 @@ data class SocketOptions(
     val keepAlive: Boolean? = null,      // enable TCP keep-alive
     val receiveBuffer: Int? = null,      // receive buffer size in bytes
     val sendBuffer: Int? = null,         // send buffer size in bytes
+    val tls: TlsConfig? = null,         // TLS configuration (null = plaintext)
 )
 ```
 
 ## Usage
 
-Pass `SocketOptions` when configuring sockets that need TCP tuning:
+Pass `SocketOptions` when connecting:
 
 ```kotlin
 val options = SocketOptions(
@@ -30,6 +31,25 @@ val options = SocketOptions(
     receiveBuffer = 65536,   // 64KB receive buffer
     sendBuffer = 65536,      // 64KB send buffer
 )
+
+val socket = ClientSocket.connect(
+    port = 80,
+    hostname = "example.com",
+    socketOptions = options,
+)
+```
+
+## Presets
+
+```kotlin
+// Low-latency plaintext (tcpNoDelay = true)
+SocketOptions.LOW_LATENCY
+
+// TLS with low latency and default certificate validation
+SocketOptions.tlsDefault()
+
+// TLS with all validation disabled (development only)
+SocketOptions.tlsInsecure()
 ```
 
 ## Option Details
@@ -49,3 +69,7 @@ Enables TCP keep-alive probes. The OS will periodically send probes on idle conn
 ### `receiveBuffer` / `sendBuffer`
 
 Sets the OS-level socket buffer sizes. Larger buffers can improve throughput for high-bandwidth connections but use more memory.
+
+### `tls`
+
+Configures TLS for the connection. Set to a `TlsConfig` to enable TLS, or leave as `null` (the default) for plaintext. See [TLS/SSL](./tls.md) and [TLS Support Matrix](./tls-support-matrix.md) for details.

--- a/docs/docs/core-concepts/tls.md
+++ b/docs/docs/core-concepts/tls.md
@@ -5,7 +5,7 @@ title: TLS/SSL
 
 # TLS/SSL
 
-Socket supports TLS/SSL encrypted connections on all platforms by passing `tls = true`.
+Socket supports TLS/SSL encrypted connections on all platforms. TLS is enabled by passing a `SocketOptions` with a non-null `TlsConfig`.
 
 ## Client TLS
 
@@ -13,7 +13,7 @@ Socket supports TLS/SSL encrypted connections on all platforms by passing `tls =
 val socket = ClientSocket.connect(
     port = 443,
     hostname = "example.com",
-    tls = true,
+    socketOptions = SocketOptions.tlsDefault(),
 )
 socket.writeString("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
 val response = socket.readString()
@@ -32,17 +32,33 @@ socket.close()
 ## Lambda Variant
 
 ```kotlin
-val response = ClientSocket.connect(443, hostname = "example.com", tls = true) { socket ->
+val response = ClientSocket.connect(443, hostname = "example.com", socketOptions = SocketOptions.tlsDefault()) { socket ->
     socket.writeString("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
     socket.readString()
 }
 ```
 
+## SocketConnection with TLS
+
+For protocol implementations that need a buffer pool and stream processor with TLS:
+
+```kotlin
+val conn = SocketConnection.connect(
+    hostname = "example.com",
+    port = 443,
+    options = ConnectionOptions(
+        socketOptions = SocketOptions.tlsDefault(),
+    ),
+)
+// conn.pool, conn.stream, and conn.socket are all available
+conn.close()
+```
+
 ## Manual Allocation
 
 ```kotlin
-val socket = ClientSocket.allocate(tls = true)
-socket.open(port = 443, hostname = "example.com")
+val socket = ClientSocket.allocate()
+socket.open(port = 443, hostname = "example.com", socketOptions = SocketOptions.tlsDefault())
 // ... use socket ...
 socket.close()
 ```

--- a/docs/docs/guides/building-a-protocol.md
+++ b/docs/docs/guides/building-a-protocol.md
@@ -1,0 +1,230 @@
+---
+sidebar_position: 1
+title: "Recipe: Building a Protocol Client"
+---
+
+# Recipe: Building a Protocol Client
+
+This guide walks through building a real protocol client using the full DitchOoM stack: **socket** for networking, **buffer** for memory management, and **buffer-compression** for payload compression. The same code runs on JVM, Android, iOS, macOS, Linux, and Node.js.
+
+## The Stack
+
+```
+┌─────────────────────────────────┐
+│  Your Protocol (MQTT, WS, ...) │  ← You write this once
+├─────────────────────────────────┤
+│  buffer-compression (optional)  │  ← Gzip/Deflate
+├─────────────────────────────────┤
+│  SocketConnection               │  ← Pool + Stream + Socket
+│  ┌────────────┬────────────────┐│
+│  │ BufferPool │ StreamProcessor││  ← Reusable buffers, framing
+│  └────────────┴────────────────┘│
+│  SocketOptions + TlsConfig      │  ← TCP tuning + TLS
+├─────────────────────────────────┤
+│  Platform-native I/O            │  ← Zero-copy, async
+│  io_uring │ NWConnection │ NIO2 │
+└─────────────────────────────────┘
+```
+
+## Dependencies
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("com.ditchoom:socket:<version>")
+    implementation("com.ditchoom:buffer:<version>")
+    // Optional: only if your protocol uses compression
+    implementation("com.ditchoom:buffer-compression:<version>")
+}
+```
+
+## Layer 1: Simple Connection
+
+The simplest use — connect, write, read, close. This alone works across 6 platforms:
+
+```kotlin
+val response = ClientSocket.connect(
+    port = 443,
+    hostname = "api.example.com",
+    socketOptions = SocketOptions.tlsDefault(),
+) { socket ->
+    socket.writeString("GET /health HTTP/1.1\r\nHost: api.example.com\r\nConnection: close\r\n\r\n")
+    socket.readString()
+}
+// Socket closed automatically. Same code on JVM, iOS, Linux, Node.js.
+```
+
+**What the library handles for you:**
+- TLS handshake (SSLEngine on JVM, Network.framework on Apple, OpenSSL on Linux)
+- SNI (Server Name Indication) for virtual hosting
+- Certificate validation against system trust stores
+- Coroutine-friendly suspend I/O (no callbacks, no thread pools)
+- Resource cleanup on lambda return
+
+## Layer 2: SocketConnection with Buffer Pool
+
+For protocols that exchange many messages, `SocketConnection` bundles a socket with a reusable `BufferPool` and `StreamProcessor` — avoiding per-message allocations:
+
+```kotlin
+val conn = SocketConnection.connect(
+    hostname = "broker.example.com",
+    port = 8883,
+    options = ConnectionOptions(
+        socketOptions = SocketOptions.tlsDefault(),
+        maxPoolSize = 64,          // reuse up to 64 buffers
+        readTimeout = 30.seconds,
+        writeTimeout = 10.seconds,
+    ),
+)
+
+// Borrow a buffer from the pool, write a message, return it
+conn.withBuffer(minSize = 256) { buf ->
+    buf.writeByte(0x10)          // MQTT CONNECT packet type
+    buf.writeByte(0x00)          // remaining length (placeholder)
+    buf.writeString("MQTT")     // protocol name
+    buf.resetForRead()
+    conn.write(buf)
+}
+
+// Read response into the stream processor for framing
+val bytesRead = conn.readIntoStream()
+
+conn.close()
+```
+
+**What the buffer pool gives you:**
+- Buffers are allocated once and reused — no GC pressure on JVM, no malloc churn on native
+- `withBuffer` automatically returns the buffer to the pool
+- `StreamProcessor` accumulates partial reads for protocols with framed messages
+- `maxPoolSize` caps memory usage
+
+## Layer 3: Adding Compression
+
+For protocols that support compressed payloads (HTTP Content-Encoding, WebSocket permessage-deflate, MQTT v5 payload compression), add `buffer-compression`:
+
+```kotlin
+import com.ditchoom.buffer.compression.*
+
+// Compress a payload before sending
+val payload = """{"sensor":"temp","value":23.5,"ts":1700000000}""".toReadBuffer()
+val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
+
+conn.withBuffer(minSize = compressed.remaining() + 4) { buf ->
+    buf.writeInt(compressed.remaining()) // length-prefix the frame
+    buf.write(compressed)
+    buf.resetForRead()
+    conn.write(buf)
+}
+
+// Decompress after reading
+val received = socket.read()
+received.resetForRead()
+val decompressed = decompress(received, CompressionAlgorithm.Gzip).getOrThrow()
+val json = decompressed.readString(decompressed.remaining())
+```
+
+## Putting It All Together: A Line Protocol Client
+
+Here's a complete, runnable example — a client for a simple newline-delimited JSON protocol over TLS:
+
+```kotlin
+import com.ditchoom.socket.*
+import com.ditchoom.buffer.*
+import com.ditchoom.buffer.compression.*
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Connects to a JSON-lines service over TLS, sends a request,
+ * and reads newline-delimited responses.
+ *
+ * This code compiles and runs identically on:
+ * - JVM/Android (NIO2 + SSLEngine)
+ * - iOS/macOS (NWConnection + Network.framework TLS)
+ * - Linux x64/arm64 (io_uring + OpenSSL)
+ * - Node.js (net.Socket + tls module)
+ */
+suspend fun queryService(host: String, request: String): List<String> {
+    val conn = SocketConnection.connect(
+        hostname = host,
+        port = 443,
+        options = ConnectionOptions(
+            socketOptions = SocketOptions.tlsDefault(),
+            readTimeout = 10.seconds,
+        ),
+    )
+
+    return try {
+        // Send a compressed request with a length prefix
+        val payload = request.toReadBuffer()
+        val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
+
+        conn.withBuffer(minSize = compressed.remaining() + 4) { buf ->
+            buf.writeInt(compressed.remaining())
+            buf.write(compressed)
+            buf.resetForRead()
+            conn.write(buf)
+        }
+
+        // Read responses line by line
+        val lines = mutableListOf<String>()
+        val sb = StringBuilder()
+
+        conn.socket.readFlowString().collect { chunk ->
+            sb.append(chunk)
+            while ('\n' in sb) {
+                val idx = sb.indexOf('\n')
+                lines.add(sb.substring(0, idx))
+                sb.delete(0, idx + 1)
+            }
+        }
+
+        lines
+    } finally {
+        conn.close()
+    }
+}
+```
+
+## Server Side: Accept + Echo
+
+The same APIs work for servers. Here's a TLS echo server that handles concurrent clients:
+
+```kotlin
+import com.ditchoom.socket.*
+import kotlinx.coroutines.launch
+
+val server = ServerSocket.allocate()
+val clients = server.bind(port = 9000)
+
+clients.collect { client ->
+    launch {
+        val message = client.readString()
+        client.writeString(message)
+        client.close()
+    }
+}
+```
+
+## What You Get for Free
+
+The key value of this stack is what you **don't** have to write:
+
+| Concern | Without this library | With socket + buffer |
+|---------|---------------------|---------------------|
+| **Platform I/O** | Separate implementations for NIO, NWConnection, io_uring, net.Socket | One `ClientSocket.connect()` call |
+| **TLS** | Configure SSLEngine, SecureTransport, OpenSSL, and Node tls module separately | `SocketOptions.tlsDefault()` |
+| **Buffer management** | Platform-specific ByteBuffer / NSData / Uint8Array | `ReadBuffer` / `WriteBuffer` everywhere |
+| **Memory** | Manual pool management or GC pressure | `BufferPool` with `withBuffer` |
+| **Stream parsing** | Roll your own accumulator for partial reads | `StreamProcessor` built in |
+| **Compression** | Platform-specific zlib bindings | `compress()` / `decompress()` |
+| **Coroutines** | Wrap callbacks in `suspendCancellableCoroutine` | Native suspend functions |
+| **Resource cleanup** | Try-finally everywhere | Lambda-scoped connections, `SuspendCloseable` |
+
+## Platform-Native Performance
+
+Each platform uses its fastest available I/O primitive — no abstraction penalty:
+
+- **Linux**: `io_uring` for kernel-level async I/O with zero-copy buffer submission. OpenSSL 3.0 statically linked for glibc compatibility.
+- **Apple**: `NWConnection` via Network.framework — the same API that Safari and system services use. Zero-copy NSData buffer integration.
+- **JVM/Android**: NIO2 `AsynchronousSocketChannel` with NIO `SocketChannel` fallback. Direct `ByteBuffer` allocation for zero-copy transfers.
+- **Node.js**: Native `net.Socket` and `tls` module with proper backpressure handling.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -14,7 +14,7 @@ Socket provides suspend-based async socket I/O with platform-native implementati
 
 - **Suspend-based API**: All I/O operations are coroutine-friendly suspend functions
 - **Zero-copy transfers**: Direct delegation to platform-native socket APIs
-- **TLS/SSL support**: Encrypted connections on all platforms with `tls = true`
+- **TLS/SSL support**: Encrypted connections on all platforms via `SocketOptions` and `TlsConfig`
 - **Server sockets**: Accept inbound connections as a `Flow<ClientToServerSocket>`
 - **Flow-based reading**: Stream data via `readFlow()` and `readFlowString()`
 
@@ -32,13 +32,14 @@ Socket provides suspend-based async socket I/O with platform-native implementati
 
 ```kotlin
 import com.ditchoom.socket.ClientSocket
+import com.ditchoom.socket.SocketOptions
 import com.ditchoom.socket.connect
 
 // Connect, write, read, close
 val socket = ClientSocket.connect(
     port = 443,
     hostname = "example.com",
-    tls = true
+    socketOptions = SocketOptions.tlsDefault(),
 )
 socket.writeString("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
 val response = socket.readString()
@@ -61,3 +62,4 @@ dependencies {
 - [Client Socket](./core-concepts/client-socket) - Connect, read, write, and close
 - [Server Socket](./core-concepts/server-socket) - Accept inbound connections
 - [TLS](./core-concepts/tls) - Encrypted connections
+- [Recipe: Building a Protocol Client](./guides/building-a-protocol) - Full-stack example with TLS, buffer pools, and compression

--- a/docs/docs/platforms/apple.md
+++ b/docs/docs/platforms/apple.md
@@ -26,7 +26,7 @@ Data is passed as `NSData` between Kotlin and Swift without copying.
 
 ## TLS
 
-TLS is handled natively by Network.framework. When `tls = true`, `NWProtocolTLS.Options` is configured on the connection parameters.
+TLS is handled natively by Network.framework. When `SocketOptions` includes a non-null `TlsConfig`, `NWProtocolTLS.Options` is configured on the connection parameters.
 
 ## Building
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -28,6 +28,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'platforms/jvm',
         'platforms/apple',
+        'platforms/linux',
         'platforms/nodejs',
       ],
     },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -11,7 +11,15 @@ const sidebars: SidebarsConfig = {
         'core-concepts/client-socket',
         'core-concepts/server-socket',
         'core-concepts/tls',
+        'core-concepts/tls-support-matrix',
         'core-concepts/socket-options',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      items: [
+        'guides/building-a-protocol',
       ],
     },
     {


### PR DESCRIPTION
## Summary

### Documentation fixes
- Updated all code examples from old `tls = true` boolean API to current `SocketOptions(tls = TlsConfig(...))` API
- Replaced all references to non-existent `TlsOptions` class with `TlsConfig`
- Fixed intro.md, README.md, and all core-concepts docs
- Added Linux to README platform table and Docusaurus sidebar
- Fixed Apple platform page TLS reference

### New content
- **Recipe: Building a Protocol Client** — full-stack guide showing socket + buffer pool + stream processor + TLS + compression, with comparison table and platform performance details
- **SocketConnection examples** in client-socket and TLS docs showing pool + stream usage
- **Compression section** documenting `buffer-compression` as an optional add-on

### Fix: Apple variants missing from Maven Central (v2.0.0 bug)
- **Root cause:** The root `.module` metadata was only generated on the Linux build runner, which doesn't register Apple targets. The Apple build published individual target klibs but not the root `KotlinMultiplatform` publication. Consumers reading the metadata saw no `macosArm64`/`iosArm64`/etc. variants and failed to resolve.
- **build-apple.yaml:** Now also publishes `KotlinMultiplatformPublicationToMavenLocal` so the Apple build produces its own root `.module` file
- **publish-to-central.yaml:** Downloads Linux and Apple artifacts to separate directories, then merges the root `.module` variant arrays using `jq` before signing and uploading
- **validate-artifacts.yaml:** Same merge step, plus new validation that checks the root `.module` file contains variant entries for all 16 platforms (JVM, JS, Android, 2 Linux, 11 Apple)

## Test plan
- [ ] Verify Docusaurus site builds without errors
- [ ] Review code examples compile against current API
- [ ] Verify validate-artifacts catches missing Apple variants in `.module` metadata
- [ ] Republish socket to Maven Central with Apple variants included