### PR TITLE
ci(quic): run socket-quic:jvmTest on Windows with cross-built quiche_jni.dll (Phase 2)

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -230,11 +230,13 @@ jobs:
           if [ -n "$WIN_LIB" ]; then
             mkdir -p "$QUICHE_LIBS/windows-x64/lib"
             x86_64-w64-mingw32-gcc -shared -Wall \
+              -static-libgcc -static-libstdc++ \
               -o "$QUICHE_LIBS/windows-x64/lib/quiche_jni.dll" "$JNI_SRC" \
               -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux \
               -I"$QUICHE_H" \
               -Wl,--whole-archive "$WIN_LIB" -Wl,--no-whole-archive \
-              -lws2_32 -lcrypt32 -lntdll -luserenv -lbcrypt -lpthread -lm -lstdc++ \
+              -lws2_32 -lcrypt32 -lntdll -luserenv -lbcrypt -lm \
+              -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic \
               && x86_64-w64-mingw32-strip --strip-all "$QUICHE_LIBS/windows-x64/lib/quiche_jni.dll" \
               && echo "Built Windows x64: $(du -h "$QUICHE_LIBS/windows-x64/lib/quiche_jni.dll" | cut -f1)"
           fi
@@ -440,6 +442,20 @@ jobs:
         with:
           name: quiche-linux-natives
           path: socket-quic/libs/quiche/linux-*/lib/
+          retention-days: 1
+          if-no-files-found: ignore
+
+      # The Windows x64 JNI shim is cross-compiled above (MinGW) but the
+      # conformance suite runs on a separate windows-latest job (review.yaml's
+      # build-windows). Hand the DLL across via this artifact so that job can
+      # stage it and run :socket-quic:jvmTest. if-no-files-found: ignore keeps
+      # the Linux job green if the cross-compile didn't produce the DLL.
+      - name: Upload quiche Windows native lib
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quiche-windows-natives
+          path: socket-quic/libs/quiche/windows-x64/lib/quiche_jni.dll
           retention-days: 1
           if-no-files-found: ignore
 

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -125,6 +125,13 @@ jobs:
     name: "Windows JVM Tests"
     runs-on: windows-latest
     timeout-minutes: 30
+    # needs build-linux for the cross-compiled quiche_jni.dll artifact below.
+    needs: build-linux
+    # continue-on-error stays during Windows-peer bring-up: the MinGW-cross-
+    # compiled DLL has not yet been proven to load on a bare windows-latest
+    # (static-libgcc/stdc++ link is the intended fix; CI is the only place to
+    # verify it). Drop this once :socket-quic:jvmTest is green here ≥2 runs —
+    # exit criterion per PLAN.md Phase 2 rule 4.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -134,15 +141,22 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
           cache: gradle
-      # socket-quic:jvmTest is excluded on Windows because no Windows quiche
-      # JNI native is packaged into the JAR — QuicheApiLoader throws
-      # NoClassDefFoundError. Building a windows-x64 native is tracked as a
-      # follow-up; see TODO.md. The leading colon on `:jvmTest` scopes the
-      # task to the root project; the unqualified `jvmTest` (Gradle multi-
-      # project name matching) ran across every subproject and would have
-      # pulled socket-quic:jvmTest back in.
+      # The Windows quiche JNI shim is cross-compiled on the Linux job and
+      # handed over as the quiche-windows-natives artifact. Drop it where
+      # stageQuicheNativeResources expects it (libs/quiche/windows-x64/lib/)
+      # so NativeLibLoader can extract quiche_jni.dll from the test classpath.
+      - name: Download Windows quiche native lib
+        uses: actions/download-artifact@v4
+        with:
+          name: quiche-windows-natives
+          path: socket-quic/libs/quiche/windows-x64/lib
+      # :jvmTest is the root project's suite. :socket-quic:jvmTest is now
+      # included (was excluded while no Windows native existed): the DLL above
+      # plus the windows-x64 entry in nativeLibsByPlatform let it stage + load.
+      # The leading colon scopes each task to its project; an unqualified
+      # `jvmTest` would match every subproject by name.
       - name: Run JVM tests
-        run: ./gradlew :jvmTest --no-configuration-cache
+        run: ./gradlew :jvmTest :socket-quic:jvmTest --no-configuration-cache
 
   docs:
     name: "Validate Docs Generation"

--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -496,6 +496,13 @@ val nativeLibsByPlatform =
         "linux-arm64" to listOf("libquiche.so", "libquiche_jni.so"),
         "macos-x64" to listOf("libquiche.dylib", "libquiche_jni.dylib"),
         "macos-arm64" to listOf("libquiche.dylib", "libquiche_jni.dylib"),
+        // Windows ships only the JNI shim: quiche is statically linked into
+        // quiche_jni.dll (boringssl-vendored + --whole-archive libquiche.a in
+        // build-linux.yaml's MinGW cross-compile), so there is no separate
+        // quiche.dll to extract — matching NativeLibLoader, which loads only
+        // quiche_jni.dll on Windows. Staged into the jvmTest classpath only;
+        // not in nativeClassifiers, so no windows publish artifact yet.
+        "windows-x64" to listOf("quiche_jni.dll"),
     )
 
 // `-PquicEchoAllArches=true` gates building the non-host-arch JNI shim

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/SockAddrUtil.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/SockAddrUtil.kt
@@ -14,9 +14,9 @@ import java.net.InetSocketAddress
  * Zero-copy: the struct is written directly into a deterministic buffer's native memory.
  * The caller must free the buffer when done.
  *
