### PR TITLE
test(quic): Android active-migration test + fix atomicfu silent-skip (Gap 3)

### DIFF
--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -1257,6 +1257,16 @@ kotlin {
         }
         jvmMain.get().dependsOn(commonJvmMain)
         androidMain.get().dependsOn(commonJvmMain)
+        androidMain.dependencies {
+            // com.ditchoom:buffer-android:5.2.0 references kotlinx.atomicfu.AtomicFU at runtime but
+            // doesn't declare the atomicfu dependency in its module metadata, so it isn't on a
+            // consumer's runtime classpath — any Android app exercising the QUIC connect/StateFlow
+            // path crashes with NoClassDefFoundError: kotlinx.atomicfu.AtomicFU. (JVM is unaffected:
+            // coroutines/buffer JVM artifacts are atomicfu-transformed.) Provide the runtime atomicfu
+            // so Android consumers — and the instrumented tests, which silently skipped on this for
+            // ages via their connect-failure catch — actually work. Version matches coroutines 1.10.2.
+            implementation("org.jetbrains.kotlinx:atomicfu:0.27.0")
+        }
         val commonJvmTest by creating {
             dependsOn(commonTest.get())
             kotlin.srcDir("src/sharedJvmTestProtocol/kotlin")

--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicConnectivityTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicConnectivityTests.kt
@@ -4,12 +4,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.flow.ReadResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.seconds
 
@@ -90,6 +92,39 @@ class AndroidQuicConnectivityTests {
                 val response = stream.read(5.seconds)
                 assertIs<com.ditchoom.buffer.flow.ReadResult.Data>(response)
 
+                stream.close()
+            }
+        }
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.Default.allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 5.seconds)
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
+    }
+
+    /**
+     * Active connection migration (RFC 9000 §9) on the Android/JNI runtime — the real-device
+     * counterpart of the JVM/K-N loopback tests, and the first test that actually calls
+     * [QuicScope.migrate] on Android (the [AndroidQuicMigrationTests] suite only does passive
+     * resilience). [migrate] rebinds a fresh local 4-tuple (new ephemeral source port) to the
+     * same docker quic-echo server, exercising the JNI `connNewScid`, client path-routing decode,
+     * and `connMigrate`. The echo server has server-side path routing (PR #63) so it validates
+     * the new path; we assert migration succeeds and the stream still round-trips.
+     */
+    @Test
+    fun streamSurvivesActiveMigration() =
+        runBlocking(Dispatchers.IO) {
+            withQuicConnection(serverHost, serverPort, testQuicOptions, timeout = 10.seconds) {
+                val stream = openStream()
+                assertEquals("before", stream.echoOnce("before"))
+
+                val result = migrate(localHost = null, localPort = 0)
+                assertIs<MigrationResult.Succeeded>(result)
+
+                assertEquals("after", stream.echoOnce("after"), "stream did not round-trip after migration")
                 stream.close()
             }
         }


### PR DESCRIPTION
## Gap 3 — active connection migration on Android/JNI

`AndroidQuicMigrationTests` only exercised *passive* resilience (block/unblock UDP)
and never called `migrate()`, so active migration had zero coverage on Android.
This adds a real `migrate()` instrumented test — and, in doing so, uncovered and
fixed a latent bug that had been **silently disabling all Android QUIC connect tests**.

### The silent-skip bug (commit 1)
`com.ditchoom:buffer-android:5.2.0` references `kotlinx.atomicfu.AtomicFU` at runtime
but **doesn't declare the atomicfu dependency** in its module metadata, so it's absent
from a consumer's Android runtime classpath. Any Android app exercising the QUIC
connect / `StateFlow` path crashes with `NoClassDefFoundError: kotlinx.atomicfu.AtomicFU`.
(JVM is unaffected — its coroutines/buffer artifacts are atomicfu-transformed.)

Because `AndroidQuicConnectivityTests`'s `@Before` catches any connect failure and
`assumeTrue(false)`s, this crash showed up as a **clean skip** — `connectToLocalServer`
and `echoOverQuic` have been **SKIPPING in CI and locally** (verified in the CI logs),
i.e. zero real coverage, green job. Fix: declare `atomicfu` in `androidMain` so the
runtime class ships for consumers and the tests actually run.

### The test (commit 2)
`streamSurvivesActiveMigration`: connect to the docker quic-echo server, echo "before",
`migrate()` to a fresh local 4-tuple (new ephemeral source port), assert `Succeeded`,
echo "after". Exercises the Android/JNI `connNewScid` + client path-routing decode +
`connMigrate`; the routing-capable echo server validates the new path.

## Validation — on a real x86_64 emulator (locally)
Booted the `test_quic` AVD (KVM) + docker quic-echo harness and ran the suite:
- **`streamSurvivesActiveMigration` → `migrate()` Succeeded, stream round-trips.**
- `connectToLocalServer` + `echoOverQuic` now **run and pass** (were silently skipping).
- Full instrumented suite green (the netem `AndroidQuicMigrationTests` cleanly skip — they need a rooted network-control server).

Two local-only stale artifacts also bit me en route (not part of this PR): the checked-out
x86_64 Android JNI shim and the docker quic-echo image were both built before the
migration code; CI rebuilds both fresh, so it's unaffected. The atomicfu fix, by contrast,
is real and applies to CI + production Android.

ktlint + `compileDebugKotlinAndroid` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)