### PR TITLE
docs(quic): record recvBufPool no-double-wrap ownership invariant

### DIFF
--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -151,6 +151,15 @@ internal class JvmQuicServer(
      * (per-connection coroutine, can hop dispatchers under Dispatchers.IO).
      * maxPoolSize=64 → ~87 KB cached (64 × 1350) — caps steady-state RSS while
      * covering typical concurrent-driver counts.
+     *
+     * Ownership invariant: [bufferFactory] is a **leaf** factory per the
+     * `ConnectionOptions.bufferFactory` contract — this pool is built *from* it
+     * here. Never pass an already-pooled factory as `factory`: wrapping a pool
+     * in a pool is the `80575c1` double-wrap regression. A `BufferPool` whose
+     * leaf `factory` is itself a `BufferPool` makes `freeNativeMemory()` return
+     * the buffer to the inner pool while the outer pool's accounting still
+     * counts it, so neither pool reclaims correctly and the cap stops bounding
+     * RSS. Keep the leaf-factory-in, pool-built-here shape.
      */
     private val recvBufPool =
         BufferPool(

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -83,6 +83,14 @@ class QuicheDriver(
      * Dispatchers.Default coroutine — different threads under load.
      * maxPoolSize=64 → ~87 KB cached (64 × 1350), generous for a single
      * connection's in-flight datagram count.
+     *
+     * Ownership invariant: [bufferFactory] is a **leaf** factory per the
+     * `ConnectionOptions.bufferFactory` contract — this pool is built *from* it.
+     * Never pass an already-pooled factory: wrapping a pool in a pool is the
+     * `80575c1` double-wrap regression (the inner pool reclaims on
+     * `freeNativeMemory()` while the outer pool's accounting still counts the
+     * buffer, so the cap stops bounding RSS). Same shape as the server-side pool
+     * in CommonJvmWithQuicServer.
      */
     private val recvBufPool: BufferPool? =
         if (clientMode) {


### PR DESCRIPTION
Closes the third bullet of `PLAN.md` Phase 1 — document the `recvBufPool` ownership contract (the regression fixed in `80575c1`, never written down) so it can't return.

## What
Both `recvBufPool` sites build a `BufferPool` from `ConnectionOptions.bufferFactory`:
- `QuicheDriver` (client-mode UDP reader pool)
- `JvmQuicServer` (server receive-loop pool)

The existing comments cover pool *mechanics* (ownership transfer, return-to-pool via `freeNativeMemory()`, sizing, threading) but never state the invariant `80575c1` enforced: **`bufferFactory` must be a leaf factory, never an already-pooled one.** Wrapping a pool in a pool double-counts — the inner pool reclaims on `freeNativeMemory()` while the outer pool's accounting still counts the buffer, so neither reclaims correctly and `maxPoolSize` stops bounding RSS.

This adds that invariant at both construction sites (where a regression would be introduced), cross-referencing `80575c1` and the existing caller-facing leaf-factory contract on `ConnectionOptions.bufferFactory`.

## Verification
Doc-only. `compileKotlinJvm` + `ktlintCheck` (commonMain + commonJvmMain) ✅