### PR TITLE
ci(quic): wire quic-echo into build-apple.yaml + skip/OK observability

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -154,11 +154,118 @@ jobs:
           :socket-quic:jvmProcessResources
           --no-configuration-cache ${{ inputs.gradle-args }}
 
+      # QUIC harness on macOS — runs the JVM `QuicEchoTestServer` natively on
+      # the runner (no Docker; macos-latest's Colima/container-CLI fixtures
+      # all fail per HANDOFF.md Q1). The fat jar produced by
+      # `:socket-quic:quicEchoJar` includes the macOS quiche dylibs from the
+      # earlier build step, so it runs end-to-end with no extra runtime deps.
+      #
+      # Risk: the quiche-0.28 native panic from `quiche_conn_recv` (the same
+      # one that excludes `:socket-quic:jvmTest` on macOS) might trigger
+      # server-side here too. If it does, the deadlock is bounded by the
+      # `timeout` wrapper and `kill` cleanup; the Apple QUIC tests below
+      # still attempt to connect and silently skip on connection failure
+      # via QuicHarnessIntegrationTests.withHarness's catch. The
+      # `continue-on-error` on the launch step prevents a server-side
+      # panic from failing the whole job.
+      - name: Build quic-echo fat jar with macOS dylibs
+        continue-on-error: true
+        run: >-
+          ./gradlew :socket-quic:quicEchoJar
+          --no-configuration-cache ${{ inputs.gradle-args }}
+
+      - name: Launch quic-echo on the macOS host
+        id: launch-quic-echo
+        continue-on-error: true
+        run: |
+          set -x
+          JAR=test-harness/quic-echo/quic-echo.jar
+          LOG=/tmp/quic-echo.log
+
+          if [ ! -f "$JAR" ]; then
+            echo "no quic-echo jar — skipping (likely missing macOS dylibs)"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Mirror the Dockerfile's JVM flags — FFM access on, NIO
+          # reflective access opened for the buffer dependency's
+          # off-heap pinning. nohup + & detaches across step boundary;
+          # the cleanup step uses lsof on UDP 14433 to find and kill.
+          cd test-harness/quic-echo
+          nohup java \
+            --enable-native-access=ALL-UNNAMED \
+            --add-opens java.base/java.nio=ALL-UNNAMED \
+            -jar quic-echo.jar testcerts/cert.crt testcerts/cert.key 14433 \
+            > "$LOG" 2>&1 &
+          ECHO_PID=$!
+          echo "$ECHO_PID" > /tmp/quic-echo.pid
+          disown $ECHO_PID
+          cd - > /dev/null
+
+          # Wait for the "READY port=14433" stdout line from
+          # QuicEchoTestServer.main, max 30s. If it doesn't appear, we
+          # surface the log and let the QUIC tests skip via their catch.
+          for i in $(seq 1 30); do
+            if grep -q "READY port=14433" "$LOG" 2>/dev/null; then
+              echo "quic-echo ready after ${i}s (pid=$ECHO_PID)"
+              echo "ready=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # Also detect early exit — if PID is gone, server crashed.
+            if ! kill -0 "$ECHO_PID" 2>/dev/null; then
+              echo "quic-echo exited before ready — tail of log:"
+              tail -50 "$LOG" 2>/dev/null || echo "(no log)"
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "quic-echo did NOT come up in 30s — tail of log:"
+          tail -50 "$LOG" 2>/dev/null || echo "(no log)"
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+
       - name: Run socket-quic Apple native tests (Network.framework)
         continue-on-error: true
         run: >-
           ./gradlew :socket-quic:macosArm64Test :socket-quic:iosSimulatorArm64Test
           --no-configuration-cache ${{ inputs.gradle-args }}
