### PR TITLE
Update buffer to 3.2.1, improve Maven Central polling

### DIFF
--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -116,12 +116,12 @@ jobs:
         run: |
           TOKEN=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
           DEPLOYMENT_ID="${{ steps.upload.outputs.deployment-id }}"
-          MAX_ATTEMPTS=60
+          MAX_ATTEMPTS=50
           ATTEMPT=0
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
-            sleep 10
+            sleep 30
 
             STATUS_RESPONSE=$(curl -s \
               -X POST "https://central.sonatype.com/api/v1/publisher/status?id=${DEPLOYMENT_ID}" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,12 +75,12 @@ jobs:
         run: |
           TOKEN=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
           DEPLOYMENT_ID="${{ steps.extract.outputs.deployment-id }}"
-          MAX_ATTEMPTS=60
+          MAX_ATTEMPTS=50
           ATTEMPT=0
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             ATTEMPT=$((ATTEMPT + 1))
-            sleep 10
+            sleep 30
 
             STATUS_RESPONSE=$(curl -s \
               -X POST "https://central.sonatype.com/api/v1/publisher/status?id=${DEPLOYMENT_ID}" \

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mavenPublish = "0.35.0"
 dokka = "2.1.0"
 kotlinxCoroutines = "1.10.2"
 kotlinWrappers = "2025.12.6"
-buffer = "3.2.0"
+buffer = "3.2.1"
 androidxCore = "1.17.0"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Update buffer dependency from 3.2.0 to 3.2.1 (fixes slice() losing NativeMemoryAccess on Apple and ManagedMemoryAccess on Android)
- Update Maven Central polling from 10s/60 attempts to 30s/50 attempts (25 min total) for more reliable deployments

## Blocked on
- [ ] buffer 3.2.1 published to Maven Central (PR: https://github.com/DitchOoM/buffer/pull/123)