### PR TITLE
ci(quic): Android instrumented runs against docker quic-echo (Phase 5)

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -73,6 +73,37 @@ jobs:
               && echo "Built Android x86_64 JNI shim"
           fi
 
+      # Bring up the docker quic-echo harness (same image / port as
+      # build-linux + build-apple) before the emulator starts. The
+      # Android emulator's 10.0.2.2 maps to the host's loopback, so
+      # AndroidQuicConnectivityTests + AndroidQuicMigrationTests reach
+      # `10.0.2.2:<QuicHarnessConfig.quicEchoPort>` over UDP through to
+      # the container bound on `127.0.0.1:14433/udp`.
+      #
+      # Previous setup ran no server at all and used `adb reverse
+      # tcp:4433 tcp:4433` — wrong on two counts: adb reverse only
+      # supports TCP (QUIC is UDP) and no QuicEchoTestServer ever
+      # started on the host. The result was a quiet skip of every
+      # instrumented QUIC test via the `assumeTrue(...)` in
+      # AndroidQuicConnectivityTests.checkServerReachable's catch
+      # block. This was the Android side of the same silent-skip
+      # failure mode being fixed across the comprehensive QUIC CI plan
+      # (macOS = PR #51, Linux ARM64 = PR #52).
+      - name: Generate harness TLS certs
+        run: bash test-harness/tls/gen-certs.sh
+
+      # Build the quic-echo fat jar so docker compose's `build: ./quic-echo`
+      # has the COPY input it needs. Default (host-arch-only) is enough —
+      # the docker image base + jar are both linux-x64 for this job, which
+      # matches the ubuntu-latest runner. The container then exposes
+      # 14433/udp on the host's loopback, where the emulator reaches it via
+      # 10.0.2.2.
+      - name: Build quic-echo fat jar (Linux x64)
+        run: ./gradlew :socket-quic:quicEchoJar --no-configuration-cache
+
+      - name: Bring up quic-echo via the docker harness
+        run: cd test-harness && docker compose up -d --wait quic-echo
+
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -105,8 +136,39 @@ jobs:
           disable-animations: true
           script: |
             adb root || true
-            adb reverse tcp:4433 tcp:4433 || true
+            # The previous `adb reverse tcp:4433 tcp:4433` is gone: QUIC
+            # is UDP and adb reverse only handles TCP. The emulator
+            # reaches the host's docker-published 127.0.0.1:14433/udp
+            # via its built-in 10.0.2.2 host alias — no port forwarding
+            # needed. AndroidQuicConnectivityTests + AndroidQuicMigrationTests
+            # now point at 10.0.2.2:14433 (matches QuicHarnessConfig.quicEchoPort).
             ./gradlew connectedAndroidTest :socket-quic:connectedAndroidTest
