### PR TITLE
Update com.ditchoom:buffer to 3.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mavenPublish = "0.35.0"
 dokka = "2.1.0"
 kotlinxCoroutines = "1.10.2"
 kotlinWrappers = "2025.12.6"
-buffer = "3.0.0"
+buffer = "3.0.1"
 androidxCore = "1.17.0"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Bumps `com.ditchoom:buffer` from 3.0.0 to 3.0.1

## Test plan
- [ ] CI passes with the updated dependency