### PR TITLE
fix(quic): bound the server per-source recv_info cache (Gap 6)

### DIFF
--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -29,6 +29,7 @@ import java.nio.channels.DatagramChannel
 import java.nio.channels.SelectionKey
 import java.nio.channels.Selector
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 
 private const val QUICHE_PROTOCOL_VERSION = 0x00000001
@@ -188,26 +189,66 @@ internal class JvmQuicServer(
      * Passive-migration support: one server socket sees a client's source address change
      * after the client migrates (RFC 9000 §9). quiche needs the *actual* per-datagram source
      * as recv_info.from to recognise the new path, so we cache one recv_info per distinct
-     * source (its `to` is the server's fixed local addr). Touched only on the receive-loop
-     * thread; freed in [close] after every driver is destroyed. Bounded by the number of
-     * distinct source addresses seen on this socket.
+     * source (its `to` is the server's fixed local addr, shared via [serverLocalSockAddr]).
+     *
+     * Bounded LRU ([maxPeerRecvInfos]) so a peer spraying spoofed source addresses on an
+     * established connection can't grow native memory without bound (the cache miss path
+     * allocates a recv_info + sockaddr per distinct source). Access-ordered so eviction
+     * targets idle sources. A cached recv_info pointer is handed to a driver via an UNLIMITED
+     * command channel, so a lagging driver may still hold it after the source goes idle;
+     * [CachedRecvInfo.inFlight] tracks outstanding references (released by the driver via
+     * [QuicheCmd.RecvPacket.onRecvInfoConsumed]) so eviction never frees one that's still in use.
+     *
+     * Touched only on the receive-loop thread (single writer); [inFlight] is the only field a
+     * driver thread mutates. Freed in [close] after every driver is destroyed.
      */
-    private val peerRecvInfos = mutableMapOf<InetSocketAddress, QuicheRecvInfo>()
-    private val recvInfoSockAddrs = mutableListOf<NativeSockAddr>()
+    private val maxPeerRecvInfos = 256
+
+    // accessOrder = true → iteration/eviction visits least-recently-used first.
+    private val peerRecvInfos =
+        LinkedHashMap<InetSocketAddress, CachedRecvInfo>(16, 0.75f, true)
     private var serverLocalSockAddr: NativeSockAddr? = null
 
-    private fun recvInfoFor(source: InetSocketAddress): QuicheRecvInfo {
-        peerRecvInfos[source]?.let { return it }
+    private class CachedRecvInfo(
+        val info: QuicheRecvInfo,
+        val from: NativeSockAddr,
+    ) {
+        /** Packets handed to a driver but not yet consumed; guards against evict-while-in-use. */
+        val inFlight = AtomicInteger(0)
+    }
+
+    private fun recvInfoFor(source: InetSocketAddress): CachedRecvInfo {
+        peerRecvInfos[source]?.let { return it } // get() promotes to most-recently-used
         val local =
             serverLocalSockAddr ?: localAddr.toNativeSockAddr(bufferFactory).also {
                 serverLocalSockAddr = it
-                recvInfoSockAddrs.add(it)
             }
         val from = source.toNativeSockAddr(bufferFactory)
-        recvInfoSockAddrs.add(from)
         val info = api.recvInfoNew(from.address, from.length, local.address, local.length)
-        peerRecvInfos[source] = info
-        return info
+        val cached = CachedRecvInfo(info, from)
+        peerRecvInfos[source] = cached
+        evictIdlePeerRecvInfo()
+        return cached
+    }
+
+    /**
+     * Free the least-recently-used cached recv_info whose [CachedRecvInfo.inFlight] is zero once
+     * over [maxPeerRecvInfos]. If every over-cap entry is still in flight (pathological), skip
+     * rather than risk a use-after-free — we briefly exceed the cap and the next miss retries.
+     * Receive-loop thread only.
+     */
+    private fun evictIdlePeerRecvInfo() {
+        if (peerRecvInfos.size <= maxPeerRecvInfos) return
+        val iterator = peerRecvInfos.entries.iterator() // access order: eldest first
+        while (iterator.hasNext()) {
+            val cached = iterator.next().value
+            if (cached.inFlight.get() == 0) {
+                api.recvInfoFree(cached.info)
+                cached.from.free()
+                iterator.remove()
+                return
+            }
+        }
     }
 
     @Volatile private var closed = false
@@ -255,12 +296,15 @@ internal class JvmQuicServer(
             driver.destroy()
         }
         connectionsByDcid.clear()
-        // Drivers destroyed (no connRecv can be in flight) — free the per-source recv_info
-        // cache. Free each recv_info before the sockaddrs it points at.
-        for (info in peerRecvInfos.values) api.recvInfoFree(info)
+        // Drivers destroyed (their drain released every in-flight ref) — free the per-source
+        // recv_info cache. Free each recv_info before the `from` sockaddr it points at, then the
+        // shared `to` sockaddr last (every recv_info pointed at it).
+        for (cached in peerRecvInfos.values) {
+            api.recvInfoFree(cached.info)
+            cached.from.free()
+        }
         peerRecvInfos.clear()
-        for (sa in recvInfoSockAddrs) sa.free()
-        recvInfoSockAddrs.clear()
+        serverLocalSockAddr?.free()
         serverLocalSockAddr = null
         // Drivers have drained — safe to free cached recv buffers. Any release
         // after this point would silently repopulate the pool (benign, but
@@ -387,12 +431,22 @@ internal class JvmQuicServer(
                     if (existingDriver != null) {
                         // Zero-copy: transfer buffer ownership to driver. The per-source recv_info
                         // lets quiche see the real datagram origin so a migrated client's new source
-                        // is recognised as a new path (passive migration).
+                        // is recognised as a new path (passive migration). Hold an in-flight ref so
+                        // the cache can't evict+free this recv_info while the driver still has it queued.
+                        val cached = recvInfoFor(peerInetAddr)
+                        cached.inFlight.incrementAndGet()
                         val sendResult =
                             existingDriver.commands.trySend(
-                                QuicheCmd.RecvPacket(recvBuf, received, recvInfoOverride = recvInfoFor(peerInetAddr)),
+                                QuicheCmd.RecvPacket(
+                                    recvBuf,
+                                    received,
+                                    recvInfoOverride = cached.info,
+                                    onRecvInfoConsumed = { cached.inFlight.decrementAndGet() },
+                                ),
                             )
                         if (sendResult.isFailure) {
+                            // Not delivered → onRecvInfoConsumed won't fire; release the ref here.
+                            cached.inFlight.decrementAndGet()
                             recvBuf.freeNativeMemory()
                             // Remove ALL entries for this dead driver, not just the one we hit
                             connectionsByDcid.entries.removeIf { it.value === existingDriver }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
@@ -19,12 +19,19 @@ sealed interface QuicheCmd {
      * source — required for passive (peer) migration, where one server socket sees a client's source address
      * change. The caller owns the recv_info's lifetime (the server caches them per source). When set it takes
      * precedence over [pathKey]; clients leave it null and use [pathKey] path routing instead.
+     *
+     * [onRecvInfoConsumed] is invoked exactly once after the driver is done with [recvInfoOverride] — both on
+     * the normal path (after `connRecv`) and when this command is dropped without processing (failCommand). The
+     * server uses it to track in-flight references so it can safely evict/free a cached recv_info only once no
+     * queued packet can still dereference it (the driver's command channel is UNLIMITED, so a lagging driver may
+     * hold a recv_info long after the source went idle). Null for the client/path-routed cases the server doesn't own.
      */
     class RecvPacket(
         val buf: PlatformBuffer,
         val len: Int,
         val pathKey: PathKey? = null,
         val recvInfoOverride: QuicheRecvInfo? = null,
+        val onRecvInfoConsumed: (() -> Unit)? = null,
     ) : QuicheCmd
 
     /** Allocate the next stream ID and create a [StreamSlot]. */

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -248,6 +248,9 @@ class QuicheDriver(
                 val info = cmd.recvInfoOverride ?: cmd.pathKey?.let { paths[it]?.recvInfo } ?: recvInfo
                 api.connRecv(conn, addr, cmd.len, info)
                 cmd.buf.freeNativeMemory()
+                // Signal the server it may now release the cached recv_info (quiche copied
+                // what it needs during connRecv; the pointer is no longer referenced).
+                cmd.onRecvInfoConsumed?.invoke()
             }
 
             is QuicheCmd.OpenStream -> {
@@ -598,7 +601,11 @@ class QuicheDriver(
 
     private fun failCommand(cmd: QuicheCmd) {
         when (cmd) {
-            is QuicheCmd.RecvPacket -> cmd.buf.freeNativeMemory()
+            is QuicheCmd.RecvPacket -> {
+                cmd.buf.freeNativeMemory()
+                // Dropped without connRecv — still release the server's in-flight ref.
+                cmd.onRecvInfoConsumed?.invoke()
+            }
             is QuicheCmd.OpenStream ->
                 cmd.result.completeExceptionally(
                     SocketClosedException.General("connection closed"),


### PR DESCRIPTION
## Gap 6 — server `recv_info` cache was unbounded

`JvmQuicServer` cached one `recv_info` (+ a `from` sockaddr) per distinct datagram
source, freed only at `close()`. A peer spraying spoofed source addresses on an
established connection (the source is read *before* quiche validates the path)
could grow native memory without bound — a mild DoS.

## Fix

Access-ordered **LRU capped at 256**, with **reference-counted** eviction.

The subtlety: the cached `recv_info` pointer is handed to a driver via a
`Channel.UNLIMITED` command channel, so a lagging driver can still hold it long
after the source goes idle. Naive free-on-evict would be a use-after-free. So:

- Each entry tracks `inFlight` (incremented before `trySend`; released via a new
  `RecvPacket.onRecvInfoConsumed` callback the driver fires after `connRecv` — or
  in `failCommand` when a queued packet is dropped — or inline if `trySend` fails).
- Eviction frees only the LRU entry whose `inFlight == 0`. If every over-cap entry
  is in flight (pathological), it skips rather than risk a UAF and retries next miss.
- The shared server-local `to` sockaddr is freed once at `close()`, after all
  `recv_info`s that point at it.

Single active path per connection ⇒ tiny working set, so 256 is ample headroom.

## Why reference-counting and not plain LRU

I verified the driver `commands` channel is `Channel.UNLIMITED` (not bounded), so a
slow-but-alive driver *can* hold a stale `recv_info` in its backlog — plain
free-on-evict is genuinely unsafe here. The drain path (`failCommand`) frees a
dropped packet's buffer **without** calling `connRecv`, and now also releases the
in-flight ref, so dead drivers never deref a freed pointer either.

## Validation (local, FFM backend — JNI shim stale locally)

- Full `:socket-quic:jvmTest -PquicheJvmBackend=ffm`: **164/164**, no crashes.
- Migration loopback (drives the server `recvInfoFor` path as the client migrates
  to a new source) + all `JvmQuicServer*` / `QuicLocalServerTests` green.
- Compile matrix (`compileKotlinJvm/TestKotlinJvm/Java21KotlinJvm/KotlinLinuxX64/TestKotlinLinuxX64`) + ktlint green.

The driver change (`onRecvInfoConsumed`) is null-safe for the client/path-routed
cases (callback is null there), confirmed by the full suite.

Closes Gap 6 in `socket-quic/MIGRATION_FOLLOWUPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)