### PR TITLE
ci(quic): harden validate-artifacts against the version-race

### DIFF
--- a/.github/workflows/validate-artifacts.yaml
+++ b/.github/workflows/validate-artifacts.yaml
@@ -40,9 +40,29 @@ jobs:
           path: /tmp/quiche-linux-natives
         continue-on-error: true  # may not exist if quiche build failed
 
+      # Validate the version that was ACTUALLY built into maven-local, not the
+      # workflow input. build-linux's getNextVersion reads Maven Central, and if a
+      # release publishes mid-CI the input version can diverge from the version
+      # build-linux actually stamped onto the artifacts here — then every resolution
+      # below looks for a version that was never published and fails spuriously (the
+      # known version-race red on otherwise-fine PRs). Deriving from the downloaded
+      # artifacts is race-proof: we validate whatever was genuinely built.
+      - name: Resolve built version
+        run: |
+          version=$(ls /tmp/linux-repo/com/ditchoom/socket/ 2>/dev/null \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+          if [ -z "$version" ]; then
+            echo "::error::No socket version present in the downloaded maven-local " \
+              "(/tmp/linux-repo/com/ditchoom/socket/). build-linux's publish didn't produce " \
+              "the artifacts — failing loudly rather than guessing a version to validate."
+            exit 1
+          fi
+          echo "RESOLVED_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "Validating version: ${version} (workflow input was '${{ inputs.version }}')"
+
       - name: Merge artifacts and module metadata
         run: |
-          version="${{ inputs.version }}"
+          version="${RESOLVED_VERSION}"
           LINUX_BASE="/tmp/linux-repo/com/ditchoom"
           APPLE_BASE="/tmp/apple-repo/com/ditchoom"
           MERGED="/tmp/maven-local/com/ditchoom"
@@ -142,7 +162,7 @@ jobs:
 
       - name: Inject native libs into socket-quic JVM JAR
         run: |
-          version="${{ inputs.version }}"
+          version="${RESOLVED_VERSION}"
           MERGED="/tmp/maven-local/com/ditchoom"
           QUIC_JAR="$MERGED/socket-quic-jvm/$version/socket-quic-jvm-$version.jar"
 
@@ -213,13 +233,13 @@ jobs:
       - name: Validate with Gradle resolution
         run: |
           gradle -p .ci/validate-resolution resolveAll \
-            -PsocketVersion=${{ inputs.version }} \
+            -PsocketVersion=${{ env.RESOLVED_VERSION }} \
             -PmavenRepoPath=/tmp/maven-local \
             --no-daemon
 
       - name: Validate artifacts
         run: |
-          version="${{ inputs.version }}"
+          version="${RESOLVED_VERSION}"
           MERGED="/tmp/maven-local/com/ditchoom"
           FAILED=false
 


### PR DESCRIPTION
## Follow-up #3 — CI version-race hardening

`validate-artifacts` took the version as a workflow input computed by build-linux's
`getNextVersion` (which reads Maven Central). When a release publishes **mid-CI**,
that input diverges from the version build-linux actually stamped onto the
maven-local artifacts it built — so every resolution in this job looked for a version
that was never published and failed **spuriously**. This is the recurring version-race
red on otherwise-fine PRs (e.g. #67's `validate` failed resolving `socket:3.1.10`
while `3.2.0` had just published from #66).

## Fix
Derive the version from the **downloaded maven-local artifacts** (`/tmp/linux-repo/
com/ditchoom/socket/<version>/`) instead of the input — we validate whatever was
genuinely built, immune to the race. **No silent fallback** (per the no-fallback
principle we applied to the FFM loader): if no version is present the artifacts are
missing/broken, so it fails loudly rather than guessing. The workflow input is kept
only as a diagnostic (logs the input-vs-derived divergence when the race happens).

CI-only change → labeled `skip-release` (no production code, no version bump). This
PR's own `validate` run exercises the new derive-from-artifacts path.

Addresses the version-race follow-up recorded in `socket-quic/MIGRATION_FOLLOWUPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)