### PR TITLE
Add streaming API, buffer-flow integration, and docs overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,23 @@ Socket
 
 See the [project website][docs] for documentation and APIs.
 
-Socket is a Kotlin Multiplatform library for cross-platform TCP networking.
-It provides suspend-based async socket I/O with platform-native implementations:
+Cross-platform TCP + TLS with streaming, compression, and buffer pooling — same Kotlin code on JVM, Android, iOS, macOS, Linux, and Node.js.
 
-- **JVM/Android**: `AsynchronousSocketChannel` (NIO2) with `SocketChannel` (NIO) fallback
-- **iOS/macOS/tvOS/watchOS**: `NWConnection` via Network.framework (zero-copy)
-- **Node.js**: `net.Socket` API
+## Why Socket?
 
-## Features
-
-- **Suspend-based API**: All I/O operations are coroutine-friendly suspend functions
-- **Zero-copy transfers**: Direct delegation to platform-native socket APIs
-- **TLS/SSL support**: Encrypted connections on all platforms via `SocketOptions` and `TlsConfig`
-- **Server sockets**: Accept inbound connections as a `Flow<ClientToServerSocket>`
-- **Flow-based reading**: Stream data via `readFlow()` and `readFlowString()`
+| Concern | Without | With socket + buffer |
+|---------|---------|---------------------|
+| **Platform I/O** | Separate NIO, NWConnection, io_uring, net.Socket | `ClientSocket.connect()` |
+| **TLS** | Configure SSLEngine, SecureTransport, OpenSSL, tls separately | `SocketOptions.tlsDefault()` |
+| **Buffer management** | Platform-specific ByteBuffer / NSData / Uint8Array | `ReadBuffer` / `WriteBuffer` everywhere |
+| **Memory** | Manual pool or GC pressure | `BufferPool` with `withBuffer` |
+| **Stream parsing** | Roll your own accumulator | `StreamProcessor` |
+| **Compression** | Platform-specific zlib | `compress()` / `decompress()` on ReadBuffer |
+| **Line splitting** | Manual StringBuilder accumulator | `readFlowLines()` |
+| **Streaming transforms** | Manual resetForRead + map boilerplate | `mapBuffer()`, `asStringFlow()` |
+| **Backpressure** | Manual flow control | Built into Flow |
+| **Coroutines** | Wrap callbacks in `suspendCancellableCoroutine` | Native suspend functions |
+| **Cleanup** | try-finally everywhere | Lambda-scoped connections |
 
 ## Installation
 
@@ -25,15 +28,19 @@ It provides suspend-based async socket I/O with platform-native implementations:
 ```kotlin
 dependencies {
     implementation("com.ditchoom:socket:<latest-version>")
+    // Optional: streaming transforms (mapBuffer, asStringFlow, lines)
+    implementation("com.ditchoom:buffer-flow:<latest-version>")
+    // Optional: compression
+    implementation("com.ditchoom:buffer-compression:<latest-version>")
 }
 ```
 