- * Layout differs between BSD (macOS) and Linux:
+ * Layout differs between BSD (macOS) and Linux/Windows:
  *
- * Linux sockaddr_in (16 bytes):
+ * Linux/Windows sockaddr_in (16 bytes):
  *   [0..1]  sin_family  = AF_INET (2), little-endian
  *   [2..3]  sin_port, [4..7] sin_addr, [8..15] sin_zero
  *
@@ -25,7 +25,9 @@ import java.net.InetSocketAddress
  *   [1]     sin_family  = AF_INET (2)
  *   [2..3]  sin_port, [4..7] sin_addr, [8..15] sin_zero
  *
- * sin6_family / AF_INET6 also differ: 10 on Linux, 30 on BSD.
+ * Windows winsock has no sin_len (same as Linux), so it uses the non-BSD
+ * branch. sin6_family / AF_INET6 differs three ways: 10 on Linux, 30 on BSD,
+ * 23 on Windows — see [AF_INET6].
  */
 internal data class NativeSockAddr(
     val buffer: PlatformBuffer,
@@ -95,11 +97,26 @@ private val IS_BSD: Boolean by lazy {
     System.getProperty("os.name").lowercase().let { it.contains("mac") || it.contains("darwin") || it.contains("bsd") }
 }
 
-// AF_INET = 2 on every POSIX
+private val IS_WINDOWS: Boolean by lazy {
+    System.getProperty("os.name").lowercase().contains("win")
+}
+
+// AF_INET = 2 on every POSIX and on Windows winsock.
 private const val AF_INET = 2
 
-// AF_INET6 is platform-specific — BSDs / Darwin use 30, Linux uses 10.
-private val AF_INET6: Int = if (IS_BSD) 30 else 10
+// AF_INET6 is platform-specific: Linux 10, BSD/Darwin 30, Windows (winsock) 23.
+// quiche compares sa_family against the value baked in for the target it was
+// compiled for, so a mismatch makes it reject the sockaddr with "unsupported
+// address type" (ffi.rs:2059) — a hard panic that crashes the JVM. This is not
+// theoretical on Windows: the JVM opens dual-stack IPv6 DatagramChannels by
+// default there, so channel.localAddress is routinely an Inet6Address even for
+// an IPv4 peer, forcing the IPv6 branch. Getting 23 right is mandatory.
+private val AF_INET6: Int =
+    when {
+        IS_BSD -> 30
+        IS_WINDOWS -> 23
+        else -> 10
+    }
 
 private const val SOCKADDR_IN_SIZE = 16
 private const val SOCKADDR_IN6_SIZE = 28


### PR DESCRIPTION
First Phase 2 item from `PLAN.md` — close the **Windows** harness coverage gap. The native loader was already Windows-ready; the DLL was already being cross-compiled; it was just orphaned. This wires it end-to-end.

## What was already in place
- `NativeLibLoader` already resolves `META-INF/native/windows-$arch/quiche_jni.dll`.
- `build-linux.yaml` already cross-compiles the Windows JNI shim via MinGW into `socket-quic/libs/quiche/windows-x64/lib/quiche_jni.dll`.
- But: `nativeLibsByPlatform` had no `windows-x64` entry (DLL never staged), and the `windows-latest` test job excluded `:socket-quic:jvmTest`.

## Changes
1. **`build.gradle.kts`** — add `windows-x64 → [quiche_jni.dll]` to `nativeLibsByPlatform` so `stageQuicheNativeResources` puts the DLL on the jvmTest classpath. Only the JNI shim (quiche is statically linked into it via `boringssl-vendored` + `--whole-archive libquiche.a`), matching the loader. **Not** added to `nativeClassifiers`, so no Windows Maven artifact yet — separate follow-up.
2. **`build-linux.yaml`** — upload the cross-built DLL as `quiche-windows-natives`; harden the MinGW link (`-static-libgcc -static-libstdc++`, `-Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic`) so the DLL is self-contained on a bare `windows-latest` (no `libstdc++-6.dll`/`libwinpthread-1.dll` dependency — the most likely load failure otherwise).
3. **`review.yaml`** — `build-windows` now `needs: build-linux`, downloads the DLL into `libs/quiche/windows-x64/lib/`, and runs `:socket-quic:jvmTest`.

`prepareQuicheNativeLib` is OS-gated (no-op on Windows), so the test task runs with just the downloaded DLL + staging.

## Verification
- ✅ YAML syntax (both workflows), `:socket-quic:stageQuicheNativeResources` green on Linux (tolerates the absent `windows-x64` dir; stages present platforms only).
- ⚠️ **The DLL actually loading on `windows-latest` can only be verified on CI** — there's no local Windows+MinGW-DLL path. `build-windows` keeps `continue-on-error: true` during bring-up so a load failure surfaces (CI speaks) without blocking the PR. **Exit criterion** (documented inline): drop `continue-on-error` once `:socket-quic:jvmTest` is green here ≥2 runs.

## Follow-ups
- Drop `continue-on-error` once green.
- Publish a `windows-x64` classifier JAR (add to `nativeClassifiers` + `validate-artifacts.yaml`).
- Phase 2's second item: macOS non-Docker QUIC peer.