### PR TITLE
ci: harden the deploy workflow (paginated diff + workflow_dispatch + poll resilience)

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -4,6 +4,24 @@ on:
     branches: [ main ]
     types:
       - closed
+  workflow_dispatch:
+    inputs:
+      version-bump:
+        description: "Version bump"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      flow:
+        description: "Release flow"
+        type: choice
+        options:
+          - release
+          - draft
+          - dry-run
+        default: release
 
 permissions:
   contents: write
@@ -15,7 +33,7 @@ concurrency:
 jobs:
   check-release:
     name: Check if release is needed
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       flow: ${{ steps.check.outputs.flow }}
@@ -29,6 +47,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Manual dispatch has no PR to inspect — take flow and version
+          # bump straight from the workflow inputs. Lets us recover from a
+          # failed publish (e.g. transient Central API hiccup) without
+          # opening a sham PR to flip the classifier.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            case "${{ inputs.version-bump }}" in
+              major) echo "gradle-args=-PincrementMajor=true" >> $GITHUB_OUTPUT ;;
+              minor) echo "gradle-args=-PincrementMinor=true" >> $GITHUB_OUTPUT ;;
+              *)     echo "gradle-args=" >> $GITHUB_OUTPUT ;;
+            esac
+            echo "flow=${{ inputs.flow }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           gradle_args=""
           if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
             gradle_args="-PincrementMajor=true"
@@ -49,8 +81,17 @@ jobs:
             exit 0
           fi
 
-          # Check if only non-code files changed
-          changed_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          # Check if only non-code files changed.
+          # Use the paginated "list PR files" API rather than `gh pr diff`:
+          # the latter hits the .diff endpoint, which GitHub caps at ~20k
+          # lines / 300 files and returns HTTP 406 for larger PRs (this is
+          # exactly what killed PR #48's deploy — the no-engine refactor
+          # was +23,933 lines so the diff was rejected and the script
+          # exited 1). The PR-files API returns objects with a `filename`
+          # field and is paginated, so size-of-change doesn't matter.
+          changed_files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
           for file in $changed_files; do
             case "$file" in
               .github/*|*.md|.gitignore|.editorconfig|CLAUDE.md|LICENSE|*.txt)
@@ -112,8 +153,8 @@ jobs:
         if: needs.check-release.outputs.flow == 'draft' && needs.publish.result == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           version="${{ needs.build-linux.outputs.version }}"
           deployment_id="${{ needs.publish.outputs.deployment-id }}"
@@ -143,8 +184,8 @@ jobs:
         if: needs.check-release.outputs.flow == 'release' && needs.publish.result == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_URL: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
           version="${{ needs.build-linux.outputs.version }}"
           tag="v${version}"

--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -116,7 +116,11 @@ jobs:
         run: |
           TOKEN=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
           DEPLOYMENT_ID="${{ steps.upload.outputs.deployment-id }}"
-          MAX_ATTEMPTS=50
+          # 240 × 30s = 2h ceiling. First-time-namespace publications (e.g. a
+          # newly added artifactId under com.ditchoom) sometimes sit in
+          # PUBLISHING for 40+ minutes while Central runs extra validation;
+          # the previous 50 × 30s = 25min limit timed those out spuriously.
+          MAX_ATTEMPTS=240
           ATTEMPT=0
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
@@ -128,7 +132,17 @@ jobs:
               -H "Authorization: Bearer $TOKEN" \
               -H "Content-Type: application/json")
 
-            STATE=$(echo "$STATUS_RESPONSE" | jq -r '.deploymentState // empty')
+            # The Central status endpoint occasionally returns non-JSON: a
+            # CDN error page (HTML), a plain "Origin error" text response, or
+            # a rate-limit body. Without redirecting stderr + falling back to
+            # empty, jq's parse-error exit code propagates under `set -e` and
+            # kills the whole step (v3.1.0 publish failure 2026-05-28 was
+            # exactly this: attempt 8 hit a non-JSON body, jq exited 5, step
+            # exited 5, polling never resumed even though Central was still
+            # PUBLISHING normally). With the fallback STATE becomes empty and
+            # the existing "Unable to parse status response" branch handles
+            # the transient cleanly — loop keeps polling.
+            STATE=$(echo "$STATUS_RESPONSE" | jq -r '.deploymentState // empty' 2>/dev/null || true)
 
             if [ -z "$STATE" ]; then
               echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Unable to parse status response"
@@ -145,7 +159,7 @@ jobs:
                 ;;
               FAILED)
                 echo "Deployment FAILED!"
-                echo "$STATUS_RESPONSE" | jq '.errors // empty'
+                echo "$STATUS_RESPONSE" | jq '.errors // empty' 2>/dev/null || echo "$STATUS_RESPONSE"
                 exit 1
                 ;;
               *)


### PR DESCRIPTION
Three fixes for the deploy workflow, all motivated by the v3.1.0 release attempt (PR #49 → run 26566482994):

### 1. Paginated PR-files API instead of `gh pr diff`
`merged.yaml`'s code-vs-docs classifier used `gh pr diff N --name-only`, which hits the GitHub .diff endpoint. That endpoint is capped at ~20k lines / 300 files; for larger PRs it returns HTTP 406 and the script exits 1.

PR #48 was +23,933 lines, so the classifier crashed instead of detecting the code change → the entire publish chain was skipped. That's what required us to open PR #49 as a synthetic trigger in the first place.

Mirroring [buffer's fix](https://github.com/DitchOoM/buffer/blob/main/.github/workflows/merged.yaml): use `gh api --paginate /repos/{owner}/{repo}/pulls/{n}/files --jq '.[].filename'`, which is paginated and has no size cap.

### 2. `workflow_dispatch` for manual deploy re-fires
Adds `workflow_dispatch` inputs for `version-bump` (patch/minor/major) and `flow` (release/draft/dry-run) so a stuck release can be re-triggered from the Actions UI without inventing a sham PR — which is exactly what PR #49 ended up being after PR #48's deploy crashed.

PR_TITLE / PR_URL fallbacks added to finalize step so release notes still render on dispatch events.

### 3. Polling-step resilience in `publish-to-central.yaml`
- `jq -r '.deploymentState' 2>/dev/null || true` so the polling script doesn't die under `set -e` when Central briefly returns a CDN error page or non-JSON body — the existing 'Unable to parse status response' branch then handles the transient cleanly. **This is the bug that broke v3.1.0**: attempt 8 hit a non-JSON body, jq exited 5, step exited 5, finalize skipped the GH release + tag.
- `MAX_ATTEMPTS` 50 → 240 (25min → 2h). First-time-namespace publications can sit in PUBLISHING 40+ minutes (we're watching socket-quic do exactly that right now); the old ceiling would have timed those out spuriously even when healthy.

### No release impact
All three changes are inside `.github/workflows/*`, which is in merged.yaml's skip list — flow=skip on merge, no version bump, no publish. Fix lands for future deploys (including any recovery attempt on the in-flight v3.1.0).