### PR TITLE
ci(quic): exercise FFM + JDK-17 JNI backends — and fix FFM, which never actually ran on Linux

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -23,11 +23,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      # Install both 17 and 21. The build/toolchain runs on 21 (the last entry
+      # becomes the default JAVA_HOME) — required to compile the FFM bindings —
+      # while JDK 17 (exposed as JAVA_HOME_17_X64) lets the "JDK 17 / JNI" test
+      # step below run :socket-quic:jvmTest on a JDK < 21 launcher.
+      - name: Set up JDKs (17 + 21)
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: |
+            17
+            21
           cache: gradle
 
       - name: Setup Chrome
@@ -339,10 +345,45 @@ jobs:
       # --continue, every failing test gets to execute and report so we see the
       # full failure surface in one CI cycle. Combined with the test-reports
       # artifact upload below, this gives complete signal per run.
+      # The default jvmTest run exercises the JNI backend on JDK 21 (loadQuicheApi()
+      # resolves to the base commonJvmMain loader — the java21/FFM output is not on
+      # the Test classpath). QUIC_MIGRATION_REQUIRE_RUN=1 turns a clean skip of
+      # QuicMigrationLoopbackTests into a hard failure here, where the native is
+      # built fresh and 127.0.0.2 is bindable, so a broken native can't pass as green.
       - name: Run socket-quic JVM tests
         timeout-minutes: 8
+        env:
+          QUIC_MIGRATION_REQUIRE_RUN: "1"
         run: >-
           ./gradlew :socket-quic:jvmTest --continue
+          --no-configuration-cache ${{ inputs.gradle-args }}
+
+      # Same suite on the FFM backend. -PquicheJvmBackend=ffm prepends the java21
+      # (FFM) output so its loader shadows the base JNI one, then loads the
+      # self-contained shim via Panama. This is the only CI run that exercises
+      # FfmQuicheApi — including the FFM migration path (the in-repo FFM server +
+      # client), which had a SIGSEGV that the old silent JNI fallback hid.
+      - name: Run socket-quic JVM tests (FFM backend)
+        timeout-minutes: 8
+        env:
+          QUIC_MIGRATION_REQUIRE_RUN: "1"
+        run: >-
+          ./gradlew :socket-quic:jvmTest -PquicheJvmBackend=ffm --continue
+          --no-configuration-cache ${{ inputs.gradle-args }}
+
+      # JNI backend on a JDK 17 launcher (the runtime Android / legacy-JVM
+      # consumers actually use). The build/toolchain stays on 21; only this Test
+      # task runs on 17, found via the JAVA_HOME_17_X64 install from setup-java.
+      # The java21/FFM classes aren't on the JNI classpath, so there is no
+      # UnsupportedClassVersionError. Proves connNewScid + sockaddr decode +
+      # server routing on the JNI shim at runtime on JDK < 21.
+      - name: Run socket-quic JVM tests (JDK 17 / JNI)
+        timeout-minutes: 8
+        env:
+          QUIC_MIGRATION_REQUIRE_RUN: "1"
+        run: >-
+          ./gradlew :socket-quic:jvmTest -PjvmTestLauncher=17 --continue
+          -Porg.gradle.java.installations.fromEnv=JAVA_HOME_17_X64
           --no-configuration-cache ${{ inputs.gradle-args }}
 
       # Audit step: mirror the macOS + Linux ARM64 audits — count

--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -583,12 +583,20 @@ afterEvaluate {
         // 21. The java21/FFM classes aren't on the JNI classpath, so there is no
         // UnsupportedClassVersionError. Do not combine with `quicheJvmBackend=ffm`.
         providers.gradleProperty("jvmTestLauncher").orNull?.let { version ->
+            val launcherVersion = version.toInt()
             val toolchains = project.extensions.getByType<JavaToolchainService>()
             javaLauncher.set(
                 toolchains.launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(version.toInt()))
+                    languageVersion.set(JavaLanguageVersion.of(launcherVersion))
                 },
             )
+            if (launcherVersion < 21) {
+                // `--enable-native-access` (added globally above for FFM/Panama) is
+                // pointless for the JNI backend and some older JVMs reject the
+                // unknown flag outright, which would kill the test worker at startup.
+                // Strip it; --add-opens java.base/java.nio stays (valid + harmless).
+                jvmArgs = jvmArgs.orEmpty().filterNot { it.contains("enable-native-access") }
+            }
         }
     }
 }

