### PR TITLE
feat(quic): connection migration on Kotlin/Native (Gap 4)

### DIFF
--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpChannelFactory.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpChannelFactory.kt
@@ -1,0 +1,107 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.nativeMemoryAccess
+import com.ditchoom.socket.linux.socket_getsockname
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.UIntVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.toCPointer
+import kotlinx.cinterop.value
+import platform.posix.AF_INET
+import platform.posix.AI_PASSIVE
+import platform.posix.SOCK_DGRAM
+import platform.posix.addrinfo
+import platform.posix.bind
+import platform.posix.close
+import platform.posix.connect
+import platform.posix.freeaddrinfo
+import platform.posix.getaddrinfo
+import platform.posix.memcpy
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.socket
+
+/**
+ * Linux/Native [UdpChannelFactory]: opens a new io_uring UDP socket bound to a chosen local
+ * address and connected to the same peer as the originating connection, for active connection
+ * migration (RFC 9000 §9). Mirrors the primary-path socket setup in `withQuicConnection`
+ * (linux) and the JVM [NioUdpChannelFactory].
+ *
+ * [peerSockAddrAddress]/[peerSockAddrLen] point at the originating connection's pinned peer
+ * sockaddr (kept alive for the driver's life via its `onCleanup`), so we connect each new path
+ * to the same peer without re-resolving DNS.
+ */
+internal class IoUringUdpChannelFactory(
+    private val peerSockAddrAddress: Long,
+    private val peerSockAddrLen: Int,
+    private val bufferFactory: BufferFactory,
+) : UdpChannelFactory {
+    override suspend fun openPath(
+        localHost: String?,
+        localPort: Int,
+    ): NewPath {
+        val fd = socket(AF_INET, SOCK_DGRAM, 0)
+        check(fd >= 0) { "Failed to create migration path UDP socket" }
+
+        try {
+            memScoped {
+                // Resolve the local bind address. AI_PASSIVE + null host = wildcard; an explicit
+                // host (e.g. a loopback alias 127.0.0.2) binds that source. Port 0 → ephemeral.
+                val hints = alloc<addrinfo>()
+                hints.ai_family = AF_INET
+                hints.ai_socktype = SOCK_DGRAM
+                hints.ai_flags = AI_PASSIVE
+                val bindResult = alloc<CPointerVar<addrinfo>>()
+                val gaiRc = getaddrinfo(localHost, localPort.toString(), hints.ptr, bindResult.ptr)
+                check(gaiRc == 0) { "Failed to resolve migration local bind addr $localHost:$localPort (rc=$gaiRc)" }
+                try {
+                    val bindAddr = bindResult.value!!.pointed
+                    val bindRc = bind(fd, bindAddr.ai_addr, bindAddr.ai_addrlen)
+                    check(bindRc == 0) { "Failed to bind migration path to $localHost:$localPort (rc=$bindRc)" }
+                } finally {
+                    freeaddrinfo(bindResult.value)
+                }
+
+                // Connect to the same peer as the originating connection.
+                val peerPtr = peerSockAddrAddress.toCPointer<sockaddr>()!!
+                val connectRc = connect(fd, peerPtr, peerSockAddrLen.convert())
+                check(connectRc == 0) { "Failed to connect migration path to peer (rc=$connectRc)" }
+
+                // Read back the resolved local 4-tuple (the ephemeral port quiche must validate).
+                val localAddr = alloc<sockaddr_in>()
+                platform.posix.memset(localAddr.ptr, 0, sizeOf<sockaddr_in>().convert())
+                val localAddrLen = alloc<UIntVar>()
+                localAddrLen.value = sizeOf<sockaddr_in>().convert()
+                val gsRc = socket_getsockname(fd, localAddr.ptr.reinterpret(), localAddrLen.ptr)
+                check(gsRc == 0) { "socket_getsockname on migration path returned $gsRc" }
+
+                // Pin the local sockaddr in a heap buffer for quiche's probe/migrate + recv_info.
+                val localSockAddrLen = sizeOf<sockaddr_in>().toInt()
+                val localSockAddrBuf = bufferFactory.allocate(localSockAddrLen)
+                val dst = localSockAddrBuf.nativeMemoryAccess!!.nativeAddress.toCPointer<ByteVar>()!!
+                memcpy(dst, localAddr.ptr, localSockAddrLen.convert())
+                localSockAddrBuf.resetForRead()
+
+                return NewPath(
+                    channel = IoUringUdpChannel(fd),
+                    localSockAddrAddress = localSockAddrBuf.nativeMemoryAccess!!.nativeAddress.toLong(),
+                    localSockAddrLength = localSockAddrLen,
+                    release = { localSockAddrBuf.freeNativeMemory() },
+                )
+            }
+        } catch (t: Throwable) {
+            close(fd)
+            throw t
+        }
+    }
+}

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpServerChannel.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/IoUringUdpServerChannel.kt
@@ -2,6 +2,7 @@
 
 package com.ditchoom.socket.quic
 
