### PR TITLE
chore: post-release cleanup — tag-push perms + dead test + Apple harness comment

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -220,7 +220,15 @@ jobs:
     if: always() && needs.check-release.outputs.flow != 'skip' && needs.check-release.outputs.flow != 'dry-run'
     runs-on: ubuntu-latest
     steps:
+      # Checkout with RELEASE_PAT (workflow scope) so the tag push in
+      # "Create tag and GitHub release" can succeed when the release commit's
+      # tree contains .github/workflows/* changes. Default GITHUB_TOKEN lacks
+      # the workflow scope and silently rejects such tag pushes (v3.1.0/v3.1.1
+      # both failed this way and were backfilled manually).
+      # Falls back to GITHUB_TOKEN if RELEASE_PAT is not configured.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Create draft GitHub release
         if: needs.check-release.outputs.flow == 'draft' && needs.publish.result == 'success'

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
@@ -37,6 +37,9 @@ import kotlin.time.Duration.Companion.seconds
  * Tests gracefully skip when the harness isn't reachable (local dev
  * without Docker, CI fallback paths) — same withConnect-or-skip pattern
  * as the public-host tests this file replaces.
+ *
+ * Apple K/N skips this entire suite via [isAppleKNative] (see PR #54);
+ * the harness only runs on Linux/JVM/JS CI.
  */
 class QuicHarnessIntegrationTests {
     private val bufferFactory = BufferFactory.deterministic()
@@ -60,15 +63,9 @@ class QuicHarnessIntegrationTests {
 
     /**
      * Run [block] inside a QUIC connection to the harness echo, or skip if
-     * unreachable.
-     *
-     * Logs an explicit `harness OK` or `harness SKIP: <reason>` line so the
-     * CI runner can tell whether the test actually exercised the QUIC
-     * client (vs silently no-op'd because the harness wasn't brought up).
-     * The Apple CI job greps for `harness OK` to assert the macOS-host
-     * `quic-echo` actually accepted at least one connection — without this
-     * signal a forgotten `docker compose up` or a broken jar launch would
-     * pass CI by accident.
+     * unreachable. Logs `harness OK` / `harness SKIP: <reason>` on
+     * Linux/JVM/JS so CI can audit whether the QUIC client actually ran;
+     * Apple K/N short-circuits and skips (see PR #54).
      */
     private suspend fun withHarness(block: suspend QuicScope.() -> Unit) {
         if (isAppleKNative()) {

--- a/src/commonJvmTest/kotlin/com/ditchoom/socket/JvmExceptionSubtypeTests.kt
+++ b/src/commonJvmTest/kotlin/com/ditchoom/socket/JvmExceptionSubtypeTests.kt
@@ -1,10 +1,8 @@
 package com.ditchoom.socket
 
-import com.ditchoom.buffer.toReadBuffer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -95,55 +93,5 @@ class JvmExceptionSubtypeTests {
                 ex.hostname == "nonexistent.jvm.test.invalid" || ex.message.contains("nonexistent.jvm.test.invalid"),
                 "Hostname should be preserved, got: hostname=${ex.hostname}, message=${ex.message}",
             )
-        }
-
-    // Replaced by ExceptionConformanceTests.writeAfterProxyDown_producesSocketClosedException +
-    // writeAfterPeerReset_producesSocketClosedException; remove after CI proves the harness path
-    // runs on every platform per TESTING_STRATEGY.md §6 Phase 5 green-throughout rule.
-    @Test
-    @Ignore
-    fun brokenPipeOrReset_isSocketClosedSubtype() =
-        runTestNoTimeSkipping {
-            val server = ServerSocket.allocate()
-            val serverFlow = server.bind()
-            val clientConnected = Mutex(locked = true)
-
-            val serverJob =
-                launch(Dispatchers.Default) {
-                    serverFlow.collect { client ->
-                        clientConnected.unlock()
-                        client.close()
-                    }
-                }
-
-            val client = ClientSocket.allocate()
-            client.open(server.port(), 5.seconds, "127.0.0.1")
-            clientConnected.lockWithTimeout()
-            kotlinx.coroutines.delay(200)
-
-            val ex =
-                try {
-                    repeat(200) {
-                        client.write(
-                            "x".repeat(8192).toReadBuffer(com.ditchoom.buffer.Charset.UTF8),
-                            1.seconds,
-                        )
-                        kotlinx.coroutines.delay(2)
-                    }
-                    fail("Should have thrown when writing to closed connection")
-                } catch (e: SocketClosedException) {
-                    e
-                }
-
-            // On JVM, writing to closed peer produces BrokenPipe or ConnectionReset
-            assertTrue(
-                ex is SocketClosedException.BrokenPipe ||
-                    ex is SocketClosedException.ConnectionReset,
-                "Expected BrokenPipe or ConnectionReset, got: ${ex::class.simpleName}",
-            )
-
-            client.close()
-            server.close()
-            serverJob.cancel()
         }
 }


### PR DESCRIPTION
## Summary

Three small follow-ups queued after the v3.1.0 / v3.1.1 / v3.1.2 releases landed.

- **Tag-push perms (`.github/workflows/merged.yaml`)** — `Finalize Release` now checks out with `secrets.RELEASE_PAT` (falling back to `secrets.GITHUB_TOKEN` so the workflow doesn't break before the secret is configured). The default `GITHUB_TOKEN` lacks the `workflow` scope and silently rejects tag pushes when the release commit's tree contains `.github/workflows/*` changes — exactly what killed v3.1.0 and v3.1.1's tag pushes (both were backfilled manually via SSH).
- **Delete `JvmExceptionSubtypeTests.brokenPipeOrReset_isSocketClosedSubtype`** — `@Ignore`'d dead code. Already replaced by `ExceptionConformanceTests.writeAfterProxyDown_producesSocketClosedException` + `writeAfterPeerReset_producesSocketClosedException` (PR #54). The harness path is green on the platforms we ship.
- **Fix stale KDoc in `QuicHarnessIntegrationTests`** — claimed Apple CI greps for `harness OK`, but PR #54 iter 9 made Apple K/N skip the harness suite entirely via `isAppleKNative()`. Comments now reflect: harness only runs on Linux/JVM/JS.

## ⚠️ Action required before next workflow-touching release

Mint a Personal Access Token (classic) with **`repo` + `workflow`** scopes and store it as `RELEASE_PAT` in repo secrets. Without it the fallback keeps current behavior — including the same v3.1.0/v3.1.1 failure mode — and the next release that modifies `.github/workflows/*` will need another manual SSH backfill.

## Test plan

- [ ] CI green on this PR (no release flow exercised since `chore:` doesn't trigger one)
- [ ] After merge + `RELEASE_PAT` set: next release PR's `Finalize Release` step pushes the tag without manual SSH intervention
- [ ] Confirm `JvmExceptionSubtypeTests` still has 3 passing tests (`connectionRefused_…`, `readAfterPeerClose_…`, `dnsFailure_…`) — only the `@Ignore`'d one was removed
- [ ] No `harness OK` grep regressions on Linux/JVM/JS QUIC CI matrix