### PR TITLE
refactor(quic): freeze public API — drop dead buffer default, document read-path ownership (Phase 1)

### DIFF
--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheStreamByteStream.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheStreamByteStream.kt
@@ -24,6 +24,25 @@ interface QuicheStreamAdapter {
      * Read from the quiche stream into a buffer allocated from [bufferFactory].
      * Returns [ReadResult.Data] with the buffer, [ReadResult.End] on FIN,
      * or throws on error/timeout.
+     *
+     * ### Buffer ownership
+     * On [ReadResult.Data], ownership of the returned buffer transfers to the
+     * caller. The implementation frees the buffer itself on every other path
+     * (FIN, error, closed channel) but **not** on the data path — there is no
+     * release point here by design. The caller must release it when fully
+     * consumed via `buffer.freeIfNeeded()` (equivalently
+     * `PlatformBuffer.freeNativeMemory()`), which is polymorphic on the
+     * concrete buffer: a no-op for heap buffers (the default
+     * [BufferFactory.Default], reclaimed by GC), an actual free for off-heap
+     * `deterministic()` buffers, and a pool-return for pooled factories.
+     *
+     * This is what makes a caller-supplied pooled or `deterministic()`
+     * [bufferFactory] safe: the codec/mux path already honors it — a
+     * `CodecConnection` hands the buffer to its `StreamProcessor`, which takes
+     * ownership and frees each chunk on consume and on `release()` — so
+     * injecting such a factory via `ConnectionOptions.bufferFactory` through
+     * `withQuicMux` leaks nothing. Only a consumer of the *raw* [read] API who
+     * ignores the returned buffer's ownership leaks under a non-GC factory.
      */
     suspend fun streamRead(
         streamId: QuicStreamId,
@@ -62,6 +81,16 @@ class QuicheStreamByteStream(
 
     override val isOpen: Boolean get() = !closed
 
+    /**
+     * Read the next chunk from the stream.
+     *
+     * On [ReadResult.Data] the returned buffer is **caller-owned** — release it
+     * via `buffer.freeIfNeeded()` once consumed. Harmless to skip under the
+     * default heap [BufferFactory.Default] (GC reclaims), but required to avoid
+     * a native leak under a `deterministic()` or pooled factory. See
+     * [QuicheStreamAdapter.streamRead] for the full ownership contract; the
+     * codec/mux path (`CodecConnection` → `StreamProcessor`) already honors it.
+     */
     override suspend fun read(timeout: Duration): ReadResult {
         check(!closed) { "QuicheStreamByteStream($streamId) is closed" }
         return adapter.streamRead(streamId, bufferFactory, bufferSize, timeout)

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheStreamByteStream.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheStreamByteStream.kt
@@ -2,7 +2,6 @@ package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
-import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.flow.ByteStream
 import com.ditchoom.buffer.flow.BytesWritten
 import com.ditchoom.buffer.flow.ReadResult
@@ -55,7 +54,7 @@ interface QuicheStreamAdapter {
 class QuicheStreamByteStream(
     val streamId: QuicStreamId,
     private val adapter: QuicheStreamAdapter,
-    private val bufferFactory: BufferFactory = BufferFactory.deterministic(),
+    private val bufferFactory: BufferFactory,
     private val bufferSize: Int = 65536,
 ) : ByteStream {
     @Volatile

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration.Companion.seconds
  * cancellation), the connection is closed (QUIC CONNECTION_CLOSE) and all
  * resources are released.
  *
- * This is the only client-facing entry point — there is no [QuicEngine]
+ * This is the only client-facing entry point — there is no `QuicEngine`
  * layer because quiche itself has no analog and the previous factory shape
  * was pure overhead that leaked on dropped error paths. The scope-only
  * block boundary is the lifecycle. See `DRIVER_REDESIGN.md` →

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.kt
@@ -10,7 +10,7 @@ import kotlin.time.Duration.Companion.seconds
  * drivers destroyed, all handler coroutines cancelled.
  *
  * This is the only server-facing entry point — there is no
- * [QuicServerEngine] layer because quiche itself has no analog and the
+ * `QuicServerEngine` layer because quiche itself has no analog and the
  * previous factory shape was pure overhead that leaked on dropped error
  * paths. The scope-only block boundary is the lifecycle. See
  * `DRIVER_REDESIGN.md` → "Engine lifecycle" for the rationale.


### PR DESCRIPTION
## Phase 1 — freeze the public API shape

Per `PLAN.md` Phase 1. Three small commits.

### Item 1 — no-engine refactor: already on `main`
The `QuicEngine`/`QuicServerEngine` collapse into the `withQuicConnection`/`withQuicServer` scope-takers already landed on `main` (commit `44578f5`). No `QuicEngine`/`defaultQuicEngine`/`withQuicEngine` symbols remain. The only residue was two **dangling KDoc links** (`[QuicEngine]`, `[QuicServerEngine]`) pointing at the deleted types — de-linked to inline code spans so Dokka stops emitting dangling-reference warnings.

### Item 2.1 — drop dead `BufferFactory.deterministic()` default
`QuicheStreamByteStream`'s `bufferFactory` default was never reached via any public path — all 5 construction sites (`QuicheDriver`, `JvmQuicConnection`, `CommonJvmWithQuicServer`, both Linux actuals) pass the connection's factory explicitly. The default was a latent footgun: a direct construction would silently get off-heap `Unsafe` buffers nobody frees. Param is now required; unused import dropped.

### Item 2.2 — document the read-path buffer-ownership contract
Investigation overturned the plan's framing ("add a release hook *on `ReadResult.Data`*"):

- The release seam **already exists** — `ReadBuffer.freeIfNeeded()` → `freeNativeMemory()` is polymorphic (no-op heap / free off-heap `deterministic()` / pool-return for `PooledBuffer`).
- `ReadResult` lives in the **pinned Maven dep `buffer-flow` 5.2.0** (not a composite build) and `Data` is a single-field `@JvmInline value class` — a member *on `ReadResult.Data`* is unreachable from this repo.
- The codec/mux path is **already leak-free with a pooled/deterministic factory**: `CodecConnection.fillFromTransport` hands the buffer to `StreamProcessor.append`, which takes ownership and frees each chunk on consume + `release()`. So a caller-supplied pooled/`deterministic()` `ConnectionOptions.bufferFactory` is safe today via `withQuicMux`. Only raw `QuicByteStream.read()` consumers must release manually.

`QuicheDriver.kt:343` transfers `ReadResult.Data` ownership out by design (frees on every other path). Documented that contract on `QuicheStreamAdapter.streamRead` and `QuicheStreamByteStream.read`.

## Verification
- `./gradlew :socket-quic:compileKotlinJvm` ✅
- `./gradlew :socket-quic:ktlintCheck` (commonMain) ✅
- `./gradlew :socket-quic:jvmTest` ✅ (green after the signature change; subsequent commits are comment-only)

## Out of scope (follow-up)
- `PLAN.md` Phase 1 also lists documenting the `recvBufPool` ownership contract (fixed in `80575c1`, never written down).
- `PLAN.md`/`NEXT_SESSION.md`/`TODO.md` Phase 1 checkboxes live only on `chore/post-release-cleanup` (separate docs PR) — to be closed there.
- Next per the plan: Phase 2 (Windows quiche peer, macOS non-Docker QUIC peer).