--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -549,6 +549,47 @@ afterEvaluate {
         // Put staged natives on the test runtime classpath so NativeLibLoader
         // can extract them as classloader resources.
         classpath += files(stagedNativeResourcesDir)
+
+        // --- Backend selector ---------------------------------------------------
+        // By default this task resolves `loadQuicheApi()` to the base commonJvmMain
+        // JNI loader: the java21/FFM compilation output is deliberately NOT on the
+        // Test runtime classpath, so the base `QuicheApiLoaderKt` (→ JniQuicheApi)
+        // is the only one present. That means `:socket-quic:jvmTest` exercises the
+        // *JNI* backend on every JDK — including the JDK 21 CI job — NOT FFM.
+        //
+        // Passing `-PquicheJvmBackend=ffm` prepends the java21 (FFM) compilation
+        // output ahead of the base output, so its `QuicheApiLoaderKt` shadows the
+        // base one — the same multi-release-JAR class shadowing that production
+        // JDK 21+ consumers get, reproduced here via classpath order. FFM then
+        // loads the pure `libquiche.{so,dylib}` via Panama (falling back to JNI
+        // only if that lib is absent). Requires a JDK 21+ launcher (FFM bindings
+        // are JVM-21 bytecode). This is what gives CI an FFM-backed test run.
+        if (providers.gradleProperty("quicheJvmBackend").orNull == "ffm") {
+            dependsOn("compileJava21KotlinJvm")
+            val ffmOutput =
+                kotlin
+                    .jvm()
+                    .compilations["java21"]
+                    .output.allOutputs
+            classpath = files(ffmOutput) + classpath
+        }
+
+        // --- Launcher selector --------------------------------------------------
+        // The build/toolchain is JDK 21 (required to compile the FFM bindings),
+        // but the JNI backend (base loader + tests are JVM-8 bytecode) runs on
+        // older JVMs too. `-PjvmTestLauncher=17` points *this Test task* at a
+        // JDK 17 launcher so CI can exercise JNI on the runtime that Android /
+        // legacy-JVM consumers actually use, while the rest of the build stays on
+        // 21. The java21/FFM classes aren't on the JNI classpath, so there is no
+        // UnsupportedClassVersionError. Do not combine with `quicheJvmBackend=ffm`.
+        providers.gradleProperty("jvmTestLauncher").orNull?.let { version ->
+            val toolchains = project.extensions.getByType<JavaToolchainService>()
+            javaLauncher.set(
+                toolchains.launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(version.toInt()))
+                },
+            )
+        }
     }
 }
 

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -772,9 +772,14 @@ class FfmQuicheApi private constructor(
     }
 
     override fun sendInfoToAddr(info: QuicheSendInfo): Long {
-        // to field starts at offset 136 (after from sockaddr_storage 128 + from_len 4 + padding 4)
-        val segment = MemorySegment.ofAddress(info.handle).reinterpret(SEND_INFO_SIZE.toLong())
-        return segment.get(ADDRESS, SEND_INFO_TO_OFFSET.toLong()).address()
+        // In quiche_send_info, `to` is an INLINE struct sockaddr_storage (unlike
+        // quiche_recv_info, whose to/from are pointers). So its address is
+        // `&info->to` = handle + offset, NOT a pointer value stored at that offset.
+        // The old code read 8 bytes at the offset and treated them as a pointer,
+        // yielding a garbage address that SIGSEGV'd in sockAddrFamily on every
+        // flush (decodePathKey runs per-send). Mirror sendInfoFromAddr, which
+        // returns the inline `from` at offset 0. Matches JNI nSendInfoToAddr (&info->to).
+        return info.handle + SEND_INFO_TO_OFFSET
     }
 
     override fun sendInfoToAddrLen(info: QuicheSendInfo): Int {

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/QuicheApiLoader.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/QuicheApiLoader.kt
@@ -6,23 +6,47 @@ package com.ditchoom.socket.quic
  * JDK 21+ shadow of [loadQuicheApi] — returns [FfmQuicheApi] using Panama FFM downcalls.
  * Zero-copy: no JNI boundary, MemorySegment passed directly to quiche.
  *
- * The multi-release JAR ensures this replaces the JNI version on JDK 21+.
+ * The multi-release JAR ensures this replaces the JNI version on JDK 21+, so on
+ * JDK 21+ the backend is **deterministically FFM**. There is intentionally no
+ * silent fallback to JNI: a native lib that can't be loaded via FFM is a
+ * packaging bug, and degrading to JNI is exactly what masked FFM being broken on
+ * Linux (it loaded the pure `libquiche.so`, which dlopens with unresolved
+ * BoringSSL symbols, then silently dropped to JNI). We fail loudly instead.
+ *
+ * JNI is reached only where it's genuinely the only option — JDK < 21, served by
+ * the base `commonJvmMain` loader this shadows — or when a test deliberately
+ * selects it by keeping this FFM loader off the classpath (`-PquicheJvmBackend`).
  */
 fun loadQuicheApi(): QuicheApi {
-    // Only use FFM if the pure quiche shared lib is available.
-    // If only the JNI shim exists (libquiche_jni.so), fall back to JNI
-    // to avoid double-loading the native library.
-    val resourcePath = resolveQuicheResourcePath()
-    val stream = QuicheApi::class.java.classLoader?.getResourceAsStream(resourcePath)
-    if (stream != null) {
+    val classLoader =
+        QuicheApi::class.java.classLoader
+            ?: error("Cannot load quiche FFM backend: no class loader for QuicheApi")
+    // Try each candidate native lib via FFM, preferring the self-contained JNI
+    // shim (libquiche_jni.*). FFM only needs quiche's C API symbols, which the
+    // shim re-exports (it whole-archives libquiche.a + BoringSSL), so it loads
+    // cleanly via dlopen on every platform we ship. The "pure" libquiche.* is
+    // kept as a secondary candidate for platforms where it *is* self-contained
+    // (e.g. macOS boringssl-vendored); on Linux it is non-self-contained and is
+    // simply skipped when its load fails.
+    val failures = mutableListOf<String>()
+    for (resourcePath in quicheFfmResourceCandidates()) {
+        val stream = classLoader.getResourceAsStream(resourcePath)
+        if (stream == null) {
+            failures += "$resourcePath (not on classpath)"
+            continue
+        }
         stream.close()
-        return try {
-            FfmQuicheApi.create(extractToTemp(resourcePath))
-        } catch (_: Throwable) {
-            JniQuicheApi
+        try {
+            return FfmQuicheApi.create(extractToTemp(resourcePath))
+        } catch (t: Throwable) {
+            failures += "$resourcePath (${t.message})"
         }
     }
-    return JniQuicheApi
+    error(
+        "FFM is the required quiche backend on JDK 21+ but no native lib could be " +
+            "loaded. This is a packaging bug — fix the bundled natives rather than " +
+            "expecting a JNI fallback. Tried: ${failures.joinToString("; ")}",
+    )
 }
 
 private fun extractToTemp(resourcePath: String): String {
@@ -39,7 +63,11 @@ private fun extractToTemp(resourcePath: String): String {
     return tempFile.absolutePath
 }
 
-private fun resolveQuicheResourcePath(): String {
+/**
+ * Candidate classpath resources for the FFM native lib, in load-preference order:
+ * the self-contained JNI shim first (always loads), then the pure quiche lib.
+ */
+private fun quicheFfmResourceCandidates(): List<String> {
     val osName = System.getProperty("os.name").lowercase()
     val archName = System.getProperty("os.arch").lowercase()
     val os =
@@ -55,12 +83,12 @@ private fun resolveQuicheResourcePath(): String {
             archName == "aarch64" || archName == "arm64" -> "arm64"
             else -> error("Unsupported architecture: $archName")
         }
-    val ext =
-        when (os) {
-            "linux" -> "so"
-            "macos" -> "dylib"
-            "windows" -> "dll"
-            else -> "so"
-        }
-    return "META-INF/native/$os-$arch/libquiche.$ext"
+    val dir = "META-INF/native/$os-$arch"
+    return if (os == "windows") {
+        // Windows ships only the self-contained quiche_jni.dll (no separate quiche.dll).
+        listOf("$dir/quiche_jni.dll")
+    } else {
+        val ext = if (os == "macos") "dylib" else "so"
+        listOf("$dir/libquiche_jni.$ext", "$dir/libquiche.$ext")
+    }
 }

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
@@ -52,11 +52,26 @@ class QuicMigrationLoopbackTests {
     private val tlsConfig
         get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
 
+    // When QUIC_MIGRATION_REQUIRE_RUN is set (CI on platforms that *must* be able
+    // to run this — e.g. Linux, where the native is built fresh and 127.0.0.2 is
+    // bindable), an otherwise-clean skip becomes a hard failure. Otherwise a silent
+    // skip on a broken native or unbindable alias reads as a green pass, which is
+    // exactly how the FFM migration crash went unnoticed. Elsewhere (macOS without
+    // a loopback alias, etc.) the skip stays a skip.
+    private val requireRun: Boolean =
+        System.getenv("QUIC_MIGRATION_REQUIRE_RUN")?.lowercase() in setOf("1", "true", "yes")
+
+    private fun skipOrFail(reason: String): Nothing {
+        if (requireRun) kotlin.test.fail("QUIC_MIGRATION_REQUIRE_RUN set but test could not run: $reason")
+        assumeTrue(reason, false)
+        error("unreachable") // assumeTrue(false) aborts via AssumptionViolatedException
+    }
+
     private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
         try {
             block()
         } catch (e: UnsatisfiedLinkError) {
-            assumeTrue("Native lib not available: ${e.message}", false)
+            skipOrFail("Native lib not available: ${e.message}")
         }
     }
 
@@ -67,7 +82,7 @@ class QuicMigrationLoopbackTests {
                 .open()
                 .use { it.bind(InetSocketAddress("127.0.0.2", 0)) }
         } catch (e: Exception) {
-            assumeTrue("Loopback alias 127.0.0.2 not bindable on this host: ${e.message}", false)
+            skipOrFail("Loopback alias 127.0.0.2 not bindable on this host: ${e.message}")
         }
     }
 


### PR DESCRIPTION
## TL;DR

Started as MIGRATION_FOLLOWUPS Gap 1 ("add a JDK-17 matrix entry so the JNI
migration paths are runtime-tested"). Investigating the premise revealed it was
**inverted**, and uncovered that **FFM connection migration crashed the JVM and
had never actually run on Linux** — silently masked by a JNI fallback. This PR
fixes FFM, makes the backend deterministic, and adds the missing CI coverage.

## What I found (all reproduced locally, not inferred)

1. **`:socket-quic:jvmTest` runs JNI on every JDK**, including the JDK 21 CI job —
   the java21/FFM output isn't on the Test runtime classpath, so `loadQuicheApi()`
   resolves to the base JNI loader. The doc's "JDK21 = FFM, JNI never executes" was
   backwards.
2. **FFM never loaded on Linux.** The FFM loader targeted the pure `libquiche.so`,
   which is built against an external BoringSSL and `dlopen`s with unresolved
   `SSL_*`/`CRYPTO_*` symbols (and often isn't even shipped). `create()` always
   threw → loader silently returned `JniQuicheApi`. So the quic-echo server and
   every JDK 21+ consumer were on JNI.
3. **FFM migration SIGSEGV'd.** Once forced to load, `FfmQuicheApi.sendInfoToAddr`
   read the inline `quiche_send_info.to` sockaddr_storage as a *pointer*, so
   `sockAddrFamily` dereferenced garbage — a crash on *every* flush
   (`decodePathKey` runs per-send). The silent fallback hid it the whole time.

## Changes

- **fix: `sendInfoToAddr`** returns `handle + offset` (the inline `&info->to`),
  mirroring `sendInfoFromAddr` and matching the JNI shim. Fixes the SIGSEGV.
- **fix: deterministic FFM loader** — loads the self-contained `libquiche_jni.*`
  (re-exports the full quiche C API, `dlopen`s cleanly everywhere) and **throws
  instead of falling back to JNI**. On JDK 21+ the backend is FFM, period; a
  native that won't load is now a loud packaging error, not a silent degrade.
- **test: backend/launcher knobs** — `-PquicheJvmBackend=ffm` (FFM via classpath
  shadowing) and `-PjvmTestLauncher=N` (run on a JDK N launcher).
- **test: skip-visibility** — `QUIC_MIGRATION_REQUIRE_RUN` turns a clean skip of
  the migration loopback test into a hard failure where it must run (Linux CI).
- **ci: two new jvmTest runs** in build-linux — FFM backend, and JNI on a JDK 17
  launcher — plus require-run on all three Linux runs.

## Validation (local, JDK 21)

- Full FFM suite: **165 tests, 0 failures, 0 skipped**, no crashes — including
  `streamSurvivesActiveMigrationToLoopbackAlias` end-to-end on real FFM.
- Skip gate verified both ways (FFM runs → pass; missing native + require-run → fail).
- Compile matrix green: `compileKotlinJvm`, `compileTestKotlinJvm`,
  `compileJava21KotlinJvm`, `compileKotlinLinuxX64`, `compileTestKotlinLinuxX64`,
  `ktlintCheck`. JDK-17 launcher run + JNI C shim are CI-only.

## Behavior change / risk

JDK 21+ Linux consumers (and the quic-echo Docker server) now use **FFM for real**
instead of silently falling back to JNI — the intended zero-copy fast path. This
is validated locally but is the main thing CI will prove on the existing harness
jobs. Given it's a bug fix **and** a backend behavior change, this may warrant a
`minor` label rather than the default patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)