+
+      - name: Stop quic-echo + capture log
+        if: always() && steps.launch-quic-echo.outputs.ready == 'true'
+        run: |
+          # The launched java process is detached; kill anything still
+          # holding 14433/udp. `lsof` is the cleanest cross-platform probe
+          # on macOS runners.
+          if command -v lsof >/dev/null; then
+            for pid in $(lsof -ti udp:14433 2>/dev/null); do
+              echo "killing pid=$pid (udp:14433)"
+              kill "$pid" 2>/dev/null || true
+            done
+          fi
+          pkill -f 'quic-echo.jar' 2>/dev/null || true
+          echo "--- quic-echo log tail ---"
+          tail -100 /tmp/quic-echo.log 2>/dev/null || echo "(no log)"
+
+      # Audit step: count how many QuicHarnessIntegrationTests actually
+      # exercised the harness vs silently skipped. Each test prints
+      # `harness OK` on success or `harness SKIP: <reason>` on connection
+      # failure via QuicHarnessIntegrationTests.withHarness. The counts
+      # come from the JUnit XML's <system-out> blocks. Surfaces in the CI
+      # log so a regression that breaks the macOS QUIC client (every test
+      # quietly skips, suite stays green) is visible at a glance.
+      - name: Audit QUIC harness coverage on macOS
+        if: always() && steps.launch-quic-echo.outputs.ready == 'true'
+        continue-on-error: true
+        run: |
+          REPORT_ROOT=socket-quic/build/test-results
+          OK=$(grep -rh 'harness OK' "$REPORT_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+          SKIP=$(grep -rh 'harness SKIP' "$REPORT_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+          echo "QuicHarnessIntegrationTests on macOS: OK=$OK, SKIP=$SKIP"
+          if [ "$OK" = "0" ] && [ "$SKIP" != "0" ]; then
+            echo "::warning::Every QuicHarnessIntegrationTest skipped on macOS — Apple QUIC client not actually validated"
+          fi
 
       # Test reports on failure — see build-linux.yaml for the why.
       - name: Upload test reports (on failure)

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
@@ -51,7 +51,18 @@ class QuicHarnessIntegrationTests {
         )
     private val connOptions = ConnectionOptions(bufferFactory = bufferFactory)
 
-    /** Run block inside a QUIC connection to the harness echo, or skip if unreachable. */
+    /**
+     * Run [block] inside a QUIC connection to the harness echo, or skip if
+     * unreachable.
+     *
+     * Logs an explicit `harness OK` or `harness SKIP: <reason>` line so the
+     * CI runner can tell whether the test actually exercised the QUIC
+     * client (vs silently no-op'd because the harness wasn't brought up).
+     * The Apple CI job greps for `harness OK` to assert the macOS-host
+     * `quic-echo` actually accepted at least one connection — without this
+     * signal a forgotten `docker compose up` or a broken jar launch would
+     * pass CI by accident.
+     */
     private suspend fun withHarness(block: suspend QuicScope.() -> Unit) {
         try {
             withQuicConnection(
@@ -62,10 +73,13 @@ class QuicHarnessIntegrationTests {
                 5.seconds,
                 block,
             )
-        } catch (_: Throwable) {
+            println("[QuicHarnessIntegrationTests] harness OK")
+        } catch (t: Throwable) {
             // Harness not up, native lib not built, or connection failed —
-            // silently skip. Mirrors the `withCloudflare { ... }` skip
-            // behaviour in QuicIntegrationTests.
+            // skip silently from the test framework's perspective (no
+            // assertion) but emit a grep-able signal so we can audit
+            // whether tests are actually running.
+            println("[QuicHarnessIntegrationTests] harness SKIP: ${t::class.simpleName}: ${t.message}")
         }
     }
 


### PR DESCRIPTION
**Phase 1 of comprehensive QUIC CI coverage** (see PR description for the full multi-phase plan).

## Today

`build-apple` runs the Apple K/N target tests, but the QUIC harness side is entirely disabled: `HARNESS_DISABLED=true` blankets the harness fixtures (lines 120-138 in build-apple.yaml — three Docker fixture paths all failed on macos-latest, see HANDOFF.md Q1). Net result: every `QuicHarnessIntegrationTest` silently passes by hitting its skip-on-connection-failure catch. **Apple's Network.framework QUIC client is not actually validated against any server in CI.**

## This PR

1. **Run `quic-echo.jar` natively on the macOS runner — no Docker.**

   The existing `:socket-quic:quicEchoJar` task produces a fat jar that bundles `stageQuicheNativeResources`'s output. On macOS that includes the dylibs from the earlier 'Build quiche + JNI shim for macOS' step. So the jar runs end-to-end on the runner with no extra deps.

   Sequence: build jar → launch with `nohup + & + disown`, log to `/tmp/quic-echo.log` → poll for `READY port=14433` stdout signal (or early-exit detection via `kill -0`) up to 30s → run `:socket-quic:macosArm64Test` and `:socket-quic:iosSimulatorArm64Test` → kill via `lsof -ti udp:14433`.

   `continue-on-error` guards the launch + tests in case the quiche-0.28 server-side panic from `quiche_conn_recv` (the same one that excludes `:socket-quic:jvmTest` on macOS) deadlocks the long-running server too. If that happens, tests silently skip via the existing catch and the audit warning surfaces. The Apple K/N target unit tests still run.

   `HARNESS_DISABLED=true` is kept set — quic-echo is a separate harness component; the other harness fixtures (TLS, HTTP, toxiproxy, etc.) are still blocked on macOS for unrelated reasons.

2. **Log `harness OK` / `harness SKIP: <reason>` from `QuicHarnessIntegrationTests.withHarness()`.**

   Replaces the previous silent swallow. The Apple CI 'Audit QUIC harness coverage' step counts OK vs SKIP across the JUnit XML `<system-out>` blocks and emits a CI warning when every test skipped — protects against the silent-pass failure mode where a broken jar launch or wrong-port config would otherwise let the suite stay green without any actual validation.

## What I'm watching for in CI

- `Build quic-echo fat jar with macOS dylibs` step: does `./gradlew :socket-quic:quicEchoJar` succeed on Apple CI? If the staging task can't find the macOS dylibs the jar build fails — discoverable here.
- `Launch quic-echo on the macOS host` step output: `ready=true` or early-exit log tail.
- `Audit QUIC harness coverage` step: `OK=N, SKIP=M` counts. If OK > 0, **Apple QUIC client is now validated against the JVM server in CI**.
- If `OK=0, SKIP > 0`: the launch succeeded but tests still couldn't reach the harness — likely a port/host mismatch we'll diagnose.
- If quiche-0.28 server-side panic deadlocks the launch: audit step warning fires, we file the discovery and pursue the Apple NWListener implementation (`socket-quic/src/appleNativeImpl/.../WithQuicServer.apple.kt` currently `TODO()`) as the proper unblock.

## Follow-up phases (separate PRs, queued)

- Phase 2: multi-arch `quic-echo` Docker image (`linux/amd64 + linux/arm64` via `buildx`) so it runs on the Linux ARM64 (native) CI job.
- Phase 3: wire `quic-echo` into the Linux ARM64 (native) job; drop the explicit skip.
- Phase 4: visible per-platform interop matrix labels on the PR check list.
- Phase 5: unify Android instrumented `androidQuicIntegrationTest` onto the same harness container.
- Phase 6 (blocked): Windows JVM QUIC validation once the Windows quiche JNI lib build lands.