+
+      # Mirror the audit step from build-apple.yaml + build-linux.yaml:
+      # count `harness OK` vs `harness SKIP` markers from
+      # QuicHarnessIntegrationTests' withHarness() across the
+      # connectedAndroidTest report XMLs. Surfaces a regression that
+      # silently breaks the Android QUIC client as a CI warning instead
+      # of letting it pass via the skip-on-failure catch.
+      - name: Audit QUIC harness coverage on Android
+        if: always()
+        continue-on-error: true
+        run: |
+          REPORT_ROOT=socket-quic/build/outputs/androidTest-results
+          if [ ! -d "$REPORT_ROOT" ]; then
+            echo "no android instrumented-test results — audit skipped"
+            exit 0
+          fi
+          OK=$(grep -rh 'harness OK' "$REPORT_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+          SKIP=$(grep -rh 'harness SKIP' "$REPORT_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+          echo "QuicHarnessIntegrationTests on Android: OK=$OK, SKIP=$SKIP"
+          if [ "$OK" = "0" ] && [ "$SKIP" != "0" ]; then
+            echo "::warning::Every QuicHarnessIntegrationTest skipped on Android — emulator QUIC client not actually validated"
+          fi
+
+      - name: Bring down quic-echo harness
+        if: always()
+        run: cd test-harness && docker compose down -v
 
       - name: Kill emulator processes
         if: always()

--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicConnectivityTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicConnectivityTests.kt
@@ -14,15 +14,35 @@ import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Android QUIC connectivity tests against a local server.
+ * Android QUIC connectivity tests against the local `quic-echo` docker
+ * harness service (`test-harness/quic-echo/`).
  *
- * Run via `./gradlew :socket-quic:androidQuicIntegrationTest` which starts
- * the test server on the host and configures `adb reverse`.
+ * CI runs this via `.github/workflows/android_integration.yaml`, which
+ * brings up the docker harness on the host (`14433/udp` published on
+ * loopback) before the emulator boots. The emulator reaches the host
+ * via its built-in `10.0.2.2` alias.
+ *
+ * For local dev:
+ *   docker compose -f test-harness/docker-compose.yml up -d --wait quic-echo
+ *   ./gradlew :socket-quic:connectedDebugAndroidTest
+ *   docker compose -f test-harness/docker-compose.yml down -v
+ *
+ * The legacy `:socket-quic:androidQuicIntegrationTest` Gradle task is
+ * still wired (starts a host-side `QuicEchoTestServer` JVM process)
+ * for envs without Docker, but the docker harness is the canonical
+ * path going forward — it matches the server used by every other
+ * QUIC test target.
  */
 @RunWith(AndroidJUnit4::class)
 class AndroidQuicConnectivityTests {
+    // 10.0.2.2 is the Android emulator's alias for the host's loopback,
+    // and 14433/udp is where the docker-compose `quic-echo` service binds
+    // on the host (test-harness/docker-compose.yml). Must stay in sync with
+    // test-harness/harness.env QUIC_ECHO_PORT — mirrored manually here
+    // because androidInstrumentedTest doesn't depend on commonTest, so
+    // the generated QuicHarnessConfig isn't visible from this source set.
     private val serverHost = "10.0.2.2"
-    private val serverPort = 4433
+    private val serverPort = 14433
 
     private val testQuicOptions =
         QuicOptions(
@@ -39,7 +59,13 @@ class AndroidQuicConnectivityTests {
                 withQuicConnection(serverHost, serverPort, testQuicOptions, timeout = 5.seconds) {}
             }
         } catch (_: Throwable) {
-            assumeTrue("QUIC test server not reachable at $serverHost:$serverPort — run androidQuicIntegrationTest", false)
+            assumeTrue(
+                "QUIC test server not reachable at $serverHost:$serverPort — " +
+                    "start the docker harness (`docker compose -f test-harness/docker-compose.yml " +
+                    "up -d --wait quic-echo`) or fall back to the legacy " +
+                    "`:socket-quic:androidQuicIntegrationTest` Gradle task.",
+                false,
+            )
         }
     }
 

--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicMigrationTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicMigrationTests.kt
@@ -25,8 +25,10 @@ import kotlin.time.Duration.Companion.seconds
  */
 @RunWith(AndroidJUnit4::class)
 class AndroidQuicMigrationTests {
+    // See AndroidQuicConnectivityTests for why these mirror
+    // test-harness/harness.env QUIC_ECHO_PORT manually.
     private val serverHost = "10.0.2.2"
-    private val serverPort = 4433
+    private val serverPort = 14433
 
     private val testQuicOptions =
         QuicOptions(


### PR DESCRIPTION
**Phase 5 of comprehensive QUIC CI coverage.** Brings the Android instrumented test job onto the same docker `quic-echo` harness used by every other QUIC test target.

## Today's state

`android_integration.yaml` does `adb reverse tcp:4433 tcp:4433` and runs the tests — except:

- `adb reverse` only handles TCP. QUIC is UDP.
- No `QuicEchoTestServer` ever starts on the host in this workflow.

Result: every instrumented QUIC test silently skips via the `assumeTrue` in `AndroidQuicConnectivityTests.checkServerReachable`'s catch, and the suite "passes" because skipped JUnit tests count as passing. Same silent-skip failure mode being closed in [PR #51](https://github.com/DitchOoM/socket/pull/51) (macOS) and [PR #52](https://github.com/DitchOoM/socket/pull/52) (Linux ARM64).

## This PR

1. **Bring up the docker `quic-echo` service** on the `ubuntu-latest` runner before the emulator boots. Build the fat jar via `./gradlew :socket-quic:quicEchoJar` so docker compose's `build: ./quic-echo` has the COPY input it needs, then `docker compose up -d --wait quic-echo`. Container binds `14433/udp` on host loopback. `docker compose down -v` after tests.

2. **Drop the `adb reverse tcp:4433` line** and the misleading port-4433 config. The emulator's built-in `10.0.2.2` host alias handles UDP to host loopback natively.

3. **`AndroidQuicConnectivityTests` + `AndroidQuicMigrationTests`** now use `10.0.2.2:14433` matching the harness. `QuicHarnessConfig` isn't imported because `androidInstrumentedTest` doesn't depend on `commonTest`; the port is hardcoded with a comment pointing at `test-harness/harness.env`. `assumeTrue` message updated.

4. **Audit step** mirrors the macOS / Linux ARM64 audit. Counts `harness OK` / `harness SKIP` markers across the connectedAndroidTest JUnit XMLs. Best-effort on Android (the instrumented tests don't funnel through the commonTest `withHarness` helper); the warning fires when explicit OK markers are 0 and SKIPs > 0.

## What I'm watching for in CI

- `Build quic-echo fat jar (Linux x64)` succeeds (uses default `quicEchoJar`, host-arch-only).
- `Bring up quic-echo via the docker harness` reports healthy.
- Emulator job's `run tests` step: connectedAndroidTest no longer skips `AndroidQuicConnectivityTests.connectToLocalServer` / `echoOverQuic` via assumeTrue — those should now actually exercise the Android x86_64 QUIC client against the JVM server.
- `Audit QUIC harness coverage on Android` reports test counts.

## Follow-up

Align `AndroidQuic*Tests` on a shared `withHarness`-style helper so the audit signal becomes as strong on Android as on the other platforms — low-priority polish.