-Find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.ditchoom/socket).
+Find the latest versions on [Maven Central](https://central.sonatype.com/search?q=com.ditchoom).
 
 ## Quick Example
 
 ```kotlin
-// Client: connect, write, read, close
+// Connect, write, read, close — same code on JVM, iOS, Linux, Node.js
 val socket = ClientSocket.connect(
     port = 443,
     hostname = "example.com",
@@ -42,6 +49,72 @@ val socket = ClientSocket.connect(
 socket.writeString("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
 val response = socket.readString()
 socket.close()
+```
+
+## Real-Time Streaming over TLS
+
+```kotlin
+ClientSocket.connect(8883, hostname = "broker.example.com", socketOptions = SocketOptions.tlsDefault()) { socket ->
+    socket.writeString("SUBSCRIBE events\n")
+    socket.readFlowLines().collect { line ->
+        println(line)
+    }
+} // socket closed automatically
+```
+
+## Streaming as a Flow
+
+Return a cold Flow — the socket opens on collection and closes when done:
+
+```kotlin
+fun streamEvents(host: String): Flow<String> = flow {
+    ClientSocket.connect(8883, hostname = host, socketOptions = SocketOptions.tlsDefault()) { socket ->
+        socket.writeString("SUBSCRIBE events\n")
+        emitAll(socket.readFlowLines())
+    }
+}
+
+// Compose with standard Flow operators
+streamEvents("broker.example.com")
+    .filter { "critical" in it }
+    .onEach { alert(it) }
+    .launchIn(scope)
+```
+
+## Streaming with Compression
+
+```kotlin
+socket.readFlow()
+    .mapBuffer { decompress(it, Gzip).getOrThrow() }
+    .asStringFlow()
+    .lines()
+    .collect { line -> process(line) }
+```
+
+## Buffer Pooling with SocketConnection
+
+For protocol implementations that exchange many messages, `SocketConnection` bundles a socket with a reusable `BufferPool` — no per-message allocations:
+
+```kotlin
+SocketConnection.connect(
+    hostname = "broker.example.com",
+    port = 8883,
+    options = ConnectionOptions(
+        socketOptions = SocketOptions.tlsDefault(),
+        maxPoolSize = 64,
+    ),
+) { conn ->
+    sensorReadings.collect { reading ->
+        conn.withBuffer { buf ->
+            val payload = reading.toJson().toReadBuffer()
+            val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
+            buf.writeInt(compressed.remaining())
+            buf.write(compressed)
+            buf.resetForRead()
+            conn.write(buf)
+        }
+    }
+}
 ```
 
 ## Server Example
@@ -66,15 +139,22 @@ client.close()
 server.close()
 ```
 
-## Lambda-Scoped Connections
+## Part of the DitchOoM Stack
 
-For automatic resource cleanup:
+Socket builds on the [buffer](https://github.com/DitchOoM/buffer) library for zero-copy memory management:
 
-```kotlin
-val response = ClientSocket.connect(80, hostname = "example.com") { socket ->
-    socket.writeString("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
-    socket.readString()
-} // socket closed automatically
+```
+┌──────────────────────────────────┐
+│  Your Protocol (MQTT, WS, ...)   │
+├──────────────────────────────────┤
+│  socket (TCP + TLS)              │  ← com.ditchoom:socket
+├──────────────────────────────────┤
+│  buffer-compression (optional)   │  ← com.ditchoom:buffer-compression
+├──────────────────────────────────┤
+│  buffer-flow                     │  ← com.ditchoom:buffer-flow
+├──────────────────────────────────┤
+│  buffer                          │  ← com.ditchoom:buffer
+└──────────────────────────────────┘
 ```
 
 ## Platform Support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -633,6 +633,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.buffer)
+            api(libs.buffer.flow)
             implementation(libs.kotlinx.coroutines.core)
         }
         androidMain.dependencies {

--- a/docs/docs/core-concepts/server-socket.md
+++ b/docs/docs/core-concepts/server-socket.md
@@ -46,7 +46,7 @@ val port: Int = server.port() // -1 if not bound
 server.close() // stops accepting new connections
 ```
 
-## Echo Server Example
+## Echo Server
 
 ```kotlin
 val server = ServerSocket.allocate()
@@ -66,4 +66,22 @@ client.writeString("Hello!")
 assertEquals("Hello!", client.readString())
 client.close()
 server.close()
+```
+
+## Streaming Echo Server
+
+An echo server that streams lines back to each client:
+
+```kotlin
+val server = ServerSocket.allocate()
+val clients = server.bind(port = 9000)
+
+clients.collect { client ->
+    launch {
+        client.readFlowLines().collect { line ->
+            client.writeString("Echo: $line\n")
+        }
+        client.close()
+    }
+}
 ```

--- a/docs/docs/core-concepts/socket-options.md
+++ b/docs/docs/core-concepts/socket-options.md
@@ -7,6 +7,19 @@ title: Socket Options
 
 The `SocketOptions` data class allows you to configure TCP socket behavior and TLS.
 
+## Presets
+
+```kotlin
+// TLS with low latency and default certificate validation
+SocketOptions.tlsDefault()
+
+// Low-latency plaintext (tcpNoDelay = true)
+SocketOptions.LOW_LATENCY
+
+// TLS with all validation disabled (development only)
+SocketOptions.tlsInsecure()
+```
+
 ## Available Options
 
 ```kotlin
@@ -37,19 +50,6 @@ val socket = ClientSocket.connect(
     hostname = "example.com",
     socketOptions = options,
 )
-```
-
-## Presets
-
-```kotlin
-// Low-latency plaintext (tcpNoDelay = true)
-SocketOptions.LOW_LATENCY
-
-// TLS with low latency and default certificate validation
-SocketOptions.tlsDefault()
-
-// TLS with all validation disabled (development only)
-SocketOptions.tlsInsecure()
 ```
 
 ## Option Details

--- a/docs/docs/guides/building-a-protocol.md
+++ b/docs/docs/guides/building-a-protocol.md
@@ -5,25 +5,25 @@ title: "Recipe: Building a Protocol Client"
 
 # Recipe: Building a Protocol Client
 
-This guide walks through building a real protocol client using the full DitchOoM stack: **socket** for networking, **buffer** for memory management, and **buffer-compression** for payload compression. The same code runs on JVM, Android, iOS, macOS, Linux, and Node.js.
+This guide walks through building a real protocol client using the full DitchOoM stack. Each layer adds a capability — start with the simplest approach and add complexity only when needed.
 
 ## The Stack
 
 ```
-┌─────────────────────────────────┐
-│  Your Protocol (MQTT, WS, ...) │  ← You write this once
-├─────────────────────────────────┤
-│  buffer-compression (optional)  │  ← Gzip/Deflate
-├─────────────────────────────────┤
-│  SocketConnection               │  ← Pool + Stream + Socket
-│  ┌────────────┬────────────────┐│
-│  │ BufferPool │ StreamProcessor││  ← Reusable buffers, framing
-│  └────────────┴────────────────┘│
-│  SocketOptions + TlsConfig      │  ← TCP tuning + TLS
-├─────────────────────────────────┤
-│  Platform-native I/O            │  ← Zero-copy, async
-│  io_uring │ NWConnection │ NIO2 │
-└─────────────────────────────────┘
+┌──────────────────────────────────┐
+│  Your Protocol (MQTT, WS, ...)   │
+├──────────────────────────────────┤
+│  buffer-compression (optional)   │  compress()/decompress() on ReadBuffer
+├──────────────────────────────────┤
+│  buffer-flow                     │  mapBuffer(), asStringFlow(), lines()
+├──────────────────────────────────┤
+│  SocketConnection                │  socket + pool + stream processor
+│  ├─ BufferPool     ← reuse buffers, no GC pressure
+│  ├─ StreamProcessor ← accumulate partial reads for framing
+│  └─ ClientSocket    ← platform-native I/O
+├──────────────────────────────────┤
+│  ReadBuffer / WriteBuffer        │  same types everywhere
+└──────────────────────────────────┘
 ```
 
 ## Dependencies
@@ -33,14 +33,16 @@ This guide walks through building a real protocol client using the full DitchOoM
 dependencies {
     implementation("com.ditchoom:socket:<version>")
     implementation("com.ditchoom:buffer:<version>")
-    // Optional: only if your protocol uses compression
+    // Optional: streaming transforms
+    implementation("com.ditchoom:buffer-flow:<version>")
+    // Optional: compression
     implementation("com.ditchoom:buffer-compression:<version>")
 }
 ```
 
-## Layer 1: Simple Connection
+## Layer 1: Request/Response
 
-The simplest use — connect, write, read, close. This alone works across 6 platforms:
+The simplest use — connect, write, read, close. Lambda scope handles cleanup:
 
 ```kotlin
 val response = ClientSocket.connect(
@@ -61,35 +63,123 @@ val response = ClientSocket.connect(
 - Coroutine-friendly suspend I/O (no callbacks, no thread pools)
 - Resource cleanup on lambda return
 
-## Layer 2: SocketConnection with Buffer Pool
+## Layer 2: Persistent Streaming
 
-For protocols that exchange many messages, `SocketConnection` bundles a socket with a reusable `BufferPool` and `StreamProcessor` — avoiding per-message allocations:
+For connections that stay open — event streams, pub/sub, log tailing — use `readFlowLines()`:
 
 ```kotlin
-val conn = SocketConnection.connect(
-    hostname = "broker.example.com",
+ClientSocket.connect(8883, hostname = "broker.example.com", socketOptions = SocketOptions.tlsDefault()) { socket ->
+    socket.writeString("SUBSCRIBE events\n")
+    socket.readFlowLines().collect { line ->
+        println(line)
+    }
+}
+```
+
+`readFlowLines()` handles `\n` and `\r\n` line endings, splits lines correctly across TCP chunk boundaries, and emits one line at a time in constant memory.
+
+## Layer 3: Return a Flow
+
+Wrap the connection in a cold Flow. The socket opens when collection starts and closes when done:
+
+```kotlin
+fun streamEvents(host: String): Flow<String> = flow {
+    ClientSocket.connect(8883, hostname = host, socketOptions = SocketOptions.tlsDefault()) { socket ->
+        socket.writeString("SUBSCRIBE events\n")
+        emitAll(socket.readFlowLines())
+    }
+}
+```
+
+Now you get the full power of Flow composition:
+
+```kotlin
+// Filter, limit, compose
+streamEvents("broker.example.com")
+    .filter { "critical" in it }
+    .take(100) // auto-closes socket after 100 lines
+    .collect { alert(it) }
+
+// Launch in a scope
+streamEvents("broker.example.com")
+    .onEach { process(it) }
+    .launchIn(scope)
+
+// Combine multiple streams
+merge(
+    streamEvents("broker-1.example.com"),
+    streamEvents("broker-2.example.com"),
+).collect { event -> handle(event) }
+```
+
+**What the streaming API gives you:**
+
+| Concern | How |
+|---------|-----|
+| **Backpressure** | Slow collector suspends `read()` — no unbounded buffering |
+| **Cancellation** | `.take(N)`, scope cancel, or exception closes the socket |
+| **Constant memory** | Lines emitted one at a time, never accumulated |
+| **Composition** | `filter`, `map`, `take`, `zip`, `combine` — all Flow operators |
+| **Lazy connection** | Cold Flow — socket only opens when collection starts |
+| **Cleanup** | Lambda-scoped connect closes socket on any exit path |
+
+## Layer 4: Bidirectional Streaming
+
+Read and write simultaneously using coroutines:
+
+```kotlin
+ClientSocket.connect(port, hostname = host, socketOptions = SocketOptions.tlsDefault()) { socket ->
+    coroutineScope {
+        // Writer: send commands
+        launch {
+            for (command in commandChannel) {
+                socket.writeString("$command\n")
+            }
+        }
+
+        // Reader: process responses
+        socket.readFlowLines().collect { line ->
+            handleResponse(line)
+        }
+    }
+}
+```
+
+## Layer 5: Full Stack — Buffer Pool + Stream Processor + Compression
+
+For protocols that exchange many messages (MQTT, WebSocket, custom binary protocols), `SocketConnection` bundles a socket with a reusable `BufferPool` and `StreamProcessor`:
+
+```kotlin
+SocketConnection.connect(
+    hostname = "telemetry.example.com",
     port = 8883,
     options = ConnectionOptions(
         socketOptions = SocketOptions.tlsDefault(),
-        maxPoolSize = 64,          // reuse up to 64 buffers
-        readTimeout = 30.seconds,
-        writeTimeout = 10.seconds,
+        maxPoolSize = 64,
     ),
-)
-
-// Borrow a buffer from the pool, write a message, return it
-conn.withBuffer(minSize = 256) { buf ->
-    buf.writeByte(0x10)          // MQTT CONNECT packet type
-    buf.writeByte(0x00)          // remaining length (placeholder)
-    buf.writeString("MQTT")     // protocol name
-    buf.resetForRead()
-    conn.write(buf)
+) { conn ->
+    // Write compressed frames with pooled buffers
+    sensorReadings.collect { reading ->
+        conn.withBuffer { buf ->
+            val payload = reading.toJson().toReadBuffer()
+            val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
+            buf.writeInt(compressed.remaining())
+            buf.write(compressed)
+            buf.resetForRead()
+            conn.write(buf)
+        }
+    }
 }
+```
 
-// Read response into the stream processor for framing
-val bytesRead = conn.readIntoStream()
+Read with decompression using `buffer-flow`:
 
-conn.close()
+```kotlin
+socket.readFlow()
+    .mapBuffer { decompress(it, Gzip).getOrThrow() }
+    .asStringFlow()
+    .lines()
+    .collect { line -> process(line) }
 ```
 
 **What the buffer pool gives you:**
@@ -98,108 +188,33 @@ conn.close()
 - `StreamProcessor` accumulates partial reads for protocols with framed messages
 - `maxPoolSize` caps memory usage
 
-## Layer 3: Adding Compression
+## Layer 6: Large Data with Constant Memory
 
-For protocols that support compressed payloads (HTTP Content-Encoding, WebSocket permessage-deflate, MQTT v5 payload compression), add `buffer-compression`:
-
-```kotlin
-import com.ditchoom.buffer.compression.*
-
-// Compress a payload before sending
-val payload = """{"sensor":"temp","value":23.5,"ts":1700000000}""".toReadBuffer()
-val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
-
-conn.withBuffer(minSize = compressed.remaining() + 4) { buf ->
-    buf.writeInt(compressed.remaining()) // length-prefix the frame
-    buf.write(compressed)
-    buf.resetForRead()
-    conn.write(buf)
-}
-
-// Decompress after reading
-val received = socket.read()
-received.resetForRead()
-val decompressed = decompress(received, CompressionAlgorithm.Gzip).getOrThrow()
-val json = decompressed.readString(decompressed.remaining())
-```
-
-## Putting It All Together: A Line Protocol Client
-
-Here's a complete, runnable example — a client for a simple newline-delimited JSON protocol over TLS:
+Process millions of records with backpressure. A slow collector suspends `read()` — no unbounded buffering:
 
 ```kotlin
-import com.ditchoom.socket.*
-import com.ditchoom.buffer.*
-import com.ditchoom.buffer.compression.*
-import kotlin.time.Duration.Companion.seconds
-
-/**
- * Connects to a JSON-lines service over TLS, sends a request,
- * and reads newline-delimited responses.
- *
- * This code compiles and runs identically on:
- * - JVM/Android (NIO2 + SSLEngine)
- * - iOS/macOS (NWConnection + Network.framework TLS)
- * - Linux x64/arm64 (io_uring + OpenSSL)
- * - Node.js (net.Socket + tls module)
- */
-suspend fun queryService(host: String, request: String): List<String> {
-    val conn = SocketConnection.connect(
-        hostname = host,
-        port = 443,
-        options = ConnectionOptions(
-            socketOptions = SocketOptions.tlsDefault(),
-            readTimeout = 10.seconds,
-        ),
-    )
-
-    return try {
-        // Send a compressed request with a length prefix
-        val payload = request.toReadBuffer()
-        val compressed = compress(payload, CompressionAlgorithm.Gzip).getOrThrow()
-
-        conn.withBuffer(minSize = compressed.remaining() + 4) { buf ->
-            buf.writeInt(compressed.remaining())
-            buf.write(compressed)
-            buf.resetForRead()
-            conn.write(buf)
+ClientSocket.connect(port, hostname = host) { socket ->
+    socket.readFlowLines()
+        .take(1_000_000)  // stop after N records, socket auto-closes
+        .collect { line ->
+            db.insert(parseLine(line))
         }
-
-        // Read responses line by line
-        val lines = mutableListOf<String>()
-        val sb = StringBuilder()
-
-        conn.socket.readFlowString().collect { chunk ->
-            sb.append(chunk)
-            while ('\n' in sb) {
-                val idx = sb.indexOf('\n')
-                lines.add(sb.substring(0, idx))
-                sb.delete(0, idx + 1)
-            }
-        }
-
-        lines
-    } finally {
-        conn.close()
-    }
 }
 ```
 
 ## Server Side: Accept + Echo
 
-The same APIs work for servers. Here's a TLS echo server that handles concurrent clients:
+The same APIs work for servers:
 
 ```kotlin
-import com.ditchoom.socket.*
-import kotlinx.coroutines.launch
-
 val server = ServerSocket.allocate()
 val clients = server.bind(port = 9000)
 
 clients.collect { client ->
     launch {
-        val message = client.readString()
-        client.writeString(message)
+        client.readFlowLines().collect { line ->
+            client.writeString("Echo: $line\n")
+        }
         client.close()
     }
 }
@@ -217,6 +232,9 @@ The key value of this stack is what you **don't** have to write:
 | **Memory** | Manual pool management or GC pressure | `BufferPool` with `withBuffer` |
 | **Stream parsing** | Roll your own accumulator for partial reads | `StreamProcessor` built in |
 | **Compression** | Platform-specific zlib bindings | `compress()` / `decompress()` |
+| **Line splitting** | Manual StringBuilder accumulator | `readFlowLines()` |
+| **Streaming transforms** | Manual resetForRead + map boilerplate | `mapBuffer()`, `asStringFlow()` |
+| **Backpressure** | Manual flow control | Built into Flow |
 | **Coroutines** | Wrap callbacks in `suspendCancellableCoroutine` | Native suspend functions |
 | **Resource cleanup** | Try-finally everywhere | Lambda-scoped connections, `SuspendCloseable` |
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mavenPublish = "0.35.0"
 dokka = "2.1.0"
 kotlinxCoroutines = "1.10.2"
 kotlinWrappers = "2025.12.6"
-buffer = "3.0.2-SNAPSHOT"
+buffer = "3.1.0"
 androidxCore = "1.17.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,11 +13,12 @@ mavenPublish = "0.35.0"
 dokka = "2.1.0"
 kotlinxCoroutines = "1.10.2"
 kotlinWrappers = "2025.12.6"
-buffer = "3.0.1"
+buffer = "3.0.2-SNAPSHOT"
 androidxCore = "1.17.0"
 
 [libraries]
 buffer = { module = "com.ditchoom:buffer", version.ref = "buffer" }
+buffer-flow = { module = "com.ditchoom:buffer-flow", version.ref = "buffer" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlinxCoroutines" }

--- a/src/commonMain/kotlin/com/ditchoom/data/Reader.kt
+++ b/src/commonMain/kotlin/com/ditchoom/data/Reader.kt
@@ -3,6 +3,7 @@ package com.ditchoom.data
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.flow.lines
 import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -32,6 +33,11 @@ interface Reader {
         it.resetForRead()
         it.readString(it.remaining(), charset)
     }
+
+    fun readFlowLines(
+        charset: Charset = Charset.UTF8,
+        timeout: Duration = 15.seconds,
+    ): Flow<String> = readFlowString(charset, timeout).lines()
 
     @Throws(CancellationException::class, SocketClosedException::class)
     suspend fun read(timeout: Duration = 15.seconds): ReadBuffer

--- a/src/commonMain/kotlin/com/ditchoom/socket/SocketConnection.kt
+++ b/src/commonMain/kotlin/com/ditchoom/socket/SocketConnection.kt
@@ -67,6 +67,20 @@ class SocketConnection private constructor(
             return SocketConnection(socket, pool, stream, options)
         }
 
+        suspend fun <T> connect(
+            hostname: String,
+            port: Int,
+            options: ConnectionOptions = ConnectionOptions(),
+            block: suspend (SocketConnection) -> T,
+        ): T {
+            val connection = connect(hostname, port, options)
+            return try {
+                block(connection)
+            } finally {
+                connection.close()
+            }
+        }
+
         fun wrap(
             socket: ClientToServerSocket,
             options: ConnectionOptions = ConnectionOptions(),


### PR DESCRIPTION
## Summary

- Add `readFlowLines()` to `Reader` for line-based streaming with `\n`/`\r\n` handling across chunk boundaries
- Add lambda-scoped `SocketConnection.connect { }` overload for automatic resource cleanup
- Add `buffer-flow` dependency for `mapBuffer()`, `asStringFlow()`, `lines()` Flow extensions
- Rewrite README and all docs to lead with high-value patterns: streaming, TLS, compression, buffer pooling, Flow composition
- Building-a-protocol guide now shows 6 progressive layers from simple request/response to full-stack with compression and pooling
- Update `com.ditchoom:buffer` from `3.0.2-SNAPSHOT` to published `3.1.0`

## New API

### `Reader.readFlowLines()`
```kotlin
socket.readFlowLines().collect { line -> println(line) }
```

### Lambda-scoped `SocketConnection.connect`
```kotlin
SocketConnection.connect(hostname, port, options) { conn ->
    conn.withBuffer { buf -> /* ... */ }
} // auto-closed
```

### Composed streaming pipeline (via buffer-flow)
```kotlin
socket.readFlow()
    .mapBuffer { decompress(it, Gzip).getOrThrow() }
    .asStringFlow()
    .lines()
    .collect { line -> process(line) }
```

## Test plan

- [ ] JVM tests pass (`./gradlew jvmTest`)
- [ ] Verify `readFlowLines()` splits lines across chunked reads
- [ ] Verify `SocketConnection.connect { }` lambda closes connection on return
- [ ] Review docs render correctly in Docusaurus (`cd docs && npm start`)