### PR TITLE
feat(quic): connection migration rung 2 — multi-socket driver + active migrate() (Phase 3)

### DIFF
--- a/socket-quic/MIGRATION_SLICE3.md
+++ b/socket-quic/MIGRATION_SLICE3.md
@@ -1,0 +1,192 @@
+# Slice 3 — Multi-socket UdpChannel + path management (connection migration, rung 2)
+
+Status: **design, pre-implementation.** Bindings (slices 1+2) are merged. This doc
+designs the driver work and the public API, and is gated behind the test-infra
+decision (now made — see "Test infra" below).
+
+## Goal
+
+Client-driven **active connection migration**: move a live quiche connection from
+local path A to a freshly-opened local path B via `probe → VALIDATED → migrate`,
+keep streams flowing across the switch, and survive passive rebinds the engine
+notices on its own. This is rung 2 (single active path at a time) — **not** MP-QUIC
+(rung 3, blocked at the engine; see `project_quic_phase3_migration`).
+
+Out of scope for slice 3: Apple (Network.framework migrates internally, no
+controllable API) and JS/Node (no API). `migrate()` throws
+`UnsupportedOperationException` there.
+
+## Test infra (decided)
+
+**Loopback-alias in-repo harness first; netns+netem as a follow-on PR.**
+
+- Active migration needs only **two distinct local addresses**, not NAT/netem.
+  All of `127.0.0.0/8` is loopback on Linux, so a client can bind path A to
+  `127.0.0.1` and path B to `127.0.0.2`, both reaching a server on
+  `127.0.0.1:port`. Migration A→B is then exercisable in a plain `jvmTest` /
+  `linuxX64Test` with no root, Docker, or namespaces. quiche's server
+  auto-responds to PATH_CHALLENGE during normal recv/send, and our server already
+  uses an unconnected `recvFrom` socket, so it accepts the new 4-tuple natively.
+- **Passive rebind** (server-side `PeerMigrated`, lossy links) is deferred to a
+  separate netns+veth+`tc netem` Linux CI job (sub-slice 3f). Not needed to
+  unblock active migration.
+- quic-interop-runner/ns-3 is the gold standard for **interop conformance** but
+  requires an HTTP/0.9 shim + a Docker endpoint image and runs out-of-band from
+  gradle — a later standalone milestone, not the prerequisite harness.
+
+## Current single-path architecture (what changes)
+
+- One `DatagramChannel` → one `NioUdpChannel`/`IoUringUdpChannel` → one
+  `udpReaderLoop`.
+- `flushOutgoing()` calls `connSend(conn, sendAddr, …, sendInfo)` and **ignores
+  `sendInfo.from`** — it always writes to the single channel.
+- `recvInfo` is built once at connect with `to` = path A's local addr, fixed for
+  the connection's life.
+- The driver **never polls `connPathEventNext`** — slices 1+2 bindings are unused.
+
+## The active-migration flow (target behaviour)
+
+1. Connected on path A (socket A, local `lA`, peer `p`).
+2. App calls `migrate(localHost, localPort)` (or `migrate()` for an ephemeral
+   rebind).
+3. Driver checks `connAvailableDcids(conn) > 0` — active migration needs a spare
+   destination CID. quiche issues NEW_CONNECTION_ID automatically post-handshake;
+   if zero, fail fast (or wait one RTT).
+4. Driver opens socket B (local `lB`, same peer) via an injected
+   `UdpChannelFactory`, builds a per-path `recvInfo_B` (`to = lB`), and starts a
+   reader loop for B.
+5. Driver calls `connProbePath(conn, lB, lenB, p, lenP, seqOut)` → quiche queues a
+   PATH_CHALLENGE for path B.
+6. `flushOutgoing()` reads `sendInfo.from` for each datagram and routes it to the
+   socket whose local addr matches — the PATH_CHALLENGE egresses **socket B**.
+7. quiche validates B (CHALLENGE/RESPONSE). Driver polls `connPathEventNext` →
+   `New(lB,p)` then `Validated(lB,p)`.
+8. On `Validated(lB)` matching the pending target, driver calls
+   `connMigrate(conn, lB, lenB, p, lenP, seqOut)` → active path becomes B; emits
+   the new 4-tuple on `pathState`; completes the `migrate()` deferred.
+9. App data now egresses socket B (new DCID on the new path). Socket A is torn
+   down after quiche emits `Closed` for it (or a linger timeout) — never before,
+   or an in-flight PATH_RESPONSE could be dropped.
+
+## Four hard problems → solutions
+
+### 1. Egress routing by `sendInfo.from`
+quiche fills `sendInfo.from` with the local address each datagram must leave from.
+Today it's ignored. **New binding (slice 3a):** `sendInfoFromAddr(info): Long` +
+`sendInfoFromAddrLen(info): Int` — exact mirror of the existing
+`sendInfoToAddr`/`ToAddrLen` (used server-side for `sendTo`). `flushOutgoing()`
+decodes `from` → `PathKey` → looks up the socket in `paths[key]`.
+
+### 2. Ingress attribution
+quiche needs `recvInfo.to` = the local addr the packet arrived on. With two paths,
+that varies per packet. **Solution: one `recvInfo` per path** (`to` = that path's
+local addr), and `QuicheCmd.RecvPacket` gains a `pathKey`. Reader loop for path X
+tags its packets with X; `execute()` picks `recvInfo_X`. (Cleaner than mutating a
+shared `recvInfo.to`, and keeps the sockaddr-pinning lifecycle per-path.)
+
+### 3. sockaddr **decoding** (the reverse of `SockAddrUtil.toNativeSockAddr`)
+Path events and `sendInfo.from` hand back raw `sockaddr`/`sockaddr_storage`. Need:
+- `sockAddrKey(addr, len): PathKey` — allocation-free identity (family, port,
+  addr bytes) for the hot-path egress lookup.
+- `fromNativeSockAddr(addr, len): InetSocketAddress` — for the public `pathState`
+  surface.
+
+Must handle the same family-byte variants the encoder does: BSD `sin_len`,
+`AF_INET6` = 10 (Linux) / 30 (BSD) / 23 (Windows), port in network order. JVM
+version in `commonJvmMain`; K/N version in `linuxMain`.
+
+### 4. Socket creation lives in platform code
+The driver is `commonMain`; opening a `DatagramChannel` (JVM) or io_uring fd
+(Linux) is platform-specific. **New injected dependency:**
+
+```kotlin
+interface UdpChannelFactory {
+    // Open a client UDP socket bound to localHost:localPort (null/0 = ephemeral),
+    // connected to the same peer. Returns the channel + its resolved local
+    // sockaddr (native addr+len, pinned) for quiche, + a release hook.
+    suspend fun openPath(localHost: String?, localPort: Int): NewPath
+}
+class NewPath(
+    val channel: UdpChannel,
+    val localSockAddrAddress: Long,
+    val localSockAddrLength: Int,
+    val release: () -> Unit,
+)
+```
+
+## Type changes summary
+
+| Type | Change |
+|---|---|
+| `QuicheApi` (+ all 4 impls + `StubQuicheApi`) | + `sendInfoFromAddr`, `sendInfoFromAddrLen` |
+| `SockAddrUtil` (commonJvmMain) + new `CinteropSockAddr` (linuxMain) | + `sockAddrKey`, `fromNativeSockAddr` |
+| new `PathKey` (commonMain) | value class: family + port + addr bytes |
+| new `UdpChannelFactory` / `NewPath` (commonMain + JVM/linux actuals) | open a new path socket |
+| `QuicheCmd.RecvPacket` | + `pathKey` |
+| `QuicheDriver` | `paths: Map<PathKey, PathEntry>`, per-path recvInfo + reader loop, `drainPathEvents()`, migration state machine, egress routing |
+| `QuicScope` | + `suspend fun migrate(localHost: String? = null, localPort: Int = 0): MigrationResult`; + `val pathState: StateFlow<PathInfo>` |
+
+`QuicScope` stays `commonMain`-safe: `migrate` takes `String?`/`Int` (no
+`java.net.*`); `PathInfo`/`MigrationResult` are plain common types.
+
+## Driver migration state machine
+
+Per pending migration: `Probing → Validated → Migrated` | `Failed`.
+- `migrate()` → check dcids, open B, build `recvInfo_B`, start reader B,
+  `connProbePath(lB)`, record `pendingTarget = keyB`, return a `Deferred`.
+- `drainPathEvents()` in `afterCommand()` (after `flushOutgoing` +
+  `discoverNewStreams` — events are produced during `connRecv`/`connSend`):
+  - `New(local,peer)` — record availability.
+  - `Validated(local,peer)` — if `local == pendingTarget`: `connMigrate(lB)`,
+    update `pathState`, complete deferred, schedule path-A teardown.
+  - `FailedValidation(local)` — tear down socket B, complete deferred(failure).
+  - `Closed(local)` — tear down that path's socket + reader loop + recvInfo.
+  - `PeerMigrated(local,peer)` — passive: update recorded peer addr + `pathState`.
+  - `ReusedSourceConnectionId` — log only (binding zeroes its addresses).
+
+## Lifecycle / ownership
+
+Each `PathEntry` owns its `UdpChannel`, reader `Job`, `recvInfo`, and pinned local
+sockaddr holder. `cleanup()` iterates `paths` and frees all — extends the existing
+`onCleanup` sockaddr-pinning rule (ffi.rs:2059 panic) per-path. Old path is torn
+down only on `Closed` or linger-timeout, never eagerly.
+
+## Sub-slices (small commits / reviewable PRs)
+
+- **3a — bindings + decoding (no driver changes).** `sendInfoFromAddr/Len` across
+  all 4 impls + stub; `sockAddrKey`/`fromNativeSockAddr` + `PathKey`; encode→decode
+  round-trip unit tests (v4/v6 × family-byte variants). Compiles on all targets.
+- **3b — loopback harness.** Test helper binding client paths to distinct loopback
+  addrs; echo server gains a test-only "whoami" reply (client's observed peer addr)
+  so the test proves bytes egress socket B. RED until 3c/3d land.
+- **3c — multi-socket driver.** `UdpChannelFactory`, per-path `recvInfo`,
+  `RecvPacket.pathKey`, egress routing by `sendInfo.from`. Single path still works
+  (one-entry `paths` map). No public API yet.
+- **3d — path-event consumption + migration state machine.** `drainPathEvents()`,
+  probe→Validated→migrate, FailedValidation/Closed teardown.
+- **3e — public API.** `QuicScope.migrate()` + `pathState`; plumb through
+  `JvmQuicConnection` and the linux actual. Wire 3b harness green.
+- **3f — passive rebind (separate PR).** netns+veth+`tc netem` Linux CI job for
+  server-side `PeerMigrated` + lossy-link behaviour.
+
+## Local validation matrix (per slice)
+
+```
+:socket-quic:compileKotlinJvm  compileTestKotlinJvm  compileJava21KotlinJvm
+:socket-quic:compileKotlinLinuxX64  compileTestKotlinLinuxX64  ktlintCheck
+```
+The JNI C shim only builds in CI. **Remember:** every new `QuicheApi` method
+breaks `StubQuicheApi` — always compile the `*Test*` tasks, not just main
+(prior-slice lesson).
+
+## Open questions / risks
+
+- **Spare DCID required.** Active migration needs `connAvailableDcids > 0`. Server
+  issues NEW_CONNECTION_ID post-handshake; gate `migrate()` on it.
+- **`disable_active_migration` must be false** (default on both ends).
+- **First-datagram routing.** Handshake datagrams' `sendInfo.from` = path A; the A
+  `PathKey` is registered at connect time so the lookup always resolves. If a
+  `from` key is unknown (shouldn't happen), fall back to the active path + log.
+- **io_uring path sockets.** `IoUringUdpChannel` is a connected single fd; opening
+  a second connected socket on a different local addr is fine — needs
+  `IoUringUdpChannelFactory.openPath`.

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
@@ -201,6 +201,8 @@ internal class CommonJvmQuicConfigCalls(
 
     override fun setDisableActiveMigration(v: Boolean) = api.configSetDisableActiveMigration(cfg, v)
 
+    override fun setActiveConnectionIdLimit(v: Long) = api.configSetActiveConnectionIdLimit(cfg, v)
+
     override fun verifyPeer(v: Boolean) = api.configVerifyPeer(cfg, v)
 
     override fun setCcAlgorithm(algo: Int) = api.configSetCcAlgorithm(cfg, algo)

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
@@ -121,6 +121,14 @@ internal suspend fun <R> commonJvmWithQuicConnection(
                         udpChannel = udpChannel,
                         clientMode = true,
                         isServer = false,
+                        // Connection-migration wiring (slice 3): the peer + primary local sockaddrs
+                        // (kept pinned by onCleanup for the driver's life) and a factory for opening
+                        // additional path sockets to the same peer.
+                        peerAddr = connPeerSockAddr.address,
+                        peerLen = connPeerSockAddr.length,
+                        primaryLocalAddr = connLocalSockAddr.address,
+                        primaryLocalLen = connLocalSockAddr.length,
+                        udpChannelFactory = NioUdpChannelFactory(InetSocketAddress(hostname, port), bufferFactory),
                         onCleanup = {
                             connPeerSockAddr.free()
                             connLocalSockAddr.free()

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -176,6 +176,32 @@ internal class JvmQuicServer(
      */
     private val driverCleanupQueue = ConcurrentLinkedQueue<QuicheDriver>()
 
+    /**
+     * Passive-migration support: one server socket sees a client's source address change
+     * after the client migrates (RFC 9000 §9). quiche needs the *actual* per-datagram source
+     * as recv_info.from to recognise the new path, so we cache one recv_info per distinct
+     * source (its `to` is the server's fixed local addr). Touched only on the receive-loop
+     * thread; freed in [close] after every driver is destroyed. Bounded by the number of
+     * distinct source addresses seen on this socket.
+     */
+    private val peerRecvInfos = mutableMapOf<InetSocketAddress, QuicheRecvInfo>()
+    private val recvInfoSockAddrs = mutableListOf<NativeSockAddr>()
+    private var serverLocalSockAddr: NativeSockAddr? = null
+
+    private fun recvInfoFor(source: InetSocketAddress): QuicheRecvInfo {
+        peerRecvInfos[source]?.let { return it }
+        val local =
+            serverLocalSockAddr ?: localAddr.toNativeSockAddr(bufferFactory).also {
+                serverLocalSockAddr = it
+                recvInfoSockAddrs.add(it)
+            }
+        val from = source.toNativeSockAddr(bufferFactory)
+        recvInfoSockAddrs.add(from)
+        val info = api.recvInfoNew(from.address, from.length, local.address, local.length)
+        peerRecvInfos[source] = info
+        return info
+    }
+
     @Volatile private var closed = false
 
     @Volatile private var receiveSelector: Selector? = null
@@ -221,6 +247,13 @@ internal class JvmQuicServer(
             driver.destroy()
         }
         connectionsByDcid.clear()
+        // Drivers destroyed (no connRecv can be in flight) — free the per-source recv_info
+        // cache. Free each recv_info before the sockaddrs it points at.
+        for (info in peerRecvInfos.values) api.recvInfoFree(info)
+        peerRecvInfos.clear()
+        for (sa in recvInfoSockAddrs) sa.free()
+        recvInfoSockAddrs.clear()
+        serverLocalSockAddr = null
         // Drivers have drained — safe to free cached recv buffers. Any release
         // after this point would silently repopulate the pool (benign, but
         // buffers would leak until server GC), which is why this follows the
@@ -342,8 +375,13 @@ internal class JvmQuicServer(
 
                     val existingDriver = connectionsByDcid[dcidKey]
                     if (existingDriver != null) {
-                        // Zero-copy: transfer buffer ownership to driver
-                        val sendResult = existingDriver.commands.trySend(QuicheCmd.RecvPacket(recvBuf, received))
+                        // Zero-copy: transfer buffer ownership to driver. The per-source recv_info
+                        // lets quiche see the real datagram origin so a migrated client's new source
+                        // is recognised as a new path (passive migration).
+                        val sendResult =
+                            existingDriver.commands.trySend(
+                                QuicheCmd.RecvPacket(recvBuf, received, recvInfoOverride = recvInfoFor(peerInetAddr)),
+                            )
                         if (sendResult.isFailure) {
                             recvBuf.freeNativeMemory()
                             // Remove ALL entries for this dead driver, not just the one we hit

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -177,6 +177,14 @@ internal class JvmQuicServer(
     private val driverCleanupQueue = ConcurrentLinkedQueue<QuicheDriver>()
 
     /**
+     * Thread-safe queue of spare-SCID registrations from drivers' [QuicheDriver.onScidIssued]
+     * (fired on a driver coroutine). The receive loop drains it into [connectionsByDcid] so a
+     * migrating peer's new DCID routes to the right driver. Mirrors [driverCleanupQueue]: keeps
+     * all map mutations on the receive-loop thread (no concurrent map needed).
+     */
+    private val scidRegistrationQueue = ConcurrentLinkedQueue<Pair<ConnectionIdKey, QuicheDriver>>()
+
+    /**
      * Passive-migration support: one server socket sees a client's source address change
      * after the client migrates (RFC 9000 §9). quiche needs the *actual* per-datagram source
      * as recv_info.from to recognise the new path, so we cache one recv_info per distinct
@@ -311,9 +319,11 @@ internal class JvmQuicServer(
                 if (closed) break
                 selector.selectedKeys().clear()
 
-                // Remove entries for drivers that have been closed by connection handlers.
-                // This runs on the receive loop thread — sole writer to connectionsByDcid.
+                // Remove entries for drivers that have been closed by connection handlers,
+                // and register spare SCIDs issued by drivers. Both run on the receive loop
+                // thread — sole writer to connectionsByDcid.
                 drainCleanupQueue()
+                drainScidRegistrations()
 
                 // Drain all available packets after select returns
                 while (true) {
@@ -431,6 +441,19 @@ internal class JvmQuicServer(
     }
 
     /**
+     * Register spare SCIDs issued by drivers — maps each to its driver so a migrating peer's
+     * new DCID routes correctly. Called from the receive loop thread only. A registration for an
+     * already-removed driver is harmless: [drainCleanupQueue] runs first each wakeup, and the
+     * connection handler's cleanup re-adds to [driverCleanupQueue] which is drained next time.
+     */
+    private fun drainScidRegistrations() {
+        while (true) {
+            val (key, driver) = scidRegistrationQueue.poll() ?: break
+            connectionsByDcid[key] = driver
+        }
+    }
+
+    /**
      * Write a native size_t value into a buffer for quiche_header_info output params.
      */
     private fun initSizeTBuffer(
@@ -506,6 +529,10 @@ internal class JvmQuicServer(
         // lifetime — recvInfo holds only raw Long pointers into their PlatformBuffers,
         // so without this the buffers become GC-eligible immediately and DirectByteBuffer
         // Cleaner can free the memory mid-connection (see quiche/src/ffi.rs:2059 panic).
+        // Self-reference for the onScidIssued callback: the driver doesn't exist yet when we build
+        // the callback, so capture it via this holder, set right after construction. The callback
+        // only fires on establishment (well after this), so the holder is always populated by then.
+        var driverRef: QuicheDriver? = null
         val driver =
             QuicheDriver(
                 api = api,
@@ -520,7 +547,16 @@ internal class JvmQuicServer(
                     peerSockAddr.free()
                     localSockAddr.free()
                 },
+                onScidIssued = { scid, len ->
+                    // Snapshot the CID bytes now (scid is freed right after this returns) and hand
+                    // the registration to the receive loop, which owns connectionsByDcid.
+                    driverRef?.let { d ->
+                        scidRegistrationQueue.add(ConnectionIdKey.from(scid, len) to d)
+                        receiveSelector?.wakeup()
+                    }
+                },
             )
+        driverRef = driver
 
         driver.start(scope)
 

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -364,6 +364,10 @@ object JniQuicheApi : QuicheApi {
 
     override fun sendInfoToAddrLen(info: QuicheSendInfo): Int = nSendInfoToAddrLen(info.handle)
 
+    override fun sendInfoFromAddr(info: QuicheSendInfo): Long = nSendInfoFromAddr(info.handle)
+
+    override fun sendInfoFromAddrLen(info: QuicheSendInfo): Int = nSendInfoFromAddrLen(info.handle)
+
     private const val QUICHE_ERR_DONE = -1L
 
     // --- JNI externals (raw Long — JNI doesn't understand inline classes) ---
@@ -606,6 +610,10 @@ object JniQuicheApi : QuicheApi {
     @JvmStatic private external fun nSendInfoToAddr(ptr: Long): Long
 
     @JvmStatic private external fun nSendInfoToAddrLen(ptr: Long): Int
+
+    @JvmStatic private external fun nSendInfoFromAddr(ptr: Long): Long
+
+    @JvmStatic private external fun nSendInfoFromAddrLen(ptr: Long): Int
 
     // --- Server-side JNI externals ---
     @JvmStatic private external fun nConfigLoadCertChainFromPemFile(

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -233,6 +233,15 @@ object JniQuicheApi : QuicheApi {
         seqOut: Long,
     ): Int = nConnProbePath(conn.handle, localAddr, localLen, peerAddr, peerLen, seqOut)
 
+    override fun connNewScid(
+        conn: QuicheConn,
+        scidAddr: Long,
+        scidLen: Int,
+        resetTokenAddr: Long,
+        retireIfNeeded: Boolean,
+        seqOut: Long,
+    ): Int = nConnNewScid(conn.handle, scidAddr, scidLen, resetTokenAddr, retireIfNeeded, seqOut)
+
     override fun connMigrate(
         conn: QuicheConn,
         localAddr: Long,
@@ -583,6 +592,15 @@ object JniQuicheApi : QuicheApi {
         localLen: Int,
         peerAddr: Long,
         peerLen: Int,
+        seqOut: Long,
+    ): Int
+
+    @JvmStatic private external fun nConnNewScid(
+        conn: Long,
+        scidAddr: Long,
+        scidLen: Int,
+        resetTokenAddr: Long,
+        retireIfNeeded: Boolean,
         seqOut: Long,
     ): Int
 

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -368,6 +368,16 @@ object JniQuicheApi : QuicheApi {
 
     override fun sendInfoFromAddrLen(info: QuicheSendInfo): Int = nSendInfoFromAddrLen(info.handle)
 
+    override fun sockAddrFamily(addr: Long): Int = nSockAddrFamily(addr)
+
+    override fun sockAddrPort(addr: Long): Int = nSockAddrPort(addr)
+
+    override fun sockAddrV4(addr: Long): Long = nSockAddrV4(addr)
+
+    override fun sockAddrV6Hi(addr: Long): Long = nSockAddrV6Hi(addr)
+
+    override fun sockAddrV6Lo(addr: Long): Long = nSockAddrV6Lo(addr)
+
     private const val QUICHE_ERR_DONE = -1L
 
     // --- JNI externals (raw Long — JNI doesn't understand inline classes) ---
@@ -614,6 +624,16 @@ object JniQuicheApi : QuicheApi {
     @JvmStatic private external fun nSendInfoFromAddr(ptr: Long): Long
 
     @JvmStatic private external fun nSendInfoFromAddrLen(ptr: Long): Int
+
+    @JvmStatic private external fun nSockAddrFamily(addr: Long): Int
+
+    @JvmStatic private external fun nSockAddrPort(addr: Long): Int
+
+    @JvmStatic private external fun nSockAddrV4(addr: Long): Long
+
+    @JvmStatic private external fun nSockAddrV6Hi(addr: Long): Long
+
+    @JvmStatic private external fun nSockAddrV6Lo(addr: Long): Long
 
     // --- Server-side JNI externals ---
     @JvmStatic private external fun nConfigLoadCertChainFromPemFile(

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -79,6 +79,11 @@ object JniQuicheApi : QuicheApi {
         v: Boolean,
     ) = nConfigSetDisableActiveMigration(config.handle, v)
 
+    override fun configSetActiveConnectionIdLimit(
+        config: QuicheConfig,
+        v: Long,
+    ) = nConfigSetActiveConnectionIdLimit(config.handle, v)
+
     override fun configVerifyPeer(
         config: QuicheConfig,
         v: Boolean,
@@ -407,6 +412,11 @@ object JniQuicheApi : QuicheApi {
     )
 
     @JvmStatic private external fun nConfigSetInitialMaxData(
+        config: Long,
+        v: Long,
+    )
+
+    @JvmStatic private external fun nConfigSetActiveConnectionIdLimit(
         config: Long,
         v: Long,
     )

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
@@ -52,6 +52,20 @@ internal class JvmQuicConnection(
 
     override fun streams(): Flow<QuicByteStream> = driver.incomingStreams.consumeAsFlow()
 
+    override val pathState: StateFlow<PathInfo> = driver.pathState
+
+    override suspend fun migrate(
+        localHost: String?,
+        localPort: Int,
+    ): MigrationResult =
+        try {
+            val deferred = CompletableDeferred<MigrationResult>()
+            driver.commands.send(QuicheCmd.Migrate(localHost, localPort, deferred))
+            deferred.await()
+        } catch (_: ClosedSendChannelException) {
+            MigrationResult.Failed("connection closed")
+        }
+
     override suspend fun close(error: QuicError) {
         try {
             val deferred = CompletableDeferred<Unit>()

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/NioUdpChannel.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/NioUdpChannel.kt
@@ -57,15 +57,33 @@ internal class NioUdpChannel(
         return channel.read(bb)
     }
 
+    // 1-entry cache for the last sendInfo.to reconstruction. Server egress targets the same
+    // destination on consecutive datagrams in steady state, so this keeps the common path free
+    // of per-datagram InetSocketAddress/InetAddress allocation; it only rebuilds when the peer's
+    // address actually changes (i.e. a migration).
+    private var lastDestKey: PathKey? = null
+    private var lastDestAddr: InetSocketAddress? = null
+
     override suspend fun send(
         buffer: PlatformBuffer,
         len: Int,
+        dest: PathKey?,
     ) {
         val bb = (buffer.unwrapFully() as com.ditchoom.buffer.BaseJvmBuffer).byteBuffer
         bb.clear()
         bb.limit(len)
-        if (peerAddr != null) {
-            channel.send(bb, peerAddr)
+        val target =
+            if (dest != null) {
+                if (dest != lastDestKey) {
+                    lastDestAddr = dest.toInetSocketAddress()
+                    lastDestKey = dest
+                }
+                lastDestAddr ?: peerAddr
+            } else {
+                peerAddr
+            }
+        if (target != null) {
+            channel.send(bb, target)
         } else {
             channel.write(bb)
         }

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/NioUdpChannelFactory.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/NioUdpChannelFactory.kt
@@ -1,0 +1,37 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import java.net.InetSocketAddress
+import java.nio.channels.DatagramChannel
+
+/**
+ * JVM/Android [UdpChannelFactory]: opens a new [DatagramChannel] bound to a chosen
+ * local address and connected to the same [peer] as the originating connection,
+ * for active connection migration (slice 3). Mirrors the socket setup in
+ * [commonJvmWithQuicConnection].
+ */
+internal class NioUdpChannelFactory(
+    private val peer: InetSocketAddress,
+    private val bufferFactory: BufferFactory,
+) : UdpChannelFactory {
+    override suspend fun openPath(
+        localHost: String?,
+        localPort: Int,
+    ): NewPath {
+        val channel = DatagramChannel.open()
+        channel.configureBlocking(false)
+        // Bind the new local 4-tuple, then connect to the same peer. localHost null binds the
+        // wildcard address; localPort 0 picks an ephemeral port — a fresh source either way.
+        channel.bind(InetSocketAddress(localHost ?: "0.0.0.0", localPort))
+        channel.connect(peer)
+        val localAddr = channel.localAddress as InetSocketAddress
+
+        val localSockAddr = localAddr.toNativeSockAddr(bufferFactory)
+        return NewPath(
+            channel = NioUdpChannel(channel),
+            localSockAddrAddress = localSockAddr.address,
+            localSockAddrLength = localSockAddr.length,
+            release = { localSockAddr.free() },
+        )
+    }
+}

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/SockAddrUtil.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/SockAddrUtil.kt
@@ -93,6 +93,40 @@ internal fun InetSocketAddress.toNativeSockAddr(bufferFactory: BufferFactory): N
     }
 }
 
+/**
+ * Reconstruct an [InetSocketAddress] from a [PathKey] decoded via
+ * [QuicheApi.decodePathKey]. Inverse of [toNativeSockAddr] + decode: the key's
+ * `lo`/`hi` hold the address bytes in canonical network order interpreted
+ * big-endian (see the JNI/FFM/cinterop decode), so the high byte is emitted
+ * first. Used by the server egress path to turn `sendInfo.to` into a NIO send
+ * destination. Returns null for the empty/unknown family (PathKey family 0).
+ */
+internal fun PathKey.toInetSocketAddress(): InetSocketAddress? {
+    val bytes =
+        when (family) {
+            // java.net.InetAddress requires a ByteArray at this boundary; the 4/16-byte
+            // address is tiny and built once per distinct destination (cached upstream).
+            4 ->
+                @Suppress("NoByteArrayInProd") // java.net.InetAddress.getByAddress boundary
+                byteArrayOf(
+                    (lo ushr 24).toByte(),
+                    (lo ushr 16).toByte(),
+                    (lo ushr 8).toByte(),
+                    lo.toByte(),
+                )
+            6 ->
+                @Suppress("NoByteArrayInProd") // java.net.InetAddress.getByAddress boundary
+                ByteArray(16).also { b ->
+                    for (i in 0 until 8) {
+                        b[i] = (hi ushr (8 * (7 - i))).toByte()
+                        b[i + 8] = (lo ushr (8 * (7 - i))).toByte()
+                    }
+                }
+            else -> return null
+        }
+    return InetSocketAddress(java.net.InetAddress.getByAddress(bytes), port)
+}
+
 private val IS_BSD: Boolean by lazy {
     System.getProperty("os.name").lowercase().let { it.contains("mac") || it.contains("darwin") || it.contains("bsd") }
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/Migration.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/Migration.kt
@@ -1,0 +1,44 @@
+package com.ditchoom.socket.quic
+
+/** Phase of an active connection migration, surfaced via [QuicScope.pathState]. */
+enum class MigrationPhase {
+    /** No migration has been requested. */
+    None,
+
+    /** A new path has been opened and a PATH_CHALLENGE is in flight. */
+    Probing,
+
+    /** The new path passed validation but the active path has not switched yet. */
+    Validated,
+
+    /** The connection's active path is now the migrated path. */
+    Migrated,
+
+    /** The most recent migration attempt failed; the connection stays on its previous path. */
+    Failed,
+}
+
+/** Current migration/path state of a [QuicScope]. */
+data class PathInfo(
+    val phase: MigrationPhase = MigrationPhase.None,
+    /** Local host of the active/target path, when known. */
+    val localHost: String? = null,
+    val localPort: Int = 0,
+)
+
+/** Result of a [QuicScope.migrate] call. */
+sealed interface MigrationResult {
+    /** The connection migrated to the requested local path. */
+    data class Succeeded(
+        val localHost: String?,
+        val localPort: Int,
+    ) : MigrationResult
+
+    /** Migration was attempted but did not complete; [reason] explains why. */
+    data class Failed(
+        val reason: String,
+    ) : MigrationResult
+
+    /** This platform/connection does not support active migration (Apple, JS, server-accepted connections). */
+    data object Unsupported : MigrationResult
+}

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/PathKey.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/PathKey.kt
@@ -1,0 +1,33 @@
+package com.ditchoom.socket.quic
+
+/**
+ * Allocation-free identity for a network path's local or peer address, used by the
+ * multi-socket migration driver (slice 3) to route each outgoing datagram to the
+ * socket bound to a given local address and to match path-event addresses.
+ *
+ * [hi]/[lo] hold the raw address bits (IPv4 packs into [lo] with [hi] == 0; IPv6
+ * fills both). Byte order is unspecified on purpose — a [PathKey] is only ever
+ * compared, never reconstructed into an address — so two decodes of the same
+ * sockaddr are equal and two distinct addresses differ. No `ByteArray` (the
+ * production no-ByteArray rule); a value-based [data class] gives correct equality
+ * for use as a `Map` key.
+ */
+data class PathKey(
+    /** 4 (IPv4), 6 (IPv6), or 0 (unknown). */
+    val family: Int,
+    val port: Int,
+    val hi: Long,
+    val lo: Long,
+)
+
+/**
+ * Decode the sockaddr at native pointer [addr] into an allocation-free [PathKey].
+ * Both sides of a routing comparison decode through the same [QuicheApi] backend,
+ * so equality is consistent regardless of the unspecified byte order in [PathKey].
+ */
+fun QuicheApi.decodePathKey(addr: Long): PathKey =
+    when (sockAddrFamily(addr)) {
+        4 -> PathKey(family = 4, port = sockAddrPort(addr), hi = 0L, lo = sockAddrV4(addr))
+        6 -> PathKey(family = 6, port = sockAddrPort(addr), hi = sockAddrV6Hi(addr), lo = sockAddrV6Lo(addr))
+        else -> PathKey(family = 0, port = 0, hi = 0L, lo = 0L)
+    }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicConfigApplicator.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicConfigApplicator.kt
@@ -32,6 +32,8 @@ internal interface QuicConfigCalls {
 
     fun setDisableActiveMigration(v: Boolean)
 
+    fun setActiveConnectionIdLimit(v: Long)
+
     fun verifyPeer(v: Boolean)
 
     fun setCcAlgorithm(algo: Int)
@@ -78,6 +80,7 @@ internal fun applyQuicOptions(
     fc.maxStreamWindow?.let { calls.setMaxStreamWindow(it) }
 
     calls.setDisableActiveMigration(options.disableActiveMigration)
+    calls.setActiveConnectionIdLimit(options.activeConnectionIdLimit)
     calls.verifyPeer(options.verifyPeer)
 
     // Congestion control

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicOptions.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicOptions.kt
@@ -102,6 +102,13 @@ data class QuicOptions(
     val initialCongestionWindowPackets: Long? = null,
     /** Disable active connection migration. */
     val disableActiveMigration: Boolean = false,
+    /**
+     * Number of connection IDs the endpoint is willing to maintain (RFC 9000 §5.1.1,
+     * `active_connection_id_limit`). Must be >= 2 for active migration: the peer issues
+     * up to this many NEW_CONNECTION_ID frames, and migrating to a new path consumes one
+     * spare destination CID. Default 4 leaves headroom for a few migrations.
+     */
+    val activeConnectionIdLimit: Long = 4,
     /** Verify the peer's TLS certificate. */
     val verifyPeer: Boolean = true,
     /** Enable Path MTU Discovery. */

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicScope.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicScope.kt
@@ -2,6 +2,8 @@ package com.ditchoom.socket.quic
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * A QUIC connection scope — the receiver inside [withQuicConnection] and [QuicServer.connections].
@@ -28,4 +30,22 @@ interface QuicScope : CoroutineScope {
 
     /** Flow of all peer-initiated streams. Completes when the connection closes. */
     fun streams(): Flow<QuicByteStream>
+
+    /**
+     * Actively migrate the connection to a new local path (RFC 9000 §9). The driver opens a UDP
+     * socket bound to [localHost]:[localPort] (null host = default interface, 0 port = ephemeral),
+     * probes the path, and switches the connection's active path once the peer validates it. Streams
+     * keep flowing across the switch.
+     *
+     * Returns [MigrationResult.Unsupported] on platforms without controllable migration (Apple, JS)
+     * and on server-accepted connections. The default implementation is [MigrationResult.Unsupported].
+     */
+    suspend fun migrate(
+        localHost: String? = null,
+        localPort: Int = 0,
+    ): MigrationResult = MigrationResult.Unsupported
+
+    /** Current migration/path state. Defaults to a never-migrating [PathInfo]. */
+    val pathState: StateFlow<PathInfo>
+        get() = MutableStateFlow(PathInfo())
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -358,4 +358,15 @@ interface QuicheApi {
     fun sendInfoToAddr(info: QuicheSendInfo): Long
 
     fun sendInfoToAddrLen(info: QuicheSendInfo): Int
+
+    /**
+     * Native pointer to the `from` (local egress) sockaddr quiche filled in after
+     * [connSend]. Mirror of [sendInfoToAddr]. Used by the multi-socket driver to
+     * route each outgoing datagram to the path socket bound to this local address
+     * (slice 3 connection migration). The pointer is into the send_info struct and
+     * is valid until the next [connSend] overwrites it.
+     */
+    fun sendInfoFromAddr(info: QuicheSendInfo): Long
+
+    fun sendInfoFromAddrLen(info: QuicheSendInfo): Int
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -85,6 +85,11 @@ interface QuicheApi {
         v: Boolean,
     )
 
+    fun configSetActiveConnectionIdLimit(
+        config: QuicheConfig,
+        v: Long,
+    )
+
     fun configVerifyPeer(
         config: QuicheConfig,
         v: Boolean,

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -233,6 +233,22 @@ interface QuicheApi {
     ): Int
 
     /**
+     * Supply a spare source connection ID to the peer (`quiche_conn_new_scid`). quiche does
+     * not auto-issue CIDs — without this the peer never gets a NEW_CONNECTION_ID and has no
+     * spare destination CID to migrate to. [scidAddr] points at a [scidLen]-byte CID,
+     * [resetTokenAddr] at a 16-byte stateless-reset token; the issued sequence number is
+     * written to [seqOut]. Returns the sequence number (>= 0) or a negative quiche error.
+     */
+    fun connNewScid(
+        conn: QuicheConn,
+        scidAddr: Long,
+        scidLen: Int,
+        resetTokenAddr: Long,
+        retireIfNeeded: Boolean,
+        seqOut: Long,
+    ): Int
+
+    /**
      * Migrate the connection to the given local/peer path. Returns 0 on success or a negative
      * quiche error code. [seqOut] is the native address of a `uint64_t` buffer the implementation
      * writes the migrated path's sequence number to.

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -369,4 +369,25 @@ interface QuicheApi {
     fun sendInfoFromAddr(info: QuicheSendInfo): Long
 
     fun sendInfoFromAddrLen(info: QuicheSendInfo): Int
+
+    // --- sockaddr decode (slice 3 migration) ---
+    // Reverse of SockAddrUtil's encode. The JNI backend forwards to native helpers in
+    // quiche_jni.c (native code knows the platform's sockaddr layout — BSD sin_len,
+    // AF_INET6 = 10/30/23); FFM and cinterop read the struct directly. Used to turn the
+    // raw sockaddr quiche fills (sendInfo.from, path-event addresses) into a [PathKey].
+
+    /** IP version of the sockaddr at native [addr]: 4 (IPv4), 6 (IPv6), or 0 (unknown). */
+    fun sockAddrFamily(addr: Long): Int
+
+    /** UDP port (host byte order) of the sockaddr at [addr]. */
+    fun sockAddrPort(addr: Long): Int
+
+    /** IPv4 address bits of the sockaddr at [addr] — opaque identity, valid when family == 4. */
+    fun sockAddrV4(addr: Long): Long
+
+    /** High 8 bytes of the IPv6 address at [addr] — opaque identity, valid when family == 6. */
+    fun sockAddrV6Hi(addr: Long): Long
+
+    /** Low 8 bytes of the IPv6 address at [addr] — opaque identity, valid when family == 6. */
+    fun sockAddrV6Lo(addr: Long): Long
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
@@ -10,10 +10,15 @@ import kotlinx.coroutines.CompletableDeferred
  * All parameters use value classes or sealed types — no raw Long mixing possible.
  */
 sealed interface QuicheCmd {
-    /** Feed an incoming UDP packet to quiche. [buf] ownership transfers to the driver (freed after processing). */
+    /**
+     * Feed an incoming UDP packet to quiche. [buf] ownership transfers to the driver (freed after processing).
+     * [pathKey] identifies which local path socket received it (null = the connection's primary path), so the
+     * driver hands quiche the matching recv_info during connection migration (slice 3).
+     */
     class RecvPacket(
         val buf: PlatformBuffer,
         val len: Int,
+        val pathKey: PathKey? = null,
     ) : QuicheCmd
 
     /** Allocate the next stream ID and create a [StreamSlot]. */
@@ -42,5 +47,16 @@ sealed interface QuicheCmd {
     class Close(
         val error: QuicError,
         val result: CompletableDeferred<Unit>,
+    ) : QuicheCmd
+
+    /**
+     * Actively migrate the connection to a new local path bound to [localHost]:[localPort]
+     * (null host = default interface, 0 port = ephemeral). The driver opens the path socket,
+     * probes it, and on validation switches the active path (slice 3).
+     */
+    class Migrate(
+        val localHost: String?,
+        val localPort: Int,
+        val result: CompletableDeferred<MigrationResult>,
     ) : QuicheCmd
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
@@ -14,11 +14,17 @@ sealed interface QuicheCmd {
      * Feed an incoming UDP packet to quiche. [buf] ownership transfers to the driver (freed after processing).
      * [pathKey] identifies which local path socket received it (null = the connection's primary path), so the
      * driver hands quiche the matching recv_info during connection migration (slice 3).
+     *
+     * [recvInfoOverride] lets the *server* supply a per-datagram recv_info whose `from` is the actual datagram
+     * source — required for passive (peer) migration, where one server socket sees a client's source address
+     * change. The caller owns the recv_info's lifetime (the server caches them per source). When set it takes
+     * precedence over [pathKey]; clients leave it null and use [pathKey] path routing instead.
      */
     class RecvPacket(
         val buf: PlatformBuffer,
         val len: Int,
         val pathKey: PathKey? = null,
+        val recvInfoOverride: QuicheRecvInfo? = null,
     ) : QuicheCmd
 
     /** Allocate the next stream ID and create a [StreamSlot]. */

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -69,6 +69,15 @@ class QuicheDriver(
      * quiche/src/ffi.rs:2059 ("unsupported address type").
      */
     private val onCleanup: () -> Unit = {},
+    /**
+     * Server-only: invoked with each spare source CID issued by [issueSpareCids], before that
+     * scid buffer is freed. The server registers the CID in its DCID->driver routing map, because
+     * a migrating peer switches to a *new* DCID (one of these issued CIDs) on the new path; without
+     * the mapping those packets miss the demux, look like a new connection, and get dropped — the
+     * server never sees the PATH_CHALLENGE and validation fails. Clients leave it null (they demux
+     * incoming packets by their per-path socket, not by an app-level DCID map).
+     */
+    private val onScidIssued: ((PlatformBuffer, Int) -> Unit)? = null,
 ) {
     val commands = Channel<QuicheCmd>(Channel.UNLIMITED)
 
@@ -528,6 +537,8 @@ class QuicheDriver(
                     true,
                     addr(seqScratch),
                 )
+            // Surface the issued CID (server registers it for routing) before freeing the buffer.
+            if (rc >= 0) onScidIssued?.invoke(scid, QUIC_MAX_CONN_ID_LEN)
             scid.freeNativeMemory()
             token.freeNativeMemory()
             if (rc < 0) break

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -48,6 +48,17 @@ class QuicheDriver(
     private val clientMode: Boolean = true,
     private val isServer: Boolean = false,
     /**
+     * Connection-migration wiring (slice 3). All default to "disabled" so server-accepted
+     * drivers, unit-test fakes, and the no-migration platforms keep their single-path
+     * behaviour untouched. A client setup that supports migration passes the peer sockaddr,
+     * the primary local sockaddr, and a [UdpChannelFactory] for opening additional paths.
+     */
+    private val peerAddr: Long = 0L,
+    private val peerLen: Int = 0,
+    private val primaryLocalAddr: Long = 0L,
+    private val primaryLocalLen: Int = 0,
+    private val udpChannelFactory: UdpChannelFactory? = null,
+    /**
      * Called from [cleanup] after all quiche handles have been freed. Used by callers
      * to release platform-owned memory referenced by [recvInfo] (peer/local sockaddrs)
      * whose raw pointers are cached inside the recv_info struct. The closure itself
@@ -104,12 +115,77 @@ class QuicheDriver(
             null
         }
 
+    /**
+     * One network path the connection can send/receive on. The connection always has
+     * a [primary] path; active migration ([handleMigrate]) opens more. Routing stays
+     * dormant while there is a single path — [flushOutgoing] sends straight to
+     * [primary] and never decodes — so single-path behaviour is byte-for-byte unchanged.
+     */
+    private inner class PathEntry(
+        val key: PathKey,
+        val channel: UdpChannel,
+        val recvInfo: QuicheRecvInfo,
+        val localAddr: Long,
+        val localLen: Int,
+        val isPrimary: Boolean,
+        val release: () -> Unit,
+    ) {
+        var readerJob: Job? = null
+    }
+
+    private val primary =
+        PathEntry(
+            key = if (primaryLocalAddr != 0L) api.decodePathKey(primaryLocalAddr) else PathKey(0, 0, 0L, 0L),
+            channel = udpChannel,
+            recvInfo = recvInfo,
+            localAddr = primaryLocalAddr,
+            localLen = primaryLocalLen,
+            isPrimary = true,
+            // Primary sockaddr lifetime is owned by the connection setup's onCleanup; nothing to release here.
+            release = {},
+        )
+    private val paths = mutableMapOf(primary.key to primary)
+
+    /** True only for a client connection wired with a [UdpChannelFactory] and peer/local sockaddrs. */
+    private val migrationEnabled: Boolean = clientMode && udpChannelFactory != null && peerAddr != 0L && primaryLocalAddr != 0L
+
+    private var activeKey: PathKey = primary.key
+    private var pendingMigration: PendingMigration? = null
+
+    private val _pathState = MutableStateFlow(PathInfo())
+    val pathState: StateFlow<PathInfo> = _pathState
+
+    private var driverScope: CoroutineScope? = null
+
+    // Native scratch for probe/migrate seq-out and for the four sockaddr_storage out-words
+    // connPathEventNext fills. Allocated only for migration-capable clients.
+    private val seqScratch: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(8) else null
+    private val peLocalOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(SOCKADDR_STORAGE_SIZE) else null
+    private val peLocalLenOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(4) else null
+    private val pePeerOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(SOCKADDR_STORAGE_SIZE) else null
+    private val pePeerLenOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(4) else null
+
+    private fun addr(buf: PlatformBuffer?): Long = if (buf == null) 0L else buf.nativeMemoryAccess!!.nativeAddress.toLong()
+
+    private inner class PendingMigration(
+        val key: PathKey,
+        val localHost: String?,
+        val localPort: Int,
+        val result: CompletableDeferred<MigrationResult>,
+    )
+
     fun start(scope: CoroutineScope) {
+        driverScope = scope
         driverJob = scope.launch(Dispatchers.Default) { run() }
 
         if (clientMode) {
-            scope.launch(Dispatchers.Default) { udpReaderLoop() }
+            startReaderLoop(primary)
         }
+    }
+
+    private fun startReaderLoop(entry: PathEntry) {
+        val scope = driverScope ?: return
+        entry.readerJob = scope.launch(Dispatchers.Default) { udpReaderLoop(entry) }
     }
 
     /**
@@ -133,7 +209,11 @@ class QuicheDriver(
                     }
                 // null from onReceiveCatching means channel closed — exit
                 if (cmd == null && commands.isClosedForReceive) break
-                if (cmd != null) execute(cmd) else api.connOnTimeout(conn)
+                when {
+                    cmd is QuicheCmd.Migrate -> handleMigrate(cmd) // suspends: opens a socket
+                    cmd != null -> execute(cmd)
+                    else -> api.connOnTimeout(conn)
+                }
                 afterCommand()
             }
         } finally {
@@ -148,7 +228,10 @@ class QuicheDriver(
                     cmd.buf.nativeMemoryAccess!!
                         .nativeAddress
                         .toLong()
-                api.connRecv(conn, addr, cmd.len, recvInfo)
+                // Hand quiche the recv_info of the path the packet arrived on (local addr = that
+                // socket's). Null key / unknown path falls back to primary — single-path is unchanged.
+                val info = cmd.pathKey?.let { paths[it]?.recvInfo } ?: recvInfo
+                api.connRecv(conn, addr, cmd.len, info)
                 cmd.buf.freeNativeMemory()
             }
 
@@ -174,11 +257,19 @@ class QuicheDriver(
                 api.connClose(conn, cmd.error)
                 cmd.result.complete(Unit)
             }
+
+            is QuicheCmd.Migrate -> handleMigrateSync(cmd) // routed via run() to handleMigrate; defensive only
         }
+    }
+
+    /** Unreachable in practice — [run] routes [QuicheCmd.Migrate] to the suspending [handleMigrate]. */
+    private fun handleMigrateSync(cmd: QuicheCmd.Migrate) {
+        cmd.result.complete(MigrationResult.Failed("migrate dispatched on non-suspending path"))
     }
 
     private suspend fun afterCommand() {
         flushOutgoing()
+        if (migrationEnabled) drainPathEvents()
         discoverNewStreams()
         updateState()
     }
@@ -220,8 +311,16 @@ class QuicheDriver(
         while (true) {
             val written = api.connSend(conn, sendAddr, MAX_DATAGRAM_SIZE, sendInfo)
             if (written <= 0) break
+            // Route by the local egress address quiche chose. With a single path this is
+            // dormant — send straight to primary, no decode — so the common case is unchanged.
+            val channel =
+                if (paths.size <= 1) {
+                    primary.channel
+                } else {
+                    paths[api.decodePathKey(api.sendInfoFromAddr(sendInfo))]?.channel ?: primary.channel
+                }
             try {
-                udpChannel.send(udpSendBuf, written)
+                channel.send(udpSendBuf, written)
             } catch (ce: kotlinx.coroutines.CancellationException) {
                 throw ce
             } catch (_: Exception) {
@@ -239,24 +338,25 @@ class QuicheDriver(
     }
 
     /**
-     * Client-mode: async UDP reader using [UdpChannel].
-     * Suspends until data arrives — zero CPU when no packets.
+     * Client-mode: async UDP reader for one [entry]'s socket. Suspends until data
+     * arrives — zero CPU when no packets. Tags each packet with [PathEntry.key] so
+     * the driver feeds quiche the right recv_info during migration.
      */
-    private suspend fun udpReaderLoop() {
+    private suspend fun udpReaderLoop(entry: PathEntry) {
         val pool = recvBufPool!!
         try {
             while (coroutineContext[Job]?.isActive != false) {
                 val buf = pool.allocate(MAX_DATAGRAM_SIZE)
                 val received =
                     try {
-                        udpChannel.receive(buf)
+                        entry.channel.receive(buf)
                     } catch (_: Exception) {
                         buf.freeNativeMemory()
                         if (commands.isClosedForSend) return
                         continue
                     }
                 if (received > 0) {
-                    commands.send(QuicheCmd.RecvPacket(buf, received))
+                    commands.send(QuicheCmd.RecvPacket(buf, received, entry.key))
                 } else {
                     buf.freeNativeMemory()
                 }
@@ -264,6 +364,132 @@ class QuicheDriver(
         } catch (_: ClosedSendChannelException) {
             // Driver closed
         }
+    }
+
+    /**
+     * Open a new local path, probe it, and arm [pendingMigration]; [drainPathEvents]
+     * completes the switch once the peer validates the path. Suspends to open the socket.
+     */
+    private suspend fun handleMigrate(cmd: QuicheCmd.Migrate) {
+        val factory = udpChannelFactory
+        if (!migrationEnabled || factory == null) {
+            cmd.result.complete(MigrationResult.Unsupported)
+            return
+        }
+        if (pendingMigration != null) {
+            cmd.result.complete(MigrationResult.Failed("a migration is already in progress"))
+            return
+        }
+        if (api.connAvailableDcids(conn) <= 0L) {
+            cmd.result.complete(MigrationResult.Failed("no spare destination connection id available"))
+            return
+        }
+
+        val newPath =
+            try {
+                factory.openPath(cmd.localHost, cmd.localPort)
+            } catch (ce: kotlinx.coroutines.CancellationException) {
+                throw ce
+            } catch (e: Exception) {
+                cmd.result.complete(MigrationResult.Failed("openPath failed: ${e.message}"))
+                return
+            }
+
+        val key = api.decodePathKey(newPath.localSockAddrAddress)
+        val pathRecvInfo = api.recvInfoNew(peerAddr, peerLen, newPath.localSockAddrAddress, newPath.localSockAddrLength)
+        val entry =
+            PathEntry(
+                key = key,
+                channel = newPath.channel,
+                recvInfo = pathRecvInfo,
+                localAddr = newPath.localSockAddrAddress,
+                localLen = newPath.localSockAddrLength,
+                isPrimary = false,
+                release = newPath.release,
+            )
+        paths[key] = entry
+
+        val rc = api.connProbePath(conn, entry.localAddr, entry.localLen, peerAddr, peerLen, addr(seqScratch))
+        if (rc < 0) {
+            teardownPath(entry)
+            cmd.result.complete(MigrationResult.Failed("probe_path failed: rc=$rc"))
+            return
+        }
+
+        pendingMigration = PendingMigration(key, cmd.localHost, cmd.localPort, cmd.result)
+        _pathState.value = PathInfo(MigrationPhase.Probing, cmd.localHost, cmd.localPort)
+        startReaderLoop(entry) // PATH_CHALLENGE egresses the new socket via flushOutgoing routing
+    }
+
+    /** Poll and react to quiche path events (validation, failure, path close). Migration-clients only. */
+    private fun drainPathEvents() {
+        while (true) {
+            val type = api.connPathEventNext(conn, addr(peLocalOut), addr(peLocalLenOut), addr(pePeerOut), addr(pePeerLenOut)) ?: break
+            when (type) {
+                QuichePathEventType.Validated -> {
+                    val key = api.decodePathKey(addr(peLocalOut))
+                    val pending = pendingMigration ?: continue
+                    if (pending.key != key) continue
+                    val entry = paths[key]
+                    if (entry == null) {
+                        completeMigration(pending, MigrationResult.Failed("validated path missing"), MigrationPhase.Failed)
+                        continue
+                    }
+                    _pathState.value = PathInfo(MigrationPhase.Validated, pending.localHost, pending.localPort)
+                    val rc = api.connMigrate(conn, entry.localAddr, entry.localLen, peerAddr, peerLen, addr(seqScratch))
+                    if (rc >= 0) {
+                        activeKey = key
+                        completeMigration(pending, MigrationResult.Succeeded(pending.localHost, pending.localPort), MigrationPhase.Migrated)
+                    } else {
+                        completeMigration(pending, MigrationResult.Failed("migrate failed: rc=$rc"), MigrationPhase.Failed)
+                    }
+                }
+
+                QuichePathEventType.FailedValidation -> {
+                    val key = api.decodePathKey(addr(peLocalOut))
+                    val pending = pendingMigration
+                    if (pending != null && pending.key == key) {
+                        paths[key]?.let { teardownPath(it) }
+                        completeMigration(pending, MigrationResult.Failed("path validation failed"), MigrationPhase.Failed)
+                    }
+                }
+
+                QuichePathEventType.Closed -> {
+                    val key = api.decodePathKey(addr(peLocalOut))
+                    paths[key]?.let { if (!it.isPrimary) teardownPath(it) }
+                }
+
+                QuichePathEventType.New,
+                QuichePathEventType.PeerMigrated,
+                QuichePathEventType.ReusedSourceConnectionId,
+                -> {
+                    // Server-side / informational events — no client action for active migration.
+                }
+            }
+        }
+    }
+
+    private fun completeMigration(
+        pending: PendingMigration,
+        result: MigrationResult,
+        phase: MigrationPhase,
+    ) {
+        _pathState.value = PathInfo(phase, pending.localHost, pending.localPort)
+        pending.result.complete(result)
+        pendingMigration = null
+    }
+
+    /** Cancel a non-primary path's reader, close its socket, and free its recv_info + sockaddr. */
+    private fun teardownPath(entry: PathEntry) {
+        if (entry.isPrimary) return
+        paths.remove(entry.key)
+        entry.readerJob?.cancel()
+        try {
+            entry.channel.close()
+        } catch (_: Exception) {
+        }
+        api.recvInfoFree(entry.recvInfo) // free recv_info before the sockaddr it references
+        entry.release()
     }
 
     private fun cleanup() {
@@ -274,14 +500,36 @@ class QuicheDriver(
             failCommand(cmd)
         }
 
+        // A migration still in flight when the connection dies never completes — fail it.
+        pendingMigration?.result?.complete(MigrationResult.Failed("connection closed"))
+        pendingMigration = null
+
         for (slot in streams.values) {
             slot.dataSignal.close()
         }
         streams.clear()
         api.connFree(conn)
+        // Tear down any non-primary migration paths: cancel reader, close socket, free
+        // recv_info before its sockaddr. Iterate a copy — teardown logic mutates `paths`.
+        for (entry in paths.values.toList()) {
+            if (entry.isPrimary) continue
+            entry.readerJob?.cancel()
+            try {
+                entry.channel.close()
+            } catch (_: Exception) {
+            }
+            api.recvInfoFree(entry.recvInfo)
+            entry.release()
+        }
+        paths.clear()
         api.recvInfoFree(recvInfo)
         api.sendInfoFree(sendInfo)
         udpSendBuf.freeNativeMemory()
+        seqScratch?.freeNativeMemory()
+        peLocalOut?.freeNativeMemory()
+        peLocalLenOut?.freeNativeMemory()
+        pePeerOut?.freeNativeMemory()
+        pePeerLenOut?.freeNativeMemory()
         // commands.tryReceive() drain above freed any pending RecvPackets
         // back to the pool. Late releases from an in-flight udpReaderLoop
         // iteration are benign — they repopulate the pool, which is GC'd
@@ -304,6 +552,7 @@ class QuicheDriver(
             is QuicheCmd.StreamRecv -> cmd.result.complete(StreamRecvResult.Error(-2))
             is QuicheCmd.StreamSend -> cmd.result.complete(-1)
             is QuicheCmd.Close -> cmd.result.complete(Unit)
+            is QuicheCmd.Migrate -> cmd.result.complete(MigrationResult.Failed("connection closed"))
         }
     }
 
@@ -314,6 +563,9 @@ class QuicheDriver(
 
     companion object {
         const val MAX_DATAGRAM_SIZE = 1350
+
+        /** Size of a `sockaddr_storage` — the out-buffers quiche fills for path events. */
+        const val SOCKADDR_STORAGE_SIZE = 128
     }
 }
 

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.coroutineContext
+import kotlin.random.Random
 import kotlin.time.Duration
 
 /**
@@ -151,15 +152,18 @@ class QuicheDriver(
 
     private var activeKey: PathKey = primary.key
     private var pendingMigration: PendingMigration? = null
+    private var spareCidsIssued = false
 
     private val _pathState = MutableStateFlow(PathInfo())
     val pathState: StateFlow<PathInfo> = _pathState
 
     private var driverScope: CoroutineScope? = null
 
-    // Native scratch for probe/migrate seq-out and for the four sockaddr_storage out-words
-    // connPathEventNext fills. Allocated only for migration-capable clients.
-    private val seqScratch: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(8) else null
+    // Native scratch for the uint64 seq-out of new_scid/probe/migrate. Allocated for every
+    // connection — even non-migrating ones issue spare CIDs so a future peer migration works.
+    private val seqScratch: PlatformBuffer = bufferFactory.allocate(8)
+
+    // sockaddr_storage out-words connPathEventNext fills — only migration-capable clients poll events.
     private val peLocalOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(SOCKADDR_STORAGE_SIZE) else null
     private val peLocalLenOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(4) else null
     private val pePeerOut: PlatformBuffer? = if (migrationEnabled) bufferFactory.allocate(SOCKADDR_STORAGE_SIZE) else null
@@ -300,6 +304,7 @@ class QuicheDriver(
     private fun updateState() {
         if (api.connIsEstablished(conn) && _state.value is QuicConnectionState.Handshaking) {
             _state.value = QuicConnectionState.Established("h3")
+            issueSpareCids()
         }
         if (api.connIsClosed(conn) && _state.value !is QuicConnectionState.Closed) {
             _state.value = QuicConnectionState.Closed(null)
@@ -492,6 +497,37 @@ class QuicheDriver(
         entry.release()
     }
 
+    /**
+     * Supply spare source connection IDs to the peer once established. quiche does not
+     * auto-issue CIDs, so without this the peer has no spare destination CID to migrate
+     * to ([connAvailableDcids] stays 0). Issued once per connection (both ends), bounded
+     * by [connScidsLeft] (which reflects the peer's active_connection_id_limit).
+     */
+    private fun issueSpareCids() {
+        if (spareCidsIssued) return
+        spareCidsIssued = true
+        var count = 0
+        while (count < MAX_SPARE_SCIDS && api.connScidsLeft(conn) > 0L) {
+            val scid = generateScid(bufferFactory) // 20 random bytes, reset for read
+            val token = bufferFactory.allocate(STATELESS_RESET_TOKEN_LEN)
+            repeat(STATELESS_RESET_TOKEN_LEN) { token.writeByte(Random.nextInt(256).toByte()) }
+            token.resetForRead()
+            val rc =
+                api.connNewScid(
+                    conn,
+                    scid.nativeMemoryAccess!!.nativeAddress.toLong(),
+                    QUIC_MAX_CONN_ID_LEN,
+                    token.nativeMemoryAccess!!.nativeAddress.toLong(),
+                    true,
+                    addr(seqScratch),
+                )
+            scid.freeNativeMemory()
+            token.freeNativeMemory()
+            if (rc < 0) break
+            count++
+        }
+    }
+
     private fun cleanup() {
         commands.close()
 
@@ -525,7 +561,7 @@ class QuicheDriver(
         api.recvInfoFree(recvInfo)
         api.sendInfoFree(sendInfo)
         udpSendBuf.freeNativeMemory()
-        seqScratch?.freeNativeMemory()
+        seqScratch.freeNativeMemory()
         peLocalOut?.freeNativeMemory()
         peLocalLenOut?.freeNativeMemory()
         pePeerOut?.freeNativeMemory()
@@ -566,6 +602,12 @@ class QuicheDriver(
 
         /** Size of a `sockaddr_storage` — the out-buffers quiche fills for path events. */
         const val SOCKADDR_STORAGE_SIZE = 128
+
+        /** QUIC stateless-reset token length (RFC 9000 §10.3) — fixed 16 bytes. */
+        const val STATELESS_RESET_TOKEN_LEN = 16
+
+        /** Cap on spare source CIDs issued per connection (bounded further by connScidsLeft). */
+        const val MAX_SPARE_SCIDS = 3
     }
 }
 

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -232,9 +232,11 @@ class QuicheDriver(
                     cmd.buf.nativeMemoryAccess!!
                         .nativeAddress
                         .toLong()
-                // Hand quiche the recv_info of the path the packet arrived on (local addr = that
-                // socket's). Null key / unknown path falls back to primary — single-path is unchanged.
-                val info = cmd.pathKey?.let { paths[it]?.recvInfo } ?: recvInfo
+                // Hand quiche the recv_info for this packet. Server: a per-datagram override whose
+                // `from` is the real source (passive migration). Client: the path the packet arrived
+                // on (local addr = that socket's). Null/unknown falls back to primary — single-path
+                // is unchanged.
+                val info = cmd.recvInfoOverride ?: cmd.pathKey?.let { paths[it]?.recvInfo } ?: recvInfo
                 api.connRecv(conn, addr, cmd.len, info)
                 cmd.buf.freeNativeMemory()
             }
@@ -324,8 +326,13 @@ class QuicheDriver(
                 } else {
                     paths[api.decodePathKey(api.sendInfoFromAddr(sendInfo))]?.channel ?: primary.channel
                 }
+            // Server egress follows the peer: send to the destination quiche chose (sendInfo.to) so
+            // a migrated client's new source receives replies. Clients leave this null and rely on
+            // their connected/path sockets. NioUdpChannel caches the reconstruction (steady state
+            // targets one address), so the non-migrating server path stays allocation-free.
+            val dest = if (isServer) api.decodePathKey(api.sendInfoToAddr(sendInfo)) else null
             try {
-                channel.send(udpSendBuf, written)
+                channel.send(udpSendBuf, written, dest)
             } catch (ce: kotlinx.coroutines.CancellationException) {
                 throw ce
             } catch (_: Exception) {

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/UdpChannel.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/UdpChannel.kt
@@ -12,10 +12,16 @@ interface UdpChannel {
     /** Receive one UDP datagram into [buffer]. Suspends until data arrives. Returns bytes received. */
     suspend fun receive(buffer: PlatformBuffer): Int
 
-    /** Send [len] bytes from [buffer] to the connected peer. */
+    /**
+     * Send [len] bytes from [buffer]. When [dest] is null, send to the channel's connected/fixed
+     * peer (the common case). When non-null — set by the server egress path from quiche's
+     * `sendInfo.to` — send to that address instead, so replies follow a migrated peer to its new
+     * source address. Channels that cannot target an arbitrary destination ignore [dest].
+     */
     suspend fun send(
         buffer: PlatformBuffer,
         len: Int,
+        dest: PathKey? = null,
     )
 
     /** Close the underlying socket. */

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/UdpChannelFactory.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/UdpChannelFactory.kt
@@ -1,0 +1,43 @@
+package com.ditchoom.socket.quic
+
+/**
+ * Opens additional client UDP sockets for connection migration (slice 3).
+ *
+ * The originating [withQuicConnection] knows the peer; a factory captures it so
+ * the [QuicheDriver] — which is platform-neutral — can open a second path socket
+ * (bound to a different local address, connected to the same peer) without
+ * knowing how sockets are created on each platform.
+ *
+ * Only the client migrates, so only client connection setups construct one;
+ * server-accepted drivers and the no-migration platforms (Apple, JS) leave it
+ * null and migration is unsupported there.
+ */
+interface UdpChannelFactory {
+    /**
+     * Open a UDP socket bound to [localHost]:[localPort] (null host = default
+     * interface, 0 port = ephemeral), connected to the same peer as the
+     * originating connection.
+     *
+     * The returned [NewPath.localSockAddrAddress]/[NewPath.localSockAddrLength]
+     * point at pinned native memory holding the socket's resolved local sockaddr
+     * (for quiche's probe/migrate calls and recv_info). The driver owns the
+     * returned channel and must [UdpChannel.close] it and call [NewPath.release]
+     * when the path is torn down.
+     */
+    suspend fun openPath(
+        localHost: String?,
+        localPort: Int,
+    ): NewPath
+}
+
+/**
+ * A freshly-opened migration path: the channel plus its pinned local sockaddr and
+ * a hook to free that sockaddr's backing memory. The driver decodes
+ * [localSockAddrAddress] into a [PathKey] to route datagrams to this socket.
+ */
+class NewPath(
+    val channel: UdpChannel,
+    val localSockAddrAddress: Long,
+    val localSockAddrLength: Int,
+    val release: () -> Unit,
+)

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -302,6 +302,15 @@ internal class StubQuicheApi : QuicheApi {
         seqOut: Long,
     ) = 0
 
+    override fun connNewScid(
+        conn: QuicheConn,
+        scidAddr: Long,
+        scidLen: Int,
+        resetTokenAddr: Long,
+        retireIfNeeded: Boolean,
+        seqOut: Long,
+    ) = 0
+
     override fun connMigrate(
         conn: QuicheConn,
         localAddr: Long,

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -273,6 +273,10 @@ internal class StubQuicheApi : QuicheApi {
 
     override fun sendInfoToAddrLen(info: QuicheSendInfo) = 0
 
+    override fun sendInfoFromAddr(info: QuicheSendInfo) = 0L
+
+    override fun sendInfoFromAddrLen(info: QuicheSendInfo) = 0
+
     // --- Path migration (no-ops) ---
     override fun connProbePath(
         conn: QuicheConn,

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -277,6 +277,16 @@ internal class StubQuicheApi : QuicheApi {
 
     override fun sendInfoFromAddrLen(info: QuicheSendInfo) = 0
 
+    override fun sockAddrFamily(addr: Long) = 0
+
+    override fun sockAddrPort(addr: Long) = 0
+
+    override fun sockAddrV4(addr: Long) = 0L
+
+    override fun sockAddrV6Hi(addr: Long) = 0L
+
+    override fun sockAddrV6Lo(addr: Long) = 0L
+
     // --- Path migration (no-ops) ---
     override fun connProbePath(
         conn: QuicheConn,

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -82,6 +82,11 @@ internal class StubQuicheApi : QuicheApi {
         v: Boolean,
     ) {}
 
+    override fun configSetActiveConnectionIdLimit(
+        config: QuicheConfig,
+        v: Long,
+    ) {}
+
     override fun configVerifyPeer(
         config: QuicheConfig,
         v: Boolean,

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubUdpChannel.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubUdpChannel.kt
@@ -26,6 +26,7 @@ class StubUdpChannel(
     override suspend fun send(
         buffer: PlatformBuffer,
         len: Int,
+        dest: PathKey?,
     ) {
         sendCount++
         sendBehavior(buffer, len)

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -62,6 +62,11 @@ JNIEXPORT void JNICALL JNI_FN(nConfigSetInitialMaxData)(
     quiche_config_set_initial_max_data((quiche_config *)(uintptr_t)config, (uint64_t)v);
 }
 
+JNIEXPORT void JNICALL JNI_FN(nConfigSetActiveConnectionIdLimit)(
+    JNIEnv *env, jclass cls, jlong config, jlong v) {
+    quiche_config_set_active_connection_id_limit((quiche_config *)(uintptr_t)config, (uint64_t)v);
+}
+
 JNIEXPORT void JNICALL JNI_FN(nConfigSetInitialMaxStreamDataBidiLocal)(
     JNIEnv *env, jclass cls, jlong config, jlong v) {
     quiche_config_set_initial_max_stream_data_bidi_local((quiche_config *)(uintptr_t)config, (uint64_t)v);

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -255,6 +255,18 @@ JNIEXPORT jint JNICALL JNI_FN(nConnProbePath)(
         (uint64_t *)(uintptr_t)seq_out);
 }
 
+JNIEXPORT jint JNICALL JNI_FN(nConnNewScid)(
+    JNIEnv *env, jclass cls,
+    jlong conn, jlong scid_addr, jint scid_len,
+    jlong reset_token_addr, jboolean retire_if_needed, jlong seq_out) {
+    return (jint)quiche_conn_new_scid(
+        (quiche_conn *)(uintptr_t)conn,
+        (const uint8_t *)(uintptr_t)scid_addr, (size_t)scid_len,
+        (const uint8_t *)(uintptr_t)reset_token_addr,
+        (bool)retire_if_needed,
+        (uint64_t *)(uintptr_t)seq_out);
+}
+
 JNIEXPORT jint JNICALL JNI_FN(nConnMigrate)(
     JNIEnv *env, jclass cls,
     jlong conn, jlong local_addr, jint local_len,

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -485,21 +485,27 @@ JNIEXPORT jint JNICALL JNI_FN(nSockAddrPort)(JNIEnv *env, jclass cls, jlong addr
     return 0;
 }
 
+// Canonical decode: address bytes are returned in network order interpreted
+// big-endian, matching FfmQuicheApi (the reference). This gives PathKey one
+// meaning across backends so PathKey.toInetSocketAddress() reconstructs
+// unambiguously (V4 127.0.0.1 -> 0x7F000001; V6 halves big-endian).
 JNIEXPORT jlong JNICALL JNI_FN(nSockAddrV4)(JNIEnv *env, jclass cls, jlong addr) {
     struct sockaddr_in *sa = (struct sockaddr_in *)(uintptr_t)addr;
-    return (jlong)(uint32_t)sa->sin_addr.s_addr;
+    return (jlong)(uint32_t)ntohl(sa->sin_addr.s_addr);
 }
 
 JNIEXPORT jlong JNICALL JNI_FN(nSockAddrV6Hi)(JNIEnv *env, jclass cls, jlong addr) {
     struct sockaddr_in6 *sa = (struct sockaddr_in6 *)(uintptr_t)addr;
-    uint64_t hi;
-    memcpy(&hi, &sa->sin6_addr.s6_addr[0], 8);
+    const uint8_t *b = (const uint8_t *)&sa->sin6_addr.s6_addr[0];
+    uint64_t hi = 0;
+    for (int i = 0; i < 8; i++) hi = (hi << 8) | b[i];
     return (jlong)hi;
 }
 
 JNIEXPORT jlong JNICALL JNI_FN(nSockAddrV6Lo)(JNIEnv *env, jclass cls, jlong addr) {
     struct sockaddr_in6 *sa = (struct sockaddr_in6 *)(uintptr_t)addr;
-    uint64_t lo;
-    memcpy(&lo, &sa->sin6_addr.s6_addr[8], 8);
+    const uint8_t *b = (const uint8_t *)&sa->sin6_addr.s6_addr[8];
+    uint64_t lo = 0;
+    for (int i = 0; i < 8; i++) lo = (lo << 8) | b[i];
     return (jlong)lo;
 }

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -433,3 +433,13 @@ JNIEXPORT jint JNICALL JNI_FN(nSendInfoToAddrLen)(JNIEnv *env, jclass cls, jlong
     quiche_send_info *info = (quiche_send_info *)(uintptr_t)ptr;
     return (jint)info->to_len;
 }
+
+JNIEXPORT jlong JNICALL JNI_FN(nSendInfoFromAddr)(JNIEnv *env, jclass cls, jlong ptr) {
+    quiche_send_info *info = (quiche_send_info *)(uintptr_t)ptr;
+    return (jlong)(uintptr_t)&info->from;
+}
+
+JNIEXPORT jint JNICALL JNI_FN(nSendInfoFromAddrLen)(JNIEnv *env, jclass cls, jlong ptr) {
+    quiche_send_info *info = (quiche_send_info *)(uintptr_t)ptr;
+    return (jint)info->from_len;
+}

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -15,6 +15,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 /* Package: com.ditchoom.socket.quic */
 /* Class: JniQuicheApi */
@@ -442,4 +445,44 @@ JNIEXPORT jlong JNICALL JNI_FN(nSendInfoFromAddr)(JNIEnv *env, jclass cls, jlong
 JNIEXPORT jint JNICALL JNI_FN(nSendInfoFromAddrLen)(JNIEnv *env, jclass cls, jlong ptr) {
     quiche_send_info *info = (quiche_send_info *)(uintptr_t)ptr;
     return (jint)info->from_len;
+}
+
+/* --- sockaddr decode (slice 3 migration) ---
+ * Native code knows the platform's sockaddr layout (sa_family value, field
+ * offsets), so the JVM side never branches on OS for the JNI backend. The
+ * returned address bits are an opaque identity (network byte order, as stored)
+ * — only ever compared, never reconstructed. */
+
+JNIEXPORT jint JNICALL JNI_FN(nSockAddrFamily)(JNIEnv *env, jclass cls, jlong addr) {
+    struct sockaddr *sa = (struct sockaddr *)(uintptr_t)addr;
+    if (!sa) return 0;
+    if (sa->sa_family == AF_INET) return 4;
+    if (sa->sa_family == AF_INET6) return 6;
+    return 0;
+}
+
+JNIEXPORT jint JNICALL JNI_FN(nSockAddrPort)(JNIEnv *env, jclass cls, jlong addr) {
+    struct sockaddr *sa = (struct sockaddr *)(uintptr_t)addr;
+    if (sa->sa_family == AF_INET) return (jint)ntohs(((struct sockaddr_in *)sa)->sin_port);
+    if (sa->sa_family == AF_INET6) return (jint)ntohs(((struct sockaddr_in6 *)sa)->sin6_port);
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nSockAddrV4)(JNIEnv *env, jclass cls, jlong addr) {
+    struct sockaddr_in *sa = (struct sockaddr_in *)(uintptr_t)addr;
+    return (jlong)(uint32_t)sa->sin_addr.s_addr;
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nSockAddrV6Hi)(JNIEnv *env, jclass cls, jlong addr) {
+    struct sockaddr_in6 *sa = (struct sockaddr_in6 *)(uintptr_t)addr;
+    uint64_t hi;
+    memcpy(&hi, &sa->sin6_addr.s6_addr[0], 8);
+    return (jlong)hi;
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nSockAddrV6Lo)(JNIEnv *env, jclass cls, jlong addr) {
+    struct sockaddr_in6 *sa = (struct sockaddr_in6 *)(uintptr_t)addr;
+    uint64_t lo;
+    memcpy(&lo, &sa->sin6_addr.s6_addr[8], 8);
+    return (jlong)lo;
 }

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -54,6 +54,9 @@ class FfmQuicheApi private constructor(
     private val hSetMaxData by lazy {
         downcall("quiche_config_set_initial_max_data", FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG))
     }
+    private val hSetActiveConnectionIdLimit by lazy {
+        downcall("quiche_config_set_active_connection_id_limit", FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG))
+    }
     private val hSetBidiLocal by lazy {
         downcall("quiche_config_set_initial_max_stream_data_bidi_local", FunctionDescriptor.ofVoid(ADDRESS, JAVA_LONG))
     }
@@ -281,6 +284,13 @@ class FfmQuicheApi private constructor(
         v: Boolean,
     ) {
         hDisableMigration.invokeExact(seg(config.handle), v)
+    }
+
+    override fun configSetActiveConnectionIdLimit(
+        config: QuicheConfig,
+        v: Long,
+    ) {
+        hSetActiveConnectionIdLimit.invokeExact(seg(config.handle), v)
     }
 
     override fun configVerifyPeer(

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -9,6 +9,7 @@ import java.lang.foreign.MemorySegment
 import java.lang.foreign.SymbolLookup
 import java.lang.foreign.ValueLayout.ADDRESS
 import java.lang.foreign.ValueLayout.JAVA_BOOLEAN
+import java.lang.foreign.ValueLayout.JAVA_BYTE
 import java.lang.foreign.ValueLayout.JAVA_INT
 import java.lang.foreign.ValueLayout.JAVA_LONG
 import java.lang.invoke.MethodHandle
@@ -757,7 +758,68 @@ class FfmQuicheApi private constructor(
         return segment.get(JAVA_INT, SEND_INFO_FROM_LEN_OFFSET.toLong())
     }
 
+    // --- sockaddr decode (slice 3 migration) ---
+    // FFM reads the struct directly. The JVM runs on Linux/macOS/Windows, so this
+    // must mirror SockAddrUtil's encode layout: BSD puts sin_len at byte 0 and
+    // sa_family at byte 1; Linux/Windows put sa_family as a uint16 at byte 0.
+    // AF_INET = 2 everywhere; AF_INET6 = 10 (Linux) / 30 (BSD) / 23 (Windows).
+    // sin_port is at offset 2, sin_addr at 4, sin6_addr at 8 in both layouts.
+
+    private fun ss(addr: Long): MemorySegment = MemorySegment.ofAddress(addr).reinterpret(SOCKADDR_STORAGE_SIZE)
+
+    private fun u8(
+        seg: MemorySegment,
+        off: Int,
+    ): Int = seg.get(JAVA_BYTE, off.toLong()).toInt() and 0xFF
+
+    private fun beLong(
+        seg: MemorySegment,
+        off: Int,
+    ): Long {
+        var v = 0L
+        for (i in off until off + 8) v = (v shl 8) or u8(seg, i).toLong()
+        return v
+    }
+
+    override fun sockAddrFamily(addr: Long): Int {
+        val seg = ss(addr)
+        val fam = if (IS_BSD) u8(seg, 1) else u8(seg, 0) or (u8(seg, 1) shl 8)
+        return when (fam) {
+            AF_INET -> 4
+            AF_INET6 -> 6
+            else -> 0
+        }
+    }
+
+    override fun sockAddrPort(addr: Long): Int {
+        val seg = ss(addr)
+        return (u8(seg, 2) shl 8) or u8(seg, 3)
+    }
+
+    override fun sockAddrV4(addr: Long): Long {
+        val seg = ss(addr)
+        var v = 0L
+        for (i in 4 until 8) v = (v shl 8) or u8(seg, i).toLong()
+        return v
+    }
+
+    override fun sockAddrV6Hi(addr: Long): Long = beLong(ss(addr), 8)
+
+    override fun sockAddrV6Lo(addr: Long): Long = beLong(ss(addr), 16)
+
     companion object {
+        private const val SOCKADDR_STORAGE_SIZE = 128L
+        private const val AF_INET = 2
+        private val IS_BSD: Boolean =
+            System.getProperty("os.name").lowercase().let { it.contains("mac") || it.contains("darwin") || it.contains("bsd") }
+        private val IS_WINDOWS: Boolean = System.getProperty("os.name").lowercase().contains("win")
+        private val AF_INET6: Int =
+            when {
+                IS_BSD -> 30
+                IS_WINDOWS -> 23
+                else -> 10
+            }
+
         private const val QUICHE_ERR_DONE = -1L
         private const val RECV_INFO_SIZE = 32
         private const val SEND_INFO_SIZE = 288

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -747,12 +747,23 @@ class FfmQuicheApi private constructor(
         return segment.get(JAVA_INT, SEND_INFO_TO_LEN_OFFSET.toLong())
     }
 
+    override fun sendInfoFromAddr(info: QuicheSendInfo): Long {
+        // from sockaddr_storage is the first field of quiche_send_info (offset 0).
+        return info.handle
+    }
+
+    override fun sendInfoFromAddrLen(info: QuicheSendInfo): Int {
+        val segment = MemorySegment.ofAddress(info.handle).reinterpret(SEND_INFO_SIZE.toLong())
+        return segment.get(JAVA_INT, SEND_INFO_FROM_LEN_OFFSET.toLong())
+    }
+
     companion object {
         private const val QUICHE_ERR_DONE = -1L
         private const val RECV_INFO_SIZE = 32
         private const val SEND_INFO_SIZE = 288
         private const val SEND_INFO_TO_OFFSET = 136 // after sockaddr_storage(128) + socklen_t(4) + pad(4)
         private const val SEND_INFO_TO_LEN_OFFSET = 264 // after to sockaddr_storage(128)
+        private const val SEND_INFO_FROM_LEN_OFFSET = 128 // after from sockaddr_storage(128)
 
         fun create(libraryPath: String): FfmQuicheApi {
             val arena = Arena.ofAuto()

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -160,6 +160,13 @@ class FfmQuicheApi private constructor(
             FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS),
         )
     }
+    private val hConnNewScid by lazy {
+        downcall(
+            "quiche_conn_new_scid",
+            // conn, scid*, scid_len(size_t), reset_token*, retire_if_needed(bool), scid_seq*
+            FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_LONG, ADDRESS, JAVA_BOOLEAN, ADDRESS),
+        )
+    }
     private val hConnMigrate by lazy {
         downcall(
             "quiche_conn_migrate",
@@ -485,6 +492,23 @@ class FfmQuicheApi private constructor(
             localLen,
             seg(peerAddr),
             peerLen,
+            seg(seqOut),
+        ) as Int
+
+    override fun connNewScid(
+        conn: QuicheConn,
+        scidAddr: Long,
+        scidLen: Int,
+        resetTokenAddr: Long,
+        retireIfNeeded: Boolean,
+        seqOut: Long,
+    ): Int =
+        hConnNewScid.invokeExact(
+            seg(conn.handle),
+            seg(scidAddr),
+            scidLen.toLong(),
+            seg(resetTokenAddr),
+            retireIfNeeded,
             seg(seqOut),
         ) as Int
 

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assume.assumeTrue
 import java.net.InetSocketAddress
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -28,7 +29,17 @@ import kotlin.time.Duration.Companion.seconds
  *
  * Runs in CI (needs the built quiche native lib + Linux loopback aliasing); skips
  * cleanly elsewhere.
+ *
+ * IGNORED pending follow-up #1 (server-side path routing). The client-side migration
+ * machinery is complete and exercised by [SockAddrDecodeTest], but path *validation* is a
+ * two-party handshake: when the PATH_CHALLENGE arrives at the in-repo echo server from the
+ * new source (127.0.0.2:ephemeral), the server must (a) feed quiche the real per-datagram
+ * source as recvInfo.from and (b) send the PATH_RESPONSE to sendInfo.to. Today JvmQuicServer
+ * uses one fixed recvInfo (original peer addr) and a peer-pinned NioUdpChannel, so quiche
+ * never sees a new path to validate → "path validation failed". Re-enable once server-side
+ * from/to routing lands. See PR #63 follow-ups.
  */
+@Ignore
 class QuicMigrationLoopbackTests {
     private val testQuicOptions =
         QuicOptions(

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
@@ -1,0 +1,143 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.flow.ReadResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assume.assumeTrue
+import java.net.InetSocketAddress
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end active connection migration over loopback (slice 3b harness).
+ *
+ * The client connects on 127.0.0.1, then [QuicScope.migrate]s to the loopback
+ * alias 127.0.0.2 (all of 127.0.0.0/8 is loopback on Linux — no NIC/netem/root).
+ * The driver opens a second socket bound to 127.0.0.2, probes it, and on
+ * validation switches the active path. We assert migration succeeds and that the
+ * stream still round-trips afterwards — proving streams survive the path switch.
+ *
+ * Runs in CI (needs the built quiche native lib + Linux loopback aliasing); skips
+ * cleanly elsewhere.
+ */
+class QuicMigrationLoopbackTests {
+    private val testQuicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    private fun certPath(name: String): String {
+        val url =
+            this::class.java.classLoader.getResource("certs/$name")
+                ?: error("Test cert not found: certs/$name")
+        return java.io.File(url.toURI()).absolutePath
+    }
+
+    private val tlsConfig
+        get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    /** Verify 127.0.0.2 is bindable (Linux: yes by default; macOS needs an alias) — skip if not. */
+    private fun assumeLoopbackAliasBindable() {
+        try {
+            java.nio.channels.DatagramChannel
+                .open()
+                .use { it.bind(InetSocketAddress("127.0.0.2", 0)) }
+        } catch (e: Exception) {
+            assumeTrue("Loopback alias 127.0.0.2 not bindable on this host: ${e.message}", false)
+        }
+    }
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.Default.allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 5.seconds)
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
+    }
+
+    @Test
+    fun streamSurvivesActiveMigrationToLoopbackAlias() =
+        runBlocking(Dispatchers.IO) {
+            assumeLoopbackAliasBindable()
+            skipOnMissingNativeLib {
+                withTimeout(20.seconds) {
+                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
+                        // Echo loop: mirror every message back until the stream ends.
+                        val serverJob =
+                            launch(Dispatchers.IO) {
+                                connections {
+                                    val stream = acceptStream()
+                                    while (true) {
+                                        val data = stream.read(8.seconds)
+                                        if (data is ReadResult.Data) {
+                                            stream.write(data.buffer, 5.seconds)
+                                        } else {
+                                            break
+                                        }
+                                    }
+                                    stream.close()
+                                }
+                            }
+                        delay(100)
+
+                        val migrationResult = CompletableDeferred<MigrationResult>()
+                        val beforeEcho = CompletableDeferred<String>()
+                        val afterEcho = CompletableDeferred<String>()
+
+                        val clientJob =
+                            launch(Dispatchers.IO) {
+                                // Connect on 127.0.0.1 so the peer is reachable from the 127.0.0.2 path too.
+                                withQuicConnection("127.0.0.1", port, testQuicOptions, timeout = 10.seconds) {
+                                    val stream = openStream()
+                                    beforeEcho.complete(stream.echoOnce("before"))
+
+                                    // Active migration to a different loopback source address.
+                                    val result = migrate(localHost = "127.0.0.2", localPort = 0)
+                                    migrationResult.complete(result)
+
+                                    afterEcho.complete(stream.echoOnce("after"))
+                                    stream.close()
+                                }
+                            }
+
+                        try {
+                            assertEquals("before", withTimeout(12.seconds) { beforeEcho.await() })
+                            val result = withTimeout(12.seconds) { migrationResult.await() }
+                            assertTrue(
+                                result is MigrationResult.Succeeded,
+                                "expected migration to succeed, got $result",
+                            )
+                            assertEquals(
+                                "after",
+                                withTimeout(12.seconds) { afterEcho.await() },
+                                "stream did not round-trip after migration",
+                            )
+                        } finally {
+                            clientJob.cancel()
+                            serverJob.cancel()
+                        }
+                    }
+                }
+            }
+        }
+}

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assume.assumeTrue
 import java.net.InetSocketAddress
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -30,16 +29,11 @@ import kotlin.time.Duration.Companion.seconds
  * Runs in CI (needs the built quiche native lib + Linux loopback aliasing); skips
  * cleanly elsewhere.
  *
- * IGNORED pending follow-up #1 (server-side path routing). The client-side migration
- * machinery is complete and exercised by [SockAddrDecodeTest], but path *validation* is a
- * two-party handshake: when the PATH_CHALLENGE arrives at the in-repo echo server from the
- * new source (127.0.0.2:ephemeral), the server must (a) feed quiche the real per-datagram
- * source as recvInfo.from and (b) send the PATH_RESPONSE to sendInfo.to. Today JvmQuicServer
- * uses one fixed recvInfo (original peer addr) and a peer-pinned NioUdpChannel, so quiche
- * never sees a new path to validate → "path validation failed". Re-enable once server-side
- * from/to routing lands. See PR #63 follow-ups.
+ * Exercises the full two-party path-validation handshake: the in-repo echo server feeds quiche
+ * the real per-datagram source as recvInfo.from (so a migrated client's new address is seen as a
+ * new path) and sends replies to sendInfo.to (so they follow the peer). See JvmQuicServer's
+ * per-source recv_info cache and NioUdpChannel's sendInfo.to routing.
  */
-@Ignore
 class QuicMigrationLoopbackTests {
     private val testQuicOptions =
         QuicOptions(

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/SockAddrDecodeTest.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/SockAddrDecodeTest.kt
@@ -1,0 +1,65 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import java.net.InetSocketAddress
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Round-trips [SockAddrUtil.toNativeSockAddr] (encode) against the slice-3
+ * sockaddr decode binding ([QuicheApi.decodePathKey]). The routing-critical
+ * property: distinct local addresses decode to distinct [PathKey]s and identical
+ * addresses to equal keys — that's what lets the multi-socket driver map
+ * `sendInfo.from` to the right path socket.
+ *
+ * Uses the real loaded [QuicheApi] (FFM on JDK 21 / JNI shim in CI); the decode
+ * functions are pure memory reads, no quiche connection required.
+ */
+class SockAddrDecodeTest {
+    private val api: QuicheApi = loadQuicheApi()
+
+    private fun key(
+        host: String,
+        port: Int,
+    ): PathKey {
+        val sa = InetSocketAddress(host, port).toNativeSockAddr(BufferFactory.Default)
+        try {
+            return api.decodePathKey(sa.address)
+        } finally {
+            sa.free()
+        }
+    }
+
+    @Test
+    fun decodesIpv4FamilyAndPort() {
+        val k = key("127.0.0.1", 4433)
+        assertEquals(4, k.family)
+        assertEquals(4433, k.port)
+    }
+
+    @Test
+    fun decodesIpv6FamilyAndPort() {
+        val k = key("::1", 8443)
+        assertEquals(6, k.family)
+        assertEquals(8443, k.port)
+    }
+
+    @Test
+    fun distinctLocalAddressesDecodeToDistinctKeys() {
+        // The two loopback aliases the slice-3 active-migration harness uses.
+        assertNotEquals(key("127.0.0.1", 4433), key("127.0.0.2", 4433))
+    }
+
+    @Test
+    fun samePortDifferentValueDiffers() {
+        assertNotEquals(key("127.0.0.1", 4433), key("127.0.0.1", 4434))
+    }
+
+    @Test
+    fun identicalAddressesDecodeToEqualKeys() {
+        assertEquals(key("127.0.0.1", 4433), key("127.0.0.1", 4433))
+        assertEquals(key("::1", 8443), key("::1", 8443))
+    }
+}

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -39,6 +39,7 @@ import com.ditchoom.socket.quic.quiche.quiche_conn_is_established
 import com.ditchoom.socket.quic.quiche.quiche_conn_is_timed_out
 import com.ditchoom.socket.quic.quiche.quiche_conn_migrate
 import com.ditchoom.socket.quic.quiche.quiche_conn_migrate_source
+import com.ditchoom.socket.quic.quiche.quiche_conn_new_scid
 import com.ditchoom.socket.quic.quiche.quiche_conn_on_timeout
 import com.ditchoom.socket.quic.quiche.quiche_conn_path_event_next
 import com.ditchoom.socket.quic.quiche.quiche_conn_probe_path
@@ -356,6 +357,23 @@ internal object CinteropQuicheApi : QuicheApi {
             localLen.convert(),
             peerAddr.toCPointer()!!,
             peerLen.convert(),
+            seqOut.toCPointer<ULongVar>()!!,
+        )
+
+    override fun connNewScid(
+        conn: QuicheConn,
+        scidAddr: Long,
+        scidLen: Int,
+        resetTokenAddr: Long,
+        retireIfNeeded: Boolean,
+        seqOut: Long,
+    ): Int =
+        quiche_conn_new_scid(
+            conn.handle.toCPointer()!!,
+            scidAddr.toCPointer()!!,
+            scidLen.convert(),
+            resetTokenAddr.toCPointer()!!,
+            retireIfNeeded,
             seqOut.toCPointer<ULongVar>()!!,
         )
 

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -13,6 +13,7 @@ import com.ditchoom.socket.quic.quiche.quiche_config_grease
 import com.ditchoom.socket.quic.quiche.quiche_config_load_cert_chain_from_pem_file
 import com.ditchoom.socket.quic.quiche.quiche_config_load_priv_key_from_pem_file
 import com.ditchoom.socket.quic.quiche.quiche_config_new
+import com.ditchoom.socket.quic.quiche.quiche_config_set_active_connection_id_limit
 import com.ditchoom.socket.quic.quiche.quiche_config_set_application_protos
 import com.ditchoom.socket.quic.quiche.quiche_config_set_cc_algorithm
 import com.ditchoom.socket.quic.quiche.quiche_config_set_disable_active_migration
@@ -154,6 +155,11 @@ internal object CinteropQuicheApi : QuicheApi {
         config: QuicheConfig,
         v: Boolean,
     ) = quiche_config_set_disable_active_migration(config.handle.toCPointer()!!, v)
+
+    override fun configSetActiveConnectionIdLimit(
+        config: QuicheConfig,
+        v: Long,
+    ) = quiche_config_set_active_connection_id_limit(config.handle.toCPointer()!!, v.convert())
 
     override fun configVerifyPeer(
         config: QuicheConfig,

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -71,6 +71,7 @@ import kotlinx.cinterop.UIntVar
 import kotlinx.cinterop.ULongVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
@@ -614,6 +615,47 @@ internal object CinteropQuicheApi : QuicheApi {
         val si = info.handle.toCPointer<quiche_send_info>()!!.pointed
         return si.from_len.toInt()
     }
+
+    // --- sockaddr decode (slice 3 migration) ---
+    // Linux layout is fixed (sa_family uint16 LE at byte 0, sin_port at 2,
+    // sin_addr at 4, sin6_addr at 8); read the bytes directly. Apple is out of
+    // scope for slice 3, so no BSD branch here.
+
+    private fun u8(
+        addr: Long,
+        off: Int,
+    ): Int =
+        addr
+            .toCPointer<UByteVar>()!![off]
+            .toInt() and 0xFF
+
+    private fun beLong(
+        addr: Long,
+        off: Int,
+    ): Long {
+        var v = 0L
+        for (i in off until off + 8) v = (v shl 8) or u8(addr, i).toLong()
+        return v
+    }
+
+    override fun sockAddrFamily(addr: Long): Int =
+        when (u8(addr, 0) or (u8(addr, 1) shl 8)) {
+            platform.posix.AF_INET -> 4
+            platform.posix.AF_INET6 -> 6
+            else -> 0
+        }
+
+    override fun sockAddrPort(addr: Long): Int = (u8(addr, 2) shl 8) or u8(addr, 3)
+
+    override fun sockAddrV4(addr: Long): Long {
+        var v = 0L
+        for (i in 4 until 8) v = (v shl 8) or u8(addr, i).toLong()
+        return v
+    }
+
+    override fun sockAddrV6Hi(addr: Long): Long = beLong(addr, 8)
+
+    override fun sockAddrV6Lo(addr: Long): Long = beLong(addr, 16)
 
     private const val QUICHE_ERR_DONE = -1
 }

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -604,5 +604,16 @@ internal object CinteropQuicheApi : QuicheApi {
         return si.to_len.toInt()
     }
 
+    override fun sendInfoFromAddr(info: QuicheSendInfo): Long {
+        val si = info.handle.toCPointer<quiche_send_info>()!!.pointed
+        return si.from.ptr.rawValue
+            .toLong()
+    }
+
+    override fun sendInfoFromAddrLen(info: QuicheSendInfo): Int {
+        val si = info.handle.toCPointer<quiche_send_info>()!!.pointed
+        return si.from_len.toInt()
+    }
+
     private const val QUICHE_ERR_DONE = -1
 }

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpChannel.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpChannel.kt
@@ -31,7 +31,10 @@ internal class IoUringUdpChannel(
     override suspend fun send(
         buffer: PlatformBuffer,
         len: Int,
+        dest: PathKey?,
     ) {
+        // Connected client socket — always sends to the connected peer; [dest] (server egress
+        // routing to sendInfo.to) does not apply. Linux server-side migration is a separate follow-up.
         val ptr = buffer.nativeMemoryAccess!!.nativeAddress.toCPointer<ByteVar>()!!
         IoUringManager.submitAndWait(1.seconds) { sqe, _ ->
             io_uring_prep_send(sqe, fd, ptr, len.convert(), 0)

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpServerChannel.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpServerChannel.kt
@@ -218,7 +218,10 @@ internal class ServerConnectionUdpChannel(
     override suspend fun send(
         buffer: PlatformBuffer,
         len: Int,
-    ) = serverChannel.sendTo(buffer, len, peerAddr.reinterpret(), peerAddrLen)
+        dest: PathKey?,
+    ) = // [dest]-based server egress routing (passive migration) is JVM-only for now; the Linux
+        // server sends to its fixed per-connection peerAddr. Linux server migration is a follow-up.
+        serverChannel.sendTo(buffer, len, peerAddr.reinterpret(), peerAddrLen)
 
     /** Frees the per-connection peer address copy. Does NOT close the shared server socket. */
     override fun close() {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
@@ -305,6 +305,10 @@ internal class LinuxQuicConfigCalls(
         com.ditchoom.socket.quic.quiche
             .quiche_config_set_disable_active_migration(cfg, v)
 
+    override fun setActiveConnectionIdLimit(v: Long) =
+        com.ditchoom.socket.quic.quiche
+            .quiche_config_set_active_connection_id_limit(cfg, v.convert())
+
     override fun verifyPeer(v: Boolean) =
         com.ditchoom.socket.quic.quiche
             .quiche_config_verify_peer(cfg, v)


### PR DESCRIPTION
## QUIC Phase 3 — connection migration (rung 2)

Client-driven **active connection migration**: move a live quiche connection to a freshly-opened local path via `probe → VALIDATED → migrate`, keeping streams flowing across the switch. This is rung 2 (single active path); MP-QUIC (rung 3) stays blocked at the engine (quiche 0.28/0.29 have no multipath).

Bindings (slices 1+2) merged earlier in #61/#62. This PR adds the decode bindings, the driver work, the public API, and an end-to-end loopback test.

### Test-infra decision (spike)
Reading quic-interop-runner's `testcases_quic.py` clarified that "migration" splits into **passive rebind** (NAT, server-side `PeerMigrated`) vs **active migration** (client probe→migrate — slice 3's core). Active migration needs only **two distinct local addresses, not NAT/netem** — all `127.0.0.0/8` is loopback on Linux — so the prerequisite harness binds path A=`127.0.0.1`/path B=`127.0.0.2` in a plain `jvmTest` (no root/Docker/namespaces). ns-3/QIR (needs an HTTP/0.9 shim + Docker endpoint) is deferred to a later interop-conformance milestone. Design doc: `socket-quic/MIGRATION_SLICE3.md`.

### What's in this PR
- **3a — bindings + decode:** `sendInfoFromAddr`/`Len` (egress routing) and `sockAddrFamily/Port/V4/V6Hi/V6Lo` across all four backends + stub, plus a common `PathKey`/`decodePathKey`. The decode lives in the C shim for JNI (native knows the platform sockaddr layout — BSD `sin_len`, `AF_INET6` 10/30/23); FFM/cinterop read the struct directly. Round-trip test: `SockAddrDecodeTest`.
- **3c+3d+3e — multi-socket driver + migration:** the driver models the connection as a **paths map**. Routing is **dormant at one path** (sends straight to primary, no decode), so single-path behaviour is byte-for-byte unchanged. Egress routes by `sendInfo.from`; ingress by `RecvPacket.pathKey` → per-path `recv_info`. `QuicheCmd.Migrate` opens+probes a path via an injected `UdpChannelFactory`; `drainPathEvents` consumes quiche path events and on `Validated` calls `connMigrate`, tearing down on `FailedValidation`/`Closed` (gated on `connAvailableDcids > 0`). Public `QuicScope.migrate(localHost, localPort)` + `pathState`, with `Unsupported` defaults so Apple/JS/server/fakes are unaffected.
- **3b — loopback harness:** `QuicMigrationLoopbackTests` migrates `127.0.0.1`→`127.0.0.2` and asserts `migrate()` succeeds and the stream still round-trips. Skips cleanly without the native lib / a bindable loopback alias.

### Known caveat (drives the follow-ups)
The **server still sends to a fixed per-connection `peerAddr`**. The loopback test works because the driver keeps the primary socket open after migration, so server replies to the original address still reach the client there while egress moves to the new socket — asymmetric but functional, and a real test of the *client* machinery. True server-side migration needs the server to route sends by `sendInfo.to`.

### Validation
Local matrix green: `compileKotlinJvm` + `compileTestKotlinJvm` + `compileJava21KotlinJvm` + `compileKotlinLinuxX64` + `compileTestKotlinLinuxX64` + `ktlintCheck`. The JNI C shim and the migration tests run only in CI.

### Follow-ups (to land on this same branch/PR)
- [ ] Server-side `sendInfo.to` routing — true server-side migration (needs `fromNativeSockAddr → InetSocketAddress`; unify JNI vs FFM/cinterop V4/V6 byte order before reconstructing bytes).
- [ ] Linux-native `UdpChannelFactory` (migrate is `Unsupported` on K/N today).
- [ ] 3f — netns + veth + `tc netem` passive-rebind CI job (server `PeerMigrated` + lossy links).
