### PR TITLE
docs: socket-quic in README + tidy Linux server host param (release trigger for v3.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,34 @@ dependencies {
 
 Find the latest versions on [Maven Central](https://central.sonatype.com/search?q=com.ditchoom).
 
+### Sister module: `socket-quic`
+
+QUIC client and server live in a separate artifact so the core `socket` module stays small for TCP-only consumers. Same scope-based API shape, same buffer discipline:
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:socket-quic:<latest-version>")
+}
+
+// Client — handshake completes before the block runs; connection closes on block exit.
+withQuicConnection("example.com", 443, QuicOptions(alpnProtocols = listOf("h3"))) {
+    val stream = openStream()
+    stream.write(buf, 5.seconds)
+    val response = stream.read(5.seconds)
+    stream.close()
+}
+
+// Server — UDP socket bound for the block's lifetime.
+withQuicServer(port = 4433, tlsConfig = QuicTlsConfig(certChainPath, privKeyPath), quicOptions) {
+    connections {
+        val stream = acceptStream()
+        // … echo, multiplex, etc. …
+    }
+}
+```
+
+Backed by quiche on JVM/Android (JNI on JDK ≤20, FFM on JDK 21+), quiche cinterop on Linux native, and Network.framework on Apple. JS/wasmJs throw `UnsupportedOperationException` (no raw UDP). Stream multiplexing via `withQuicMux(..., codec) { … }` for codec-typed sessions.
+
 ## Error Handling
 
 All socket errors are thrown as subtypes of the `SocketException` sealed hierarchy — catch broad categories or specific failure modes:

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -55,12 +55,14 @@ private const val QUICHE_PROTOCOL_VERSION = 0x00000001
 
 actual suspend fun <R> withQuicServer(
     port: Int,
-    host: String?,
+    @Suppress("UNUSED_PARAMETER") host: String?,
     tlsConfig: QuicTlsConfig,
     quicOptions: QuicOptions,
     @Suppress("UNUSED_PARAMETER") timeout: Duration,
     block: suspend QuicServer.() -> R,
 ): R {
+    // Linux bind path defaults to INADDR_ANY; `host` is accepted for API parity
+    // with the JVM/Android impl but not yet wired through to inet_pton / bind.
     val api: QuicheApi = CinteropQuicheApi
     val parentJob = SupervisorJob()
     val parentScope = CoroutineScope(parentJob + Dispatchers.Default)
@@ -89,10 +91,6 @@ actual suspend fun <R> withQuicServer(
         alpnBuf.freeNativeMemory()
 
         applyQuicOptions(quicOptions, LinuxQuicConfigCalls(config.handle.toCPointer()!!))
-
-        // Bind unused parameter (host not yet wired through to Linux path — defaults to INADDR_ANY).
-        @Suppress("UNUSED_VARIABLE")
-        val hostUnused = host
 
         // Create & bind UDP socket
         val fd = socket(AF_INET, SOCK_DGRAM, 0)


### PR DESCRIPTION
Small follow-up to PR #48 that doubles as the release trigger for v3.1.0.

PR #48 was +23,933 lines, which exceeded GitHub's 20k-line diff limit on `gh pr diff`; the merged.yaml `Check if release is needed` step exits 1 and skips the publish chain. So PR #48 merged but no Maven Central release fired.

This PR's diff is tiny (~30 lines), so the classifier works. Contents:

- **README.md**: add a 'Sister module: socket-quic' section after the dependencies block. The core README had zero mentions of QUIC; documents `withQuicConnection`/`withQuicServer`/`withQuicMux` usage and platform backings.
- **WithQuicServer.linux.kt**: move the `host-not-yet-wired` suppression from a dummy `val hostUnused = host` local to a parameter-level `@Suppress("UNUSED_PARAMETER")` with a one-line comment about API parity. Removes a code smell I introduced in #48.

Label `minor` so the version goes 3.0.0 → 3.1.0, carrying the QUIC + NetworkMonitor + harness + no-engine work from #48 along with this README + tidy.