### PR TITLE
feat(quic): bind quiche path-event poll (Phase 3 rung 2, slice 2)

### DIFF
--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -248,6 +248,17 @@ object JniQuicheApi : QuicheApi {
 
     override fun connScidsLeft(conn: QuicheConn): Long = nConnScidsLeft(conn.handle)
 
+    override fun connPathEventNext(
+        conn: QuicheConn,
+        localOut: Long,
+        localLenOut: Long,
+        peerOut: Long,
+        peerLenOut: Long,
+    ): QuichePathEventType? {
+        val raw = nConnPathEventNext(conn.handle, localOut, localLenOut, peerOut, peerLenOut)
+        return if (raw < 0) null else QuichePathEventType.entries[raw]
+    }
+
     // --- Server-side ---
     override fun configLoadCertChainFromPemFile(
         config: QuicheConfig,
@@ -570,6 +581,14 @@ object JniQuicheApi : QuicheApi {
     @JvmStatic private external fun nConnAvailableDcids(conn: Long): Long
 
     @JvmStatic private external fun nConnScidsLeft(conn: Long): Long
+
+    @JvmStatic private external fun nConnPathEventNext(
+        conn: Long,
+        localOut: Long,
+        localLenOut: Long,
+        peerOut: Long,
+        peerLenOut: Long,
+    ): Int
 
     @JvmStatic private external fun nRecvInfoNew(
         fromAddr: Long,

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -259,6 +259,24 @@ interface QuicheApi {
     /** Returns the number of source connection IDs that are still left to be provided to the peer. */
     fun connScidsLeft(conn: QuicheConn): Long
 
+    /**
+     * Poll and CONSUME the next path event (frees it before returning). Returns the
+     * event type, or null if none pending. For every type except
+     * [QuichePathEventType.ReusedSourceConnectionId], fills the caller-provided
+     * sockaddr_storage native buffers [localOut]/[peerOut] and the socklen_t out-words
+     * [localLenOut]/[peerLenOut] with the event's local/peer addresses. For
+     * ReusedSourceConnectionId the type is returned but addresses are NOT surfaced
+     * (its extra old/new-tuple + CID-seq fields are out of scope this slice); set
+     * both length out-words to 0 in that case.
+     */
+    fun connPathEventNext(
+        conn: QuicheConn,
+        localOut: Long,
+        localLenOut: Long,
+        peerOut: Long,
+        peerLenOut: Long,
+    ): QuichePathEventType?
+
     // --- Server-side ---
 
     fun configLoadCertChainFromPemFile(

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuichePathEventType.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuichePathEventType.kt
@@ -1,0 +1,16 @@
+package com.ditchoom.socket.quic
+
+/**
+ * QUIC path event types, mirroring quiche's `quiche_path_event_type` enum.
+ *
+ * The ordinal of each entry matches quiche's C enum value (RFC 9000 connection
+ * migration), so `QuichePathEventType.entries[type]` decodes a raw C int directly.
+ */
+enum class QuichePathEventType {
+    New,
+    Validated,
+    FailedValidation,
+    Closed,
+    ReusedSourceConnectionId,
+    PeerMigrated,
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -302,4 +302,12 @@ internal class StubQuicheApi : QuicheApi {
     override fun connAvailableDcids(conn: QuicheConn) = 0L
 
     override fun connScidsLeft(conn: QuicheConn) = 0L
+
+    override fun connPathEventNext(
+        conn: QuicheConn,
+        localOut: Long,
+        localLenOut: Long,
+        peerOut: Long,
+        peerLenOut: Long,
+    ): QuichePathEventType? = null
 }

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -275,6 +275,49 @@ JNIEXPORT jlong JNICALL JNI_FN(nConnScidsLeft)(JNIEnv *env, jclass cls, jlong co
     return (jlong)quiche_conn_scids_left((quiche_conn *)(uintptr_t)conn);
 }
 
+JNIEXPORT jint JNICALL JNI_FN(nConnPathEventNext)(
+    JNIEnv *env, jclass cls,
+    jlong conn, jlong local_out, jlong local_len_out,
+    jlong peer_out, jlong peer_len_out) {
+    quiche_path_event *ev = quiche_conn_path_event_next((quiche_conn *)(uintptr_t)conn);
+    if (!ev) return -1;
+    int t = quiche_path_event_type(ev);
+    switch (t) {
+        case 0:
+            quiche_path_event_new(ev,
+                (struct sockaddr_storage *)(uintptr_t)local_out, (socklen_t *)(uintptr_t)local_len_out,
+                (struct sockaddr_storage *)(uintptr_t)peer_out, (socklen_t *)(uintptr_t)peer_len_out);
+            break;
+        case 1:
+            quiche_path_event_validated(ev,
+                (struct sockaddr_storage *)(uintptr_t)local_out, (socklen_t *)(uintptr_t)local_len_out,
+                (struct sockaddr_storage *)(uintptr_t)peer_out, (socklen_t *)(uintptr_t)peer_len_out);
+            break;
+        case 2:
+            quiche_path_event_failed_validation(ev,
+                (struct sockaddr_storage *)(uintptr_t)local_out, (socklen_t *)(uintptr_t)local_len_out,
+                (struct sockaddr_storage *)(uintptr_t)peer_out, (socklen_t *)(uintptr_t)peer_len_out);
+            break;
+        case 3:
+            quiche_path_event_closed(ev,
+                (struct sockaddr_storage *)(uintptr_t)local_out, (socklen_t *)(uintptr_t)local_len_out,
+                (struct sockaddr_storage *)(uintptr_t)peer_out, (socklen_t *)(uintptr_t)peer_len_out);
+            break;
+        case 5:
+            quiche_path_event_peer_migrated(ev,
+                (struct sockaddr_storage *)(uintptr_t)local_out, (socklen_t *)(uintptr_t)local_len_out,
+                (struct sockaddr_storage *)(uintptr_t)peer_out, (socklen_t *)(uintptr_t)peer_len_out);
+            break;
+        case 4:
+            /* ReusedSourceConnectionId: extra old/new-tuple + CID-seq fields out of scope; surface no addresses. */
+            *(socklen_t *)(uintptr_t)local_len_out = 0;
+            *(socklen_t *)(uintptr_t)peer_len_out = 0;
+            break;
+    }
+    quiche_path_event_free(ev);
+    return (jint)t;
+}
+
 /* --- Server-side --- */
 
 JNIEXPORT jint JNICALL JNI_FN(nConfigLoadCertChainFromPemFile)(

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -174,6 +174,30 @@ class FfmQuicheApi private constructor(
     private val hConnScidsLeft by lazy {
         downcall("quiche_conn_scids_left", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
     }
+    private val hConnPathEventNext by lazy {
+        downcall("quiche_conn_path_event_next", FunctionDescriptor.of(ADDRESS, ADDRESS))
+    }
+    private val hPathEventType by lazy {
+        downcall("quiche_path_event_type", FunctionDescriptor.of(JAVA_INT, ADDRESS))
+    }
+    private val hPathEventNew by lazy {
+        downcall("quiche_path_event_new", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    }
+    private val hPathEventValidated by lazy {
+        downcall("quiche_path_event_validated", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    }
+    private val hPathEventFailedValidation by lazy {
+        downcall("quiche_path_event_failed_validation", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    }
+    private val hPathEventClosed by lazy {
+        downcall("quiche_path_event_closed", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    }
+    private val hPathEventPeerMigrated by lazy {
+        downcall("quiche_path_event_peer_migrated", FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS, ADDRESS, ADDRESS))
+    }
+    private val hPathEventFree by lazy {
+        downcall("quiche_path_event_free", FunctionDescriptor.ofVoid(ADDRESS))
+    }
 
     // --- Config ---
     override fun configNew(version: Int): QuicheConfig = QuicheConfig((hConfigNew.invokeExact(version) as MemorySegment).address())
@@ -486,6 +510,32 @@ class FfmQuicheApi private constructor(
     override fun connAvailableDcids(conn: QuicheConn): Long = hConnAvailableDcids.invokeExact(seg(conn.handle)) as Long
 
     override fun connScidsLeft(conn: QuicheConn): Long = hConnScidsLeft.invokeExact(seg(conn.handle)) as Long
+
+    override fun connPathEventNext(
+        conn: QuicheConn,
+        localOut: Long,
+        localLenOut: Long,
+        peerOut: Long,
+        peerLenOut: Long,
+    ): QuichePathEventType? {
+        val ev = hConnPathEventNext.invokeExact(seg(conn.handle)) as MemorySegment
+        if (ev.address() == 0L) return null
+        val type = hPathEventType.invokeExact(ev) as Int
+        when (type) {
+            0 -> hPathEventNew.invokeExact(ev, seg(localOut), seg(localLenOut), seg(peerOut), seg(peerLenOut))
+            1 -> hPathEventValidated.invokeExact(ev, seg(localOut), seg(localLenOut), seg(peerOut), seg(peerLenOut))
+            2 -> hPathEventFailedValidation.invokeExact(ev, seg(localOut), seg(localLenOut), seg(peerOut), seg(peerLenOut))
+            3 -> hPathEventClosed.invokeExact(ev, seg(localOut), seg(localLenOut), seg(peerOut), seg(peerLenOut))
+            4 -> {
+                // ReusedSourceConnectionId: extra old/new-tuple + CID-seq fields out of scope; surface no addresses.
+                seg(localLenOut).reinterpret(JAVA_INT.byteSize()).set(JAVA_INT, 0, 0)
+                seg(peerLenOut).reinterpret(JAVA_INT.byteSize()).set(JAVA_INT, 0, 0)
+            }
+            5 -> hPathEventPeerMigrated.invokeExact(ev, seg(localOut), seg(localLenOut), seg(peerOut), seg(peerLenOut))
+        }
+        hPathEventFree.invokeExact(ev)
+        return QuichePathEventType.entries[type]
+    }
 
     // --- Server-side ---
     private val hLoadCert by lazy {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -39,6 +39,7 @@ import com.ditchoom.socket.quic.quiche.quiche_conn_is_timed_out
 import com.ditchoom.socket.quic.quiche.quiche_conn_migrate
 import com.ditchoom.socket.quic.quiche.quiche_conn_migrate_source
 import com.ditchoom.socket.quic.quiche.quiche_conn_on_timeout
+import com.ditchoom.socket.quic.quiche.quiche_conn_path_event_next
 import com.ditchoom.socket.quic.quiche.quiche_conn_probe_path
 import com.ditchoom.socket.quic.quiche.quiche_conn_readable
 import com.ditchoom.socket.quic.quiche.quiche_conn_recv
@@ -51,6 +52,13 @@ import com.ditchoom.socket.quic.quiche.quiche_conn_writable
 import com.ditchoom.socket.quic.quiche.quiche_connect
 import com.ditchoom.socket.quic.quiche.quiche_header_info
 import com.ditchoom.socket.quic.quiche.quiche_negotiate_version
+import com.ditchoom.socket.quic.quiche.quiche_path_event_closed
+import com.ditchoom.socket.quic.quiche.quiche_path_event_failed_validation
+import com.ditchoom.socket.quic.quiche.quiche_path_event_free
+import com.ditchoom.socket.quic.quiche.quiche_path_event_new
+import com.ditchoom.socket.quic.quiche.quiche_path_event_peer_migrated
+import com.ditchoom.socket.quic.quiche.quiche_path_event_type
+import com.ditchoom.socket.quic.quiche.quiche_path_event_validated
 import com.ditchoom.socket.quic.quiche.quiche_recv_info
 import com.ditchoom.socket.quic.quiche.quiche_send_info
 import com.ditchoom.socket.quic.quiche.quiche_stream_iter_free
@@ -377,6 +385,66 @@ internal object CinteropQuicheApi : QuicheApi {
     override fun connAvailableDcids(conn: QuicheConn): Long = quiche_conn_available_dcids(conn.handle.toCPointer()!!).toLong()
 
     override fun connScidsLeft(conn: QuicheConn): Long = quiche_conn_scids_left(conn.handle.toCPointer()!!).toLong()
+
+    override fun connPathEventNext(
+        conn: QuicheConn,
+        localOut: Long,
+        localLenOut: Long,
+        peerOut: Long,
+        peerLenOut: Long,
+    ): QuichePathEventType? {
+        val ev = quiche_conn_path_event_next(conn.handle.toCPointer()!!) ?: return null
+        val t = quiche_path_event_type(ev).value.toInt()
+        when (t) {
+            0 ->
+                quiche_path_event_new(
+                    ev,
+                    localOut.toCPointer()!!,
+                    localLenOut.toCPointer()!!,
+                    peerOut.toCPointer()!!,
+                    peerLenOut.toCPointer()!!,
+                )
+            1 ->
+                quiche_path_event_validated(
+                    ev,
+                    localOut.toCPointer()!!,
+                    localLenOut.toCPointer()!!,
+                    peerOut.toCPointer()!!,
+                    peerLenOut.toCPointer()!!,
+                )
+            2 ->
+                quiche_path_event_failed_validation(
+                    ev,
+                    localOut.toCPointer()!!,
+                    localLenOut.toCPointer()!!,
+                    peerOut.toCPointer()!!,
+                    peerLenOut.toCPointer()!!,
+                )
+            3 ->
+                quiche_path_event_closed(
+                    ev,
+                    localOut.toCPointer()!!,
+                    localLenOut.toCPointer()!!,
+                    peerOut.toCPointer()!!,
+                    peerLenOut.toCPointer()!!,
+                )
+            4 -> {
+                // ReusedSourceConnectionId: extra old/new-tuple + CID-seq fields out of scope; surface no addresses.
+                localLenOut.toCPointer<UIntVar>()!!.pointed.value = 0u
+                peerLenOut.toCPointer<UIntVar>()!!.pointed.value = 0u
+            }
+            5 ->
+                quiche_path_event_peer_migrated(
+                    ev,
+                    localOut.toCPointer()!!,
+                    localLenOut.toCPointer()!!,
+                    peerOut.toCPointer()!!,
+                    peerLenOut.toCPointer()!!,
+                )
+        }
+        quiche_path_event_free(ev)
+        return QuichePathEventType.entries[t]
+    }
 
     // --- Server-side ---
 


### PR DESCRIPTION
Slice 2 of the connection-migration bindings (rung 2): **path-event consumption**. Builds on slice 1 (#61, the migrate/probe primitives).

## API
- `enum class QuichePathEventType { New, Validated, FailedValidation, Closed, ReusedSourceConnectionId, PeerMigrated }`
- `QuicheApi.connPathEventNext(conn, localOut, localLenOut, peerOut, peerLenOut): QuichePathEventType?` — polls and **consumes/frees** one path event, returns its type (or null if none), and for the 5 homogeneous types fills the caller-provided `sockaddr_storage` buffers + `socklen_t` out-words. `ReusedSourceConnectionId` returns the type with both lengths zeroed (its extra old/new-tuple + CID-seq fields are out of scope here).

This is the event side of migration: VALIDATED tells the driver a probed path is usable; PEER_MIGRATED tells a server the peer moved; etc.

## Implementations
- **FfmQuicheApi** — 8 MethodHandles (next/type/5 accessors/free); NULL via `ev.address()==0L`; `free` unconditional after dispatch.
- **JniQuicheApi** + **quiche_jni.c** — `external` + JNI_FN: `if(!ev) return -1`, switch → accessor, `free` after, `return (jint)t`.
- **CinteropQuicheApi** — direct calls; `quiche_path_event_type(ev).value.toInt()` (cinterop enum), `UIntVar` for `socklen_t*`, `?: return null`.
- **StubQuicheApi** (commonTest) — returns null.

**Event lifecycle verified:** `quiche_path_event_free` is always called when an event is returned (only the no-event early-return skips it).

## Validation (all local, all pass)
`:socket-quic:` `compileKotlinJvm`, `compileTestKotlinJvm`, `compileJava21KotlinJvm` (FFM), `compileKotlinLinuxX64` (cinterop), `compileTestKotlinLinuxX64`, `ktlintCheck`. JNI C shim builds in CI (matched line-for-line against existing JNI_FN funcs).

## Scope / next
Bindings only — no `QuicheDriver`/`UdpChannel`, and **no sockaddr decoding** (deferred to the driver slice). Next on the rung-2 ladder: multi-socket `UdpChannel` + path management in the driver, then a public `migrate()`/path API, then the test-infra spike → end-to-end migration validation.