### PR TITLE
Add threadingMode and pooled zero-copy reads to SocketConnection

### DIFF
--- a/docs/docs/guides/building-a-protocol.md
+++ b/docs/docs/guides/building-a-protocol.md
@@ -208,6 +208,23 @@ The default is `SingleThreaded`, which avoids synchronization overhead when read
 - `withBuffer` automatically returns the buffer to the pool
 - `StreamProcessor` accumulates partial reads for protocols with framed messages
 - `maxPoolSize` caps memory usage
+- `readIntoStream()` uses zero-copy pooled reads: acquires a buffer from the pool, reads directly into it from the socket, and transfers ownership to the stream processor
+
+### Threading Mode
+
+By default, `SocketConnection` uses a `SingleThreaded` buffer pool, which is optimal when reads and writes happen from the same coroutine context. For protocols where reads and writes happen from different contexts (e.g., WebSocket read loop on `Dispatchers.Default` while writes come from the caller's context), use `MultiThreaded`:
+
+```kotlin
+SocketConnection.connect(
+    hostname = "example.com",
+    port = 443,
+    options = ConnectionOptions(
+        threadingMode = ThreadingMode.MultiThreaded,
+    ),
+) { conn ->
+    // Safe to read and write from different coroutines
+}
+```
 - `readIntoStream()` uses pooled zero-copy reads — buffers go directly from pool to socket to stream processor
 
 ## Layer 6: Large Data with Constant Memory

--- a/docs/docs/guides/building-a-protocol.md
+++ b/docs/docs/guides/building-a-protocol.md
@@ -210,23 +210,6 @@ The default is `SingleThreaded`, which avoids synchronization overhead when read
 - `maxPoolSize` caps memory usage
 - `readIntoStream()` uses zero-copy pooled reads: acquires a buffer from the pool, reads directly into it from the socket, and transfers ownership to the stream processor
 
-### Threading Mode
-
-By default, `SocketConnection` uses a `SingleThreaded` buffer pool, which is optimal when reads and writes happen from the same coroutine context. For protocols where reads and writes happen from different contexts (e.g., WebSocket read loop on `Dispatchers.Default` while writes come from the caller's context), use `MultiThreaded`:
-
-```kotlin
-SocketConnection.connect(
-    hostname = "example.com",
-    port = 443,
-    options = ConnectionOptions(
-        threadingMode = ThreadingMode.MultiThreaded,
-    ),
-) { conn ->
-    // Safe to read and write from different coroutines
-}
-```
-- `readIntoStream()` uses pooled zero-copy reads — buffers go directly from pool to socket to stream processor
-
 ## Layer 6: Large Data with Constant Memory
 
 Process millions of records with backpressure. A slow collector suspends `read()` — no unbounded buffering:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mavenPublish = "0.35.0"
 dokka = "2.1.0"
 kotlinxCoroutines = "1.10.2"
 kotlinWrappers = "2025.12.6"
-buffer = "3.1.0"
+buffer = "3.2.0"
 androidxCore = "1.17.0"
 
 [libraries]

--- a/src/commonMain/kotlin/com/ditchoom/socket/ConnectionOptions.kt
+++ b/src/commonMain/kotlin/com/ditchoom/socket/ConnectionOptions.kt
@@ -1,6 +1,7 @@
 package com.ditchoom.socket
 
 import com.ditchoom.buffer.AllocationZone
+import com.ditchoom.buffer.pool.ThreadingMode
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -17,4 +18,5 @@ data class ConnectionOptions(
     val writeTimeout: Duration = 15.seconds,
     val defaultBufferSize: Int = 8192,
     val maxPoolSize: Int = 64,
+    val threadingMode: ThreadingMode = ThreadingMode.SingleThreaded,
 )

--- a/src/commonMain/kotlin/com/ditchoom/socket/SocketConnection.kt
+++ b/src/commonMain/kotlin/com/ditchoom/socket/SocketConnection.kt
@@ -1,6 +1,5 @@
 package com.ditchoom.socket
 
-import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.ReadWriteBuffer
 import com.ditchoom.buffer.SuspendCloseable
@@ -81,10 +80,11 @@ class SocketConnection private constructor(
         ): SocketConnection {
             val socket = ClientSocket.allocate(options.allocationZone)
             socket.open(port, options.connectionTimeout, hostname, options.socketOptions)
-            val pool = BufferPool(
-                maxPoolSize = options.maxPoolSize,
-                threadingMode = options.threadingMode,
-            )
+            val pool =
+                BufferPool(
+                    maxPoolSize = options.maxPoolSize,
+                    threadingMode = options.threadingMode,
+                )
             val stream = StreamProcessor.builder(pool).buildSuspending()
             return SocketConnection(socket, pool, stream, options)
         }
@@ -107,10 +107,11 @@ class SocketConnection private constructor(
             socket: ClientToServerSocket,
             options: ConnectionOptions = ConnectionOptions(),
         ): SocketConnection {
-            val pool = BufferPool(
-                maxPoolSize = options.maxPoolSize,
-                threadingMode = options.threadingMode,
-            )
+            val pool =
+                BufferPool(
+                    maxPoolSize = options.maxPoolSize,
+                    threadingMode = options.threadingMode,
+                )
             val stream = StreamProcessor.builder(pool).buildSuspending()
             return SocketConnection(socket, pool, stream, options)
         }


### PR DESCRIPTION
## Summary
- Adds `threadingMode` to `ConnectionOptions` (default `SingleThreaded`, backward compatible)
- `SocketConnection.readIntoStream()` now uses `pool.acquire()` + `socket.read(buffer)` for zero-copy reads into pooled buffers instead of `socket.read()` which allocates per read
- `connect()` and `wrap()` pass `threadingMode` to `BufferPool` constructor

## Motivation
WebSocket needs `MultiThreaded` pool (reads on Dispatchers.Default, writes from caller context) while MQTT stays `SingleThreaded`. Pooled reads avoid per-read buffer allocation, reducing GC pressure.

## Test plan
- [ ] JVM tests pass
- [ ] Linux K/N tests pass
- [ ] Integration: WebSocket and MQTT consumers validate end-to-end