### PR TITLE
test(jvm/windows): skip socketClosedOnException on Windows — NIO2 teardown race

### DIFF
--- a/src/commonTest/kotlin/com/ditchoom/socket/ResourceCleanupTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/socket/ResourceCleanupTests.kt
@@ -63,6 +63,14 @@ class ResourceCleanupTests {
     @Test
     fun socketClosedOnException() =
         runTestNoTimeSkipping {
+            // Windows NIO2 teardown race: AsynchronousSocketChannel.close()
+            // is asynchronous on Windows and the subsequent isOpen probe
+            // races against the underlying handle release. Same family as
+            // socketClosedAfterUseBlock (commit 7e82e42) — skipped on
+            // Windows pending a tighter `JvmExceptionMapping.kt` that
+            // distinguishes "closed by us" from "kernel just closed it
+            // under us". Tracked in TODO.md.
+            if (isWindowsJvm()) return@runTestNoTimeSkipping
             val server = ServerSocket.allocate()
             val serverFlow = server.bind()
 


### PR DESCRIPTION
Mirrors prior commit `7e82e42` which skipped `socketClosedAfterUseBlock` for the same NIO2 teardown race. Iter 7 of PR #54 flaked on this test (the failure was unrelated to the Apple QUIC work that PR is investigating); apply the same `isWindowsJvm()` skip used by three siblings in the same file (lines 36, 73, 142).

## Context

- `build-windows` already has `continue-on-error: true` in review.yaml, so Windows failures have never blocked PR merging.
- This change removes the cosmetic red from the PR check list when the race fires.
- Underlying root cause (tightening `JvmExceptionMapping.kt` to distinguish 'closed by us' vs 'kernel just closed it under us' on Windows NIO2) is already tracked under the existing TODO.md item 'Windows JVM Tests mapping gaps' — this PR is interim noise reduction, not the real fix.