+import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.IoUringManager
@@ -28,6 +29,58 @@ import platform.posix.sockaddr_in6
 import platform.posix.sockaddr_storage
 import platform.posix.socklen_t
 import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Reconstruct the network-order sockaddr bytes for [this] path key into a fresh buffer — the
+ * inverse of [CinteropQuicheApi]'s sockaddr decode, used for server egress to a migrated peer's
+ * new source (`sendInfo.to`). Returns the buffer + its sockaddr length, or null for an unknown
+ * family. IPv4 → `sockaddr_in` (16B), IPv6 → `sockaddr_in6` (28B). Caller frees the buffer.
+ */
+internal fun PathKey.toSockAddrBuffer(bufferFactory: BufferFactory): Pair<PlatformBuffer, Int>? {
+    // Emit `size` sockaddr bytes into the buffer's native memory (the raw send reads from its
+    // nativeAddress, position-independent). [leading] holds the meaningful prefix bytes (including
+    // any interior zeros); the remainder is zero-filled (buffers aren't guaranteed zero-init).
+    fun build(
+        size: Int,
+        leading: List<Int>,
+    ): Pair<PlatformBuffer, Int> {
+        val buf = bufferFactory.allocate(size)
+        for (i in 0 until size) buf.writeByte((if (i < leading.size) leading[i] else 0).toByte())
+        buf.resetForRead()
+        return buf to size
+    }
+    return when (family) {
+        4 ->
+            build(
+                sizeOf<sockaddr_in>().toInt(),
+                listOf(
+                    AF_INET and 0xFF,
+                    (AF_INET shr 8) and 0xFF, // sin_family (host order; Linux is LE)
+                    (port shr 8) and 0xFF,
+                    port and 0xFF, // sin_port (network order)
+                    // sin_addr (network order)
+                    ((lo shr 24) and 0xFF).toInt(),
+                    ((lo shr 16) and 0xFF).toInt(),
+                    ((lo shr 8) and 0xFF).toInt(),
+                    (lo and 0xFF).toInt(),
+                ),
+            )
+        6 ->
+            build(
+                sizeOf<sockaddr_in6>().toInt(),
+                buildList {
+                    add(AF_INET6 and 0xFF)
+                    add((AF_INET6 shr 8) and 0xFF)
+                    add((port shr 8) and 0xFF)
+                    add(port and 0xFF)
+                    repeat(4) { add(0) } // sin6_flowinfo
+                    for (i in 0 until 8) add(((hi shr (56 - 8 * i)) and 0xFF).toInt()) // sin6_addr high 8
+                    for (i in 0 until 8) add(((lo shr (56 - 8 * i)) and 0xFF).toInt()) // sin6_addr low 8
+                },
+            )
+        else -> null
+    }
+}
 
 /**
  * Result of [IoUringUdpServerChannel.recvFrom].
@@ -211,7 +264,15 @@ internal class ServerConnectionUdpChannel(
     private val serverChannel: IoUringUdpServerChannel,
     private val peerAddr: CPointer<sockaddr_storage>,
     private val peerAddrLen: socklen_t,
+    private val bufferFactory: BufferFactory,
 ) : UdpChannel {
+    // 1-entry cache for the last sendInfo.to reconstruction. After a migration the server targets
+    // the same new source on consecutive datagrams, so this keeps egress alloc-free in steady
+    // state. Mirrors NioUdpChannel's lastDestKey/lastDestAddr cache.
+    private var lastDestKey: PathKey? = null
+    private var lastDestBuf: PlatformBuffer? = null
+    private var lastDestLen: Int = 0
+
     override suspend fun receive(buffer: PlatformBuffer): Int =
         error("Server connections receive via central loop, not per-connection UdpChannel")
 
@@ -219,12 +280,31 @@ internal class ServerConnectionUdpChannel(
         buffer: PlatformBuffer,
         len: Int,
         dest: PathKey?,
-    ) = // [dest]-based server egress routing (passive migration) is JVM-only for now; the Linux
-        // server sends to its fixed per-connection peerAddr. Linux server migration is a follow-up.
+    ) {
+        // [dest] is quiche's sendInfo.to: after a peer migrates, replies must follow it to its new
+        // source. Reconstruct that sockaddr (cached) and send there; with no dest, use the fixed peer.
+        if (dest != null && dest.family != 0) {
+            if (dest != lastDestKey) {
+                lastDestBuf?.freeNativeMemory()
+                val reconstructed = dest.toSockAddrBuffer(bufferFactory)
+                lastDestBuf = reconstructed?.first
+                lastDestLen = reconstructed?.second ?: 0
+                lastDestKey = dest
+            }
+            val destBuf = lastDestBuf
+            if (destBuf != null) {
+                val destPtr = destBuf.nativeMemoryAccess!!.nativeAddress.toCPointer<sockaddr>()!!
+                serverChannel.sendTo(buffer, len, destPtr, lastDestLen.convert())
+                return
+            }
+        }
         serverChannel.sendTo(buffer, len, peerAddr.reinterpret(), peerAddrLen)
+    }
 
-    /** Frees the per-connection peer address copy. Does NOT close the shared server socket. */
+    /** Frees the per-connection peer address copy + any cached dest. Does NOT close the shared socket. */
     override fun close() {
+        lastDestBuf?.freeNativeMemory()
+        lastDestBuf = null
         nativeHeap.free(peerAddr.pointed)
     }
 }

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
@@ -181,6 +181,23 @@ actual suspend fun <R> withQuicConnection(
                         udpChannel = udpChannel,
                         clientMode = true,
                         isServer = false,
+                        // Connection-migration wiring (Gap 4): the peer + primary local sockaddrs
+                        // (kept pinned via onCleanup for the driver's life) and a factory that opens
+                        // additional io_uring path sockets to the same peer. Mirrors the JVM client.
+                        peerAddr = peerAddrBuf.nativeMemoryAccess!!.nativeAddress.toLong(),
+                        peerLen = peerSockAddrLen.toInt(),
+                        primaryLocalAddr = localAddrBuf.nativeMemoryAccess!!.nativeAddress.toLong(),
+                        primaryLocalLen = sizeOf<sockaddr_in>().toInt(),
+                        udpChannelFactory =
+                            IoUringUdpChannelFactory(
+                                peerSockAddrAddress = peerAddrBuf.nativeMemoryAccess!!.nativeAddress.toLong(),
+                                peerSockAddrLen = peerSockAddrLen.toInt(),
+                                bufferFactory = bufferFactory,
+                            ),
+                        onCleanup = {
+                            peerAddrBuf.freeNativeMemory()
+                            localAddrBuf.freeNativeMemory()
+                        },
                     )
 
                 val connJob = SupervisorJob(parentScope.coroutineContext[Job])
@@ -191,10 +208,9 @@ actual suspend fun <R> withQuicConnection(
                 try {
                     quicConn.block()
                 } finally {
+                    // Sockaddr buffers are freed by the driver's onCleanup (after quiche is done
+                    // dereferencing recvInfo.from/to during destroy) — matches the JVM client.
                     quicConn.close()
-                    // Free sockaddr buffers after driver cleanup
-                    peerAddrBuf.freeNativeMemory()
-                    localAddrBuf.freeNativeMemory()
                 }
             }
         }
@@ -240,6 +256,20 @@ private class LinuxQuicConnection(
     override suspend fun acceptStream(): QuicByteStream = driver.incomingStreams.receive()
 
     override fun streams(): Flow<QuicByteStream> = driver.incomingStreams.consumeAsFlow()
+
+    override val pathState: StateFlow<PathInfo> = driver.pathState
+
+    override suspend fun migrate(
+        localHost: String?,
+        localPort: Int,
+    ): MigrationResult =
+        try {
+            val deferred = CompletableDeferred<MigrationResult>()
+            driver.commands.send(QuicheCmd.Migrate(localHost, localPort, deferred))
+            deferred.await()
+        } catch (_: ClosedSendChannelException) {
+            MigrationResult.Failed("connection closed")
+        }
 
     override suspend fun close(error: QuicError) {
         try {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -49,6 +49,7 @@ import platform.posix.ntohs
 import platform.posix.sockaddr_in
 import platform.posix.sockaddr_storage
 import platform.posix.socket
+import kotlin.concurrent.AtomicInt
 import kotlin.time.Duration
 
 private const val QUICHE_PROTOCOL_VERSION = 0x00000001
@@ -182,11 +183,84 @@ private class LinuxQuicServer(
     private val acceptedDrivers = Channel<QuicheDriver>(Channel.UNLIMITED)
 
     /**
+     * Passive-migration support (mirrors [JvmQuicServer]): one server socket sees a client's
+     * source change after it migrates (RFC 9000 §9). quiche needs the *actual* per-datagram
+     * source as recv_info.from to recognise the new path, so cache one recv_info per distinct
+     * source (its `to` is the server's fixed local addr in [localAddrBuf]).
+     *
+     * Bounded ([maxPeerRecvInfos]) + reference-counted, identical to the JVM server: the cached
+     * pointer is handed to a driver over an UNLIMITED command channel, so eviction frees only an
+     * entry whose [CachedRecvInfo.inFlight] is zero (released via [QuicheCmd.RecvPacket.
+     * onRecvInfoConsumed]). Access order is maintained manually (remove+reinsert on hit) since
+     * K/N's LinkedHashMap has no accessOrder constructor. Receive-loop coroutine is the only
+     * writer; [inFlight] is the only field a driver coroutine touches.
+     */
+    private val maxPeerRecvInfos = 256
+    private val peerRecvInfos = LinkedHashMap<PathKey, CachedRecvInfo>()
+
+    private class CachedRecvInfo(
+        val info: QuicheRecvInfo,
+        val fromBuf: PlatformBuffer,
+    ) {
+        val inFlight = AtomicInt(0)
+    }
+
+    private fun recvInfoFor(
+        peerAddr: Long,
+        peerAddrLen: Int,
+    ): CachedRecvInfo {
+        val key = api.decodePathKey(peerAddr)
+        peerRecvInfos.remove(key)?.let {
+            peerRecvInfos[key] = it // bump to most-recently-used
+            return it
+        }
+        // Miss: pin a copy of this source's sockaddr (recvFrom's buffer is reused next call) and
+        // build a recv_info from = source, to = the server's fixed local addr.
+        val fromBuf = bufferFactory.allocate(peerAddrLen)
+        val dst = fromBuf.nativeMemoryAccess!!.nativeAddress.toCPointer<ByteVar>()!!
+        memcpy(dst, peerAddr.toCPointer<ByteVar>()!!, peerAddrLen.convert())
+        val info =
+            api.recvInfoNew(
+                fromBuf.nativeMemoryAccess!!.nativeAddress.toLong(),
+                peerAddrLen,
+                localAddrBuf.nativeMemoryAccess!!.nativeAddress.toLong(),
+                sizeOf<sockaddr_in>().toInt(),
+            )
+        val cached = CachedRecvInfo(info, fromBuf)
+        peerRecvInfos[key] = cached
+        evictIdlePeerRecvInfo()
+        return cached
+    }
+
+    /** Free the least-recently-used cached recv_info whose [inFlight] is zero once over cap. */
+    private fun evictIdlePeerRecvInfo() {
+        if (peerRecvInfos.size <= maxPeerRecvInfos) return
+        val iterator = peerRecvInfos.entries.iterator() // insertion order == access order (maintained above)
+        while (iterator.hasNext()) {
+            val cached = iterator.next().value
+            if (cached.inFlight.value == 0) {
+                api.recvInfoFree(cached.info)
+                cached.fromBuf.freeNativeMemory()
+                iterator.remove()
+                return
+            }
+        }
+    }
+
+    /**
      * Queue for drivers that need their [connectionsByDcid] entries removed.
      * Connection handlers add drivers here after close; the receive loop drains it.
      * This keeps all map mutations on the receive loop coroutine.
      */
     private val driverCleanupCh = Channel<QuicheDriver>(Channel.UNLIMITED)
+
+    /**
+     * Queue of spare-SCID registrations from drivers' [QuicheDriver.onScidIssued] (fired on a
+     * driver coroutine when it issues spare CIDs at establishment). The receive loop drains it
+     * into [connectionsByDcid] so a migrating peer's new DCID (a server-issued SCID) routes to the
+     * right driver — without this, active migration fails path validation. Mirrors [JvmQuicServer].
+     */
+    private val scidRegistrationCh = Channel<Pair<ConnectionIdKey, QuicheDriver>>(Channel.UNLIMITED)
 
     @kotlin.concurrent.Volatile
     private var closed = false
@@ -239,8 +313,17 @@ private class LinuxQuicServer(
             driver.destroy()
         }
         connectionsByDcid.clear()
+        // Drivers destroyed (their drain released every in-flight ref) — free the per-source
+        // recv_info cache. Each recv_info before its `from` buffer; localAddrBuf (the shared `to`)
+        // is freed last, below.
+        for (cached in peerRecvInfos.values) {
+            api.recvInfoFree(cached.info)
+            cached.fromBuf.freeNativeMemory()
+        }
+        peerRecvInfos.clear()
         api.configFree(config)
         acceptedDrivers.close()
+        scidRegistrationCh.close()
         serverChannel.freeBuffers()
         localAddrBuf.freeNativeMemory()
     }
@@ -265,6 +348,8 @@ private class LinuxQuicServer(
             while (!closed) {
                 // Remove entries for drivers closed by connection handlers
                 drainCleanupChannel()
+                // Register spare SCIDs issued by drivers so a migrating peer's new DCID routes.
+                drainScidRegistrations()
 
                 // Allocate a fresh buffer per packet — ownership transfers to driver (zero-copy)
                 val recvBuf = bufferFactory.allocate(MAX_DATAGRAM_SIZE)
@@ -314,8 +399,21 @@ private class LinuxQuicServer(
 
                 val existingDriver = connectionsByDcid[dcidKey]
                 if (existingDriver != null) {
-                    val sendResult = existingDriver.commands.trySend(QuicheCmd.RecvPacket(recvBuf, recvResult.bytesReceived))
+                    // Per-source recv_info so quiche sees a migrated client's new source as a new
+                    // path. Hold an in-flight ref so the cache can't evict+free it while queued.
+                    val cached = recvInfoFor(recvResult.peerAddr.rawValue.toLong(), recvResult.peerAddrLen.toInt())
+                    cached.inFlight.incrementAndGet()
+                    val sendResult =
+                        existingDriver.commands.trySend(
+                            QuicheCmd.RecvPacket(
+                                recvBuf,
+                                recvResult.bytesReceived,
+                                recvInfoOverride = cached.info,
+                                onRecvInfoConsumed = { cached.inFlight.decrementAndGet() },
+                            ),
+                        )
                     if (sendResult.isFailure) {
+                        cached.inFlight.decrementAndGet()
                         recvBuf.freeNativeMemory()
                         // Remove ALL entries for this dead driver, not just the one we hit
                         connectionsByDcid.keys.removeAll { connectionsByDcid[it] === existingDriver }
@@ -350,6 +448,18 @@ private class LinuxQuicServer(
         while (true) {
             val driver = driverCleanupCh.tryReceive().getOrNull() ?: break
             connectionsByDcid.keys.removeAll { connectionsByDcid[it] === driver }
+        }
+    }
+
+    /**
+     * Register spare SCIDs issued by drivers — maps each to its driver so a migrating peer's new
+     * DCID routes correctly. Receive-loop coroutine only. A registration for an already-removed
+     * driver is harmless: [drainCleanupChannel] runs first each iteration.
+     */
+    private fun drainScidRegistrations() {
+        while (true) {
+            val (key, driver) = scidRegistrationCh.tryReceive().getOrNull() ?: break
+            connectionsByDcid[key] = driver
         }
     }
 
@@ -420,7 +530,11 @@ private class LinuxQuicServer(
         api.connRecv(conn, recvAddr, recvResult.bytesReceived, recvInfo)
         recvBuf.freeNativeMemory()
 
-        val udpChannel = ServerConnectionUdpChannel(serverChannel, peerAddrCopy.ptr, peerAddrLen.convert())
+        val udpChannel = ServerConnectionUdpChannel(serverChannel, peerAddrCopy.ptr, peerAddrLen.convert(), bufferFactory)
+        // Self-reference for onScidIssued: the driver doesn't exist when we build the callback, so
+        // capture it via this holder, set right after construction. The callback only fires at
+        // establishment (well after this), so the holder is always populated by then.
+        var driverRef: QuicheDriver? = null
         val driver =
             QuicheDriver(
                 api = api,
@@ -431,7 +545,13 @@ private class LinuxQuicServer(
                 udpChannel = udpChannel,
                 clientMode = false,
                 isServer = true,
+                onScidIssued = { scid, len ->
+                    // Snapshot the CID (scid is freed right after this returns) and hand the
+                    // registration to the receive loop, which owns connectionsByDcid.
+                    driverRef?.let { d -> scidRegistrationCh.trySend(ConnectionIdKey.fromNative(scid, len) to d) }
+                },
             )
+        driverRef = driver
 
         driver.start(scope)
 

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicMigrationLoopbackTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicMigrationLoopbackTests.kt
@@ -1,0 +1,105 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import platform.posix.F_OK
+import platform.posix.access
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end active connection migration over loopback on Kotlin/Native (Gap 4) — the K/N
+ * counterpart of the JVM `QuicMigrationLoopbackTests`.
+ *
+ * The client connects on 127.0.0.1, then [QuicScope.migrate]s to the loopback alias 127.0.0.2
+ * (all of 127.0.0.0/8 is loopback on Linux). The [IoUringUdpChannelFactory] opens a second
+ * io_uring socket bound to 127.0.0.2; the in-process K/N server recognises the new source via
+ * its per-source recv_info routing and replies follow the peer via `sendInfo.to`. We assert
+ * migration succeeds and the stream still round-trips — proving cinterop migration on both ends.
+ */
+class LinuxQuicMigrationLoopbackTests {
+    private val testQuicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    private fun certPath(name: String): String {
+        val candidates = listOf("testcerts/$name", "socket-quic/testcerts/$name")
+        return candidates.firstOrNull { access(it, F_OK) == 0 }
+            ?: error("Test cert not found: $name (tried $candidates)")
+    }
+
+    private val tlsConfig
+        get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.deterministic().allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 5.seconds)
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
+    }
+
+    @Test
+    fun streamSurvivesActiveMigrationToLoopbackAlias() =
+        runQuicTest {
+            withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
+                // Echo loop: mirror every message back until the stream ends.
+                val serverJob =
+                    launch {
+                        connections {
+                            val stream = acceptStream()
+                            while (true) {
+                                val data = stream.read(8.seconds)
+                                if (data is ReadResult.Data) {
+                                    stream.write(data.buffer, 5.seconds)
+                                } else {
+                                    break
+                                }
+                            }
+                            stream.close()
+                        }
+                    }
+
+                val migrationResult = CompletableDeferred<MigrationResult>()
+                val beforeEcho = CompletableDeferred<String>()
+                val afterEcho = CompletableDeferred<String>()
+
+                val clientJob =
+                    launch {
+                        // Connect on 127.0.0.1 so the peer is reachable from the 127.0.0.2 path too.
+                        withQuicConnection("127.0.0.1", port, testQuicOptions, timeout = 10.seconds) {
+                            val stream = openStream()
+                            beforeEcho.complete(stream.echoOnce("before"))
+
+                            val result = migrate(localHost = "127.0.0.2", localPort = 0)
+                            migrationResult.complete(result)
+
+                            afterEcho.complete(stream.echoOnce("after"))
+                            stream.close()
+                        }
+                    }
+
+                try {
+                    assertEquals("before", beforeEcho.await())
+                    val result = migrationResult.await()
+                    assertTrue(result is MigrationResult.Succeeded, "expected migration to succeed, got $result")
+                    assertEquals("after", afterEcho.await(), "stream did not round-trip after migration")
+                } finally {
+                    clientJob.cancel()
+                    serverJob.cancel()
+                }
+            }
+        }
+}


### PR DESCRIPTION
## Gap 4 — connection migration on Kotlin/Native (full parity, option B)

`QuicScope.migrate()` returned `Unsupported` on K/N (no native `UdpChannelFactory`),
and the K/N server lacked the path-routing the JVM server got in PR #63. This PR
closes both ends so active migration works on Kotlin/Native exactly like the JVM.

### Client (commit 1)
- **`IoUringUdpChannelFactory`** — mirrors `NioUdpChannelFactory`: opens a new
  io_uring UDP socket, binds the chosen local 4-tuple (`getaddrinfo` + `AI_PASSIVE`,
  so a loopback alias / ephemeral port works), connects the same peer, pins the
  resolved local sockaddr.
- Wires peer + primary-local sockaddrs + the factory into the linux `QuicheDriver`
  (freed via `onCleanup`, matching the JVM client) and implements
  `LinuxQuicConnection.migrate()`/`pathState`.

### Server (commit 2) — the three pieces PR #63 gave the JVM server
- **Per-source `recv_info`**: receive loop feeds quiche `from` = the real datagram
  source so a migrated client's new source is a new path. **Bounded + reference-
  counted** exactly like the JVM server (Gap 6): LRU cap 256, freed on eviction
  only when `inFlight == 0` (released via `RecvPacket.onRecvInfoConsumed`), because
  the command channel is `UNLIMITED`. Access order maintained manually (K/N's
  `LinkedHashMap` has no `accessOrder` ctor).
- **`sendInfo.to` egress**: `ServerConnectionUdpChannel.send` honours the `dest`
  PathKey, reconstructing the sockaddr (`PathKey.toSockAddrBuffer`, inverse of the
  cinterop decode) with a 1-entry cache, so replies follow the migrated peer.
- **Spare-SCID registration**: `onScidIssued` registers server-issued SCIDs in
  `connectionsByDcid`. The client switches its DCID to one when migrating; without
  registration those packets were dropped → *path validation failed* (the exact
  failure I hit before adding this).

### Test (commit 3)
`LinuxQuicMigrationLoopbackTests` — K/N counterpart of the JVM loopback test:
connect 127.0.0.1 → `migrate("127.0.0.2")` → assert success + stream round-trips.

## Validation (local — `linuxX64Test` runs here with cached natives)
- New migration test **passes** (the path-validation failure surfaced the missing
  SCID registration; fixed → green).
- Full `:socket-quic:linuxX64Test`: **152/152**, no crashes/SIGSEGV.
- `compileKotlinLinuxArm64` + `compileTestKotlinLinuxArm64` green; ktlint green.

Scope: linuxMain + linuxTest only — no commonMain/JVM changes, so other platforms
are unaffected. Closes Gap 4 in `socket-quic/MIGRATION_FOLLOWUPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)