### PR TITLE
feat(quic): bind quiche connection-migration C API (Phase 3 rung 2, slice 1)

### DIFF
--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -218,6 +218,36 @@ object JniQuicheApi : QuicheApi {
         error: QuicError,
     ): Int = nConnClose(conn.handle, error is QuicError.ApplicationError, error.code, 0L, 0)
 
+    // --- Path migration ---
+    override fun connProbePath(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int = nConnProbePath(conn.handle, localAddr, localLen, peerAddr, peerLen, seqOut)
+
+    override fun connMigrate(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int = nConnMigrate(conn.handle, localAddr, localLen, peerAddr, peerLen, seqOut)
+
+    override fun connMigrateSource(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        seqOut: Long,
+    ): Int = nConnMigrateSource(conn.handle, localAddr, localLen, seqOut)
+
+    override fun connAvailableDcids(conn: QuicheConn): Long = nConnAvailableDcids(conn.handle)
+
+    override fun connScidsLeft(conn: QuicheConn): Long = nConnScidsLeft(conn.handle)
+
     // --- Server-side ---
     override fun configLoadCertChainFromPemFile(
         config: QuicheConfig,
@@ -510,6 +540,36 @@ object JniQuicheApi : QuicheApi {
         reasonAddr: Long,
         reasonLen: Int,
     ): Int
+
+    // --- Path migration JNI externals ---
+    @JvmStatic private external fun nConnProbePath(
+        conn: Long,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int
+
+    @JvmStatic private external fun nConnMigrate(
+        conn: Long,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int
+
+    @JvmStatic private external fun nConnMigrateSource(
+        conn: Long,
+        localAddr: Long,
+        localLen: Int,
+        seqOut: Long,
+    ): Int
+
+    @JvmStatic private external fun nConnAvailableDcids(conn: Long): Long
+
+    @JvmStatic private external fun nConnScidsLeft(conn: Long): Long
 
     @JvmStatic private external fun nRecvInfoNew(
         fromAddr: Long,

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -211,6 +211,54 @@ interface QuicheApi {
         error: QuicError,
     ): Int
 
+    // --- Path migration ---
+
+    /**
+     * Probe the given path for reachability. Returns 0 on success or a negative quiche error code.
+     * [seqOut] is the native address of a `uint64_t` buffer the implementation writes the probed
+     * path's sequence number to.
+     */
+    fun connProbePath(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int
+
+    /**
+     * Migrate the connection to the given local/peer path. Returns 0 on success or a negative
+     * quiche error code. [seqOut] is the native address of a `uint64_t` buffer the implementation
+     * writes the migrated path's sequence number to.
+     */
+    fun connMigrate(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int
+
+    /**
+     * Migrate the connection's source (local) address only. Returns 0 on success or a negative
+     * quiche error code. [seqOut] is the native address of a `uint64_t` buffer the implementation
+     * writes the migrated path's sequence number to.
+     */
+    fun connMigrateSource(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        seqOut: Long,
+    ): Int
+
+    /** Returns the number of source connection IDs that are available to migrate to. */
+    fun connAvailableDcids(conn: QuicheConn): Long
+
+    /** Returns the number of source connection IDs that are still left to be provided to the peer. */
+    fun connScidsLeft(conn: QuicheConn): Long
+
     // --- Server-side ---
 
     fun configLoadCertChainFromPemFile(

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -272,4 +272,34 @@ internal class StubQuicheApi : QuicheApi {
     override fun sendInfoToAddr(info: QuicheSendInfo) = 0L
 
     override fun sendInfoToAddrLen(info: QuicheSendInfo) = 0
+
+    // --- Path migration (no-ops) ---
+    override fun connProbePath(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ) = 0
+
+    override fun connMigrate(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ) = 0
+
+    override fun connMigrateSource(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        seqOut: Long,
+    ) = 0
+
+    override fun connAvailableDcids(conn: QuicheConn) = 0L
+
+    override fun connScidsLeft(conn: QuicheConn) = 0L
 }

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -234,6 +234,47 @@ JNIEXPORT jint JNICALL JNI_FN(nConnClose)(
         (const uint8_t *)(uintptr_t)reason_addr, (size_t)reason_len);
 }
 
+/* --- Path migration --- */
+
+JNIEXPORT jint JNICALL JNI_FN(nConnProbePath)(
+    JNIEnv *env, jclass cls,
+    jlong conn, jlong local_addr, jint local_len,
+    jlong peer_addr, jint peer_len, jlong seq_out) {
+    return (jint)quiche_conn_probe_path(
+        (quiche_conn *)(uintptr_t)conn,
+        (const struct sockaddr *)(uintptr_t)local_addr, (socklen_t)local_len,
+        (const struct sockaddr *)(uintptr_t)peer_addr, (socklen_t)peer_len,
+        (uint64_t *)(uintptr_t)seq_out);
+}
+
+JNIEXPORT jint JNICALL JNI_FN(nConnMigrate)(
+    JNIEnv *env, jclass cls,
+    jlong conn, jlong local_addr, jint local_len,
+    jlong peer_addr, jint peer_len, jlong seq_out) {
+    return (jint)quiche_conn_migrate(
+        (quiche_conn *)(uintptr_t)conn,
+        (const struct sockaddr *)(uintptr_t)local_addr, (socklen_t)local_len,
+        (const struct sockaddr *)(uintptr_t)peer_addr, (socklen_t)peer_len,
+        (uint64_t *)(uintptr_t)seq_out);
+}
+
+JNIEXPORT jint JNICALL JNI_FN(nConnMigrateSource)(
+    JNIEnv *env, jclass cls,
+    jlong conn, jlong local_addr, jint local_len, jlong seq_out) {
+    return (jint)quiche_conn_migrate_source(
+        (quiche_conn *)(uintptr_t)conn,
+        (const struct sockaddr *)(uintptr_t)local_addr, (socklen_t)local_len,
+        (uint64_t *)(uintptr_t)seq_out);
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nConnAvailableDcids)(JNIEnv *env, jclass cls, jlong conn) {
+    return (jlong)quiche_conn_available_dcids((const quiche_conn *)(uintptr_t)conn);
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nConnScidsLeft)(JNIEnv *env, jclass cls, jlong conn) {
+    return (jlong)quiche_conn_scids_left((quiche_conn *)(uintptr_t)conn);
+}
+
 /* --- Server-side --- */
 
 JNIEXPORT jint JNICALL JNI_FN(nConfigLoadCertChainFromPemFile)(

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -149,6 +149,32 @@ class FfmQuicheApi private constructor(
         )
     }
 
+    // --- Path migration handles ---
+    private val hConnProbePath by lazy {
+        downcall(
+            "quiche_conn_probe_path",
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS),
+        )
+    }
+    private val hConnMigrate by lazy {
+        downcall(
+            "quiche_conn_migrate",
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS),
+        )
+    }
+    private val hConnMigrateSource by lazy {
+        downcall(
+            "quiche_conn_migrate_source",
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT, ADDRESS),
+        )
+    }
+    private val hConnAvailableDcids by lazy {
+        downcall("quiche_conn_available_dcids", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
+    }
+    private val hConnScidsLeft by lazy {
+        downcall("quiche_conn_scids_left", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
+    }
+
     // --- Config ---
     override fun configNew(version: Int): QuicheConfig = QuicheConfig((hConfigNew.invokeExact(version) as MemorySegment).address())
 
@@ -408,6 +434,58 @@ class FfmQuicheApi private constructor(
             seg(0L),
             0L,
         ) as Int
+
+    // --- Path migration ---
+    override fun connProbePath(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int =
+        hConnProbePath.invokeExact(
+            seg(conn.handle),
+            seg(localAddr),
+            localLen,
+            seg(peerAddr),
+            peerLen,
+            seg(seqOut),
+        ) as Int
+
+    override fun connMigrate(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int =
+        hConnMigrate.invokeExact(
+            seg(conn.handle),
+            seg(localAddr),
+            localLen,
+            seg(peerAddr),
+            peerLen,
+            seg(seqOut),
+        ) as Int
+
+    override fun connMigrateSource(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        seqOut: Long,
+    ): Int =
+        hConnMigrateSource.invokeExact(
+            seg(conn.handle),
+            seg(localAddr),
+            localLen,
+            seg(seqOut),
+        ) as Int
+
+    override fun connAvailableDcids(conn: QuicheConn): Long = hConnAvailableDcids.invokeExact(seg(conn.handle)) as Long
+
+    override fun connScidsLeft(conn: QuicheConn): Long = hConnScidsLeft.invokeExact(seg(conn.handle)) as Long
 
     // --- Server-side ---
     private val hLoadCert by lazy {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -30,14 +30,19 @@ import com.ditchoom.socket.quic.quiche.quiche_config_set_max_recv_udp_payload_si
 import com.ditchoom.socket.quic.quiche.quiche_config_set_max_send_udp_payload_size
 import com.ditchoom.socket.quic.quiche.quiche_config_set_max_stream_window
 import com.ditchoom.socket.quic.quiche.quiche_config_verify_peer
+import com.ditchoom.socket.quic.quiche.quiche_conn_available_dcids
 import com.ditchoom.socket.quic.quiche.quiche_conn_close
 import com.ditchoom.socket.quic.quiche.quiche_conn_free
 import com.ditchoom.socket.quic.quiche.quiche_conn_is_closed
 import com.ditchoom.socket.quic.quiche.quiche_conn_is_established
 import com.ditchoom.socket.quic.quiche.quiche_conn_is_timed_out
+import com.ditchoom.socket.quic.quiche.quiche_conn_migrate
+import com.ditchoom.socket.quic.quiche.quiche_conn_migrate_source
 import com.ditchoom.socket.quic.quiche.quiche_conn_on_timeout
+import com.ditchoom.socket.quic.quiche.quiche_conn_probe_path
 import com.ditchoom.socket.quic.quiche.quiche_conn_readable
 import com.ditchoom.socket.quic.quiche.quiche_conn_recv
+import com.ditchoom.socket.quic.quiche.quiche_conn_scids_left
 import com.ditchoom.socket.quic.quiche.quiche_conn_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_send
@@ -319,6 +324,59 @@ internal object CinteropQuicheApi : QuicheApi {
             null,
             0.convert(),
         ).toInt()
+
+    // --- Path migration ---
+
+    override fun connProbePath(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int =
+        quiche_conn_probe_path(
+            conn.handle.toCPointer()!!,
+            localAddr.toCPointer()!!,
+            localLen.convert(),
+            peerAddr.toCPointer()!!,
+            peerLen.convert(),
+            seqOut.toCPointer<ULongVar>()!!,
+        )
+
+    override fun connMigrate(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        peerAddr: Long,
+        peerLen: Int,
+        seqOut: Long,
+    ): Int =
+        quiche_conn_migrate(
+            conn.handle.toCPointer()!!,
+            localAddr.toCPointer()!!,
+            localLen.convert(),
+            peerAddr.toCPointer()!!,
+            peerLen.convert(),
+            seqOut.toCPointer<ULongVar>()!!,
+        )
+
+    override fun connMigrateSource(
+        conn: QuicheConn,
+        localAddr: Long,
+        localLen: Int,
+        seqOut: Long,
+    ): Int =
+        quiche_conn_migrate_source(
+            conn.handle.toCPointer()!!,
+            localAddr.toCPointer()!!,
+            localLen.convert(),
+            seqOut.toCPointer<ULongVar>()!!,
+        )
+
+    override fun connAvailableDcids(conn: QuicheConn): Long = quiche_conn_available_dcids(conn.handle.toCPointer()!!).toLong()
+
+    override fun connScidsLeft(conn: QuicheConn): Long = quiche_conn_scids_left(conn.handle.toCPointer()!!).toLong()
 
     // --- Server-side ---
 


### PR DESCRIPTION
Phase 3 was descoped from MP-QUIC (rung 3) to **connection migration (rung 2)** after the quiche-FFI audit: **quiche 0.28 has no multipath** — zero `multipath`/`enable_multipath` in the C FFI *or* the Rust source, and Cloudflare keeps multipath on a separate experimental track (also absent from the latest 0.29.x). Rung 3 is blocked at the engine. Migration, however, is fully exposed by quiche 0.28's C FFI.

## This PR — first binding slice
Adds the migration primitives that mirror the existing `connect`/`accept` sockaddr-address pattern, across all four binding layers:

**`QuicheApi`** (interface) gains:
- `connProbePath` / `connMigrate` / `connMigrateSource` — probe/validate + migrate a 4-tuple; the path sequence number is written to a caller-provided native address.
- `connAvailableDcids` / `connScidsLeft` — connection-ID headroom you need before migrating.

**Implementations:** `FfmQuicheApi` (FFM downcalls), `JniQuicheApi` + `quiche_jni.c` (JNI externals + C glue), `CinteropQuicheApi` (direct cinterop).

## Validation
- ✅ Compiles locally on **jvm**, **jvm21 (FFM)**, and **linuxX64 (cinterop)** — including the previously-uncertain cinterop `uint64_t*` (`ULongVar`) cast and the FFM `size_t`/`socklen_t` descriptors.
- ✅ ktlint clean.
- JNI **C shim** is CI-only (native build) — reviewed line-for-line against `nConnClose` (`(uintptr_t)` casts, `socklen_t`, `uint64_t*`, jint/jlong returns).

## Scope discipline
Bindings only — **no** `QuicheDriver`/`UdpChannel` changes, and **not** the path-event iterator (opaque handle + `sockaddr_storage` out-params + sealed `PathEvent` type — the next, more complex slice).

## Next on the rung-2 ladder
1. Path-event consumption (`quiche_conn_path_event_next` → sealed `PathEvent`).
2. Multi-socket `UdpChannel` + path management in `QuicheDriver`.
3. Public `migrate()`/path API on `QuicScope`.
4. The test-infra spike (interop-runner vs multi-NIC netem) before end-to-end migration validation.

Engine stays quiche 0.28 (migration API is identical in 0.29; the bump is a separate change).