### PR TITLE
ci(quic): Windows JVM Tests tolerate a missing quiche DLL (Gap 7)

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -145,17 +145,41 @@ jobs:
       # handed over as the quiche-windows-natives artifact. Drop it where
       # stageQuicheNativeResources expects it (libs/quiche/windows-x64/lib/)
       # so NativeLibLoader can extract quiche_jni.dll from the test classpath.
+      #
+      # The cross-build is best-effort: editing socket-quic/src/jni/quiche_jni.c
+      # cold-busts the quiche native cache (keyed on its hash), and the fragile
+      # MinGW cross-build may then not emit the DLL → no artifact is uploaded
+      # (if-no-files-found: ignore). download-artifact errors on a missing
+      # artifact, so tolerate it (continue-on-error) and gate the test step on
+      # the DLL actually being present. This keeps the job GREEN when the DLL
+      # is absent — instead of a permanent cosmetic red on every PR — while
+      # still running (and surfacing) the tests whenever the DLL is produced.
       - name: Download Windows quiche native lib
+        id: download-dll
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: quiche-windows-natives
           path: socket-quic/libs/quiche/windows-x64/lib
+      - name: Check whether the Windows DLL is present
+        id: dll
+        shell: bash
+        run: |
+          if [ -f socket-quic/libs/quiche/windows-x64/lib/quiche_jni.dll ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "quiche_jni.dll present — running Windows JVM tests."
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Windows DLL missing::The Linux MinGW cross-build did not produce quiche_jni.dll (likely a cold native cache after a quiche_jni.c edit). Skipping Windows JVM tests this run."
+          fi
       # :jvmTest is the root project's suite. :socket-quic:jvmTest is now
       # included (was excluded while no Windows native existed): the DLL above
       # plus the windows-x64 entry in nativeLibsByPlatform let it stage + load.
       # The leading colon scopes each task to its project; an unqualified
-      # `jvmTest` would match every subproject by name.
+      # `jvmTest` would match every subproject by name. Runs only when the DLL
+      # is present (see above).
       - name: Run JVM tests
+        if: steps.dll.outputs.present == 'true'
         run: ./gradlew :jvmTest :socket-quic:jvmTest --no-configuration-cache
 
   docs:


### PR DESCRIPTION
## Gap 7 — stop the cosmetic Windows red

The Windows `quiche_jni.dll` is best-effort MinGW-cross-compiled in `build-linux`.
Editing `socket-quic/src/jni/quiche_jni.c` cold-busts the hash-keyed native cache,
and the fragile cross-build may then not emit the DLL → no `quiche-windows-natives`
artifact is uploaded (`if-no-files-found: ignore`). `download-artifact` **errors** on
a missing artifact, so `build-windows` failed at the download step and showed a
permanent **red** check on every PR (non-blocking via `continue-on-error`, but noise
that hides real regressions).

## Fix
- `continue-on-error` on the download step (tolerate the missing artifact).
- A `Check whether the Windows DLL is present` step sets an output + emits a
  `::warning::` when absent.
- `Run JVM tests` is gated on `steps.dll.outputs.present == 'true'`.

Net: the job is **green** when the DLL is absent (no more cosmetic red), and still
runs + surfaces the JVM tests whenever the DLL is produced. Job-level
`continue-on-error` stays until Windows `jvmTest` is green ≥2 runs (the PLAN.md
Phase 2 exit criterion) — that's a separate follow-up.

`review.yaml` triggers on `pull_request`, so this PR's own `build-windows` run
exercises the new logic. Validated by YAML parse locally.

Closes Gap 7 in `socket-quic/MIGRATION_FOLLOWUPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)