### PR TITLE
test(quic): Linux K/N passive NAT-rebind migration test (#74 Task 1)

### DIFF
--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicPassiveMigrationTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicPassiveMigrationTestSuite.kt
@@ -1,0 +1,137 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared **passive** connection-migration test suite (RFC 9000 §9.3 NAT rebinding). Each platform
+ * extends this with a [testTlsConfig] and a [createRebindingProxy] implementation; the test body is
+ * inherited, guaranteeing parity across JVM, Linux K/N, and any future common-test platform —
+ * exactly like [QuicServerTestSuite] does for the server suite.
+ *
+ * (Android's equivalent lives in `androidInstrumentedTest`, a separate on-device compilation that
+ * doesn't see `commonTest`, so it stays its own copy by necessity — see
+ * `AndroidQuicPassiveMigrationTests`.)
+ *
+ * The client never calls [QuicScope.migrate]; instead the path's *source* address changes
+ * underneath it, as a NAT rebind would. A userspace [RebindingProxy] sits between client and the
+ * in-process server (no root / netns / tc): the client talks to the proxy, the proxy forwards to
+ * the server, and mid-stream the proxy swaps its *upstream* (server-facing) socket for one with a
+ * fresh source port. From the server's view that's a single connection (unchanged DCID) whose
+ * source 4-tuple suddenly changed. We assert the stream still round-trips afterward, exercising the
+ * server's per-source recv_info + `sendInfo.to` egress routing.
+ */
+abstract class QuicPassiveMigrationTestSuite {
+    abstract fun testTlsConfig(): QuicTlsConfig
+
+    /** Platform-specific NAT-rebind proxy (DatagramChannel on JVM, io_uring/POSIX on Linux K/N). */
+    abstract fun createRebindingProxy(serverPort: Int): RebindingProxy
+
+    /**
+     * Platform hook for skip-on-missing-native-lib semantics. Default passes through; the JVM
+     * subclass overrides to convert `UnsatisfiedLinkError` into an `assumeTrue` skip. Native targets
+     * inherit the default no-op — their cinterop quiche binding is fixed at compile time, so there
+     * is no skip path and any failure is a real failure (the "must run, never silently skip"
+     * discipline `QUIC_MIGRATION_REQUIRE_RUN` enforces on the JVM active-migration test).
+     */
+    protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
+
+    private val testQuicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.deterministic().allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 5.seconds)
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
+    }
+
+    @Test
+    fun streamSurvivesPassiveSourceRebind() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = testQuicOptions) {
+                    // Echo loop: mirror every message back until the stream ends.
+                    val serverJob =
+                        launch {
+                            connections {
+                                val stream = acceptStream()
+                                while (true) {
+                                    val data = stream.read(8.seconds)
+                                    if (data is ReadResult.Data) {
+                                        stream.write(data.buffer, 5.seconds)
+                                    } else {
+                                        break
+                                    }
+                                }
+                                stream.close()
+                            }
+                        }
+
+                    val proxy = createRebindingProxy(port)
+                    val beforeEcho = CompletableDeferred<String>()
+                    val afterEcho = CompletableDeferred<String>()
+
+                    val clientJob =
+                        launch {
+                            // Client connects to the proxy, unaware of the rebind that happens on
+                            // the proxy's upstream (server-facing) socket.
+                            withQuicConnection("127.0.0.1", proxy.proxyPort, testQuicOptions, timeout = 10.seconds) {
+                                val stream = openStream()
+                                beforeEcho.complete(stream.echoOnce("before"))
+
+                                // Passive rebind: the proxy's source toward the server changes, with
+                                // NO client-side migrate(). The server must keep the stream alive via
+                                // per-source recv_info + sendInfo.to routing.
+                                proxy.rebind()
+
+                                afterEcho.complete(stream.echoOnce("after"))
+                                stream.close()
+                            }
+                        }
+
+                    try {
+                        assertEquals("before", beforeEcho.await())
+                        assertEquals(
+                            "after",
+                            afterEcho.await(),
+                            "stream did not round-trip after passive source rebind",
+                        )
+                    } finally {
+                        clientJob.cancel()
+                        serverJob.cancel()
+                        proxy.close()
+                    }
+                }
+            }
+        }
+}
+
+/**
+ * A userspace UDP forwarder that simulates a NAT rebind. Client ↔ [proxyPort] ↔ server. [rebind]
+ * swaps the upstream (server-facing) socket for one with a new source port, so the server sees the
+ * same connection arrive from a new 4-tuple. Each platform implements it over its native UDP API.
+ */
+interface RebindingProxy {
+    /** The local port the client connects to (the proxy's client-facing socket). */
+    val proxyPort: Int
+
+    /** Swap the upstream socket for a fresh source port — the NAT rebind. */
+    fun rebind()
+
+    /** Stop the pump loops and release all sockets/resources. */
+    suspend fun close()
+}

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicPassiveMigrationTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicPassiveMigrationTests.kt
@@ -1,46 +1,21 @@
 package com.ditchoom.socket.quic
 
-import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.Charset
-import com.ditchoom.buffer.Default
-import com.ditchoom.buffer.flow.ReadResult
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import org.junit.Assume.assumeTrue
 import java.net.InetSocketAddress
 import java.net.SocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 import kotlin.concurrent.thread
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.seconds
 
 /**
- * End-to-end **passive** connection migration (RFC 9000 §9.3 NAT rebinding) — the client never
- * calls [QuicScope.migrate]; instead the path's source address changes underneath it, as a NAT
- * rebind would do. This exercises the server-side routing added in PR #63 (JVM): the per-source
- * recv_info ([JvmQuicServer.recvInfoFor]) lets quiche see the rebound source as the same
- * connection, and `sendInfo.to` egress sends replies to the new source.
+ * JVM passive NAT-rebind migration test — the JVM member of the shared [QuicPassiveMigrationTestSuite].
  *
- * The rebind is simulated by a userspace UDP proxy (no root / netns / tc required): the client
- * talks to the proxy, the proxy forwards to the in-repo server, and mid-stream the proxy swaps
- * its *upstream* socket for one with a fresh source port. From the server's view that's a single
- * connection (unchanged DCID) whose source 4-tuple suddenly changed — a passive rebind. We assert
- * the stream still round-trips afterward.
+ * Provides the JVM cert resolution (classpath `certs/`), the `UnsatisfiedLinkError → assumeTrue`
+ * skip (so a missing JNI/FFM quiche native skips cleanly), and a [RebindingProxy] built on blocking
+ * [DatagramChannel]s. The test body itself lives in the common suite, guaranteeing parity with the
+ * Linux K/N port.
  */
-class QuicPassiveMigrationTests {
-    private val testQuicOptions =
-        QuicOptions(
-            alpnProtocols = listOf("test"),
-            verifyPeer = false,
-            idleTimeout = 10.seconds,
-        )
-
+class QuicPassiveMigrationTests : QuicPassiveMigrationTestSuite() {
     private fun certPath(name: String): String {
         val url =
             this::class.java.classLoader.getResource("certs/$name")
@@ -48,10 +23,9 @@ class QuicPassiveMigrationTests {
         return java.io.File(url.toURI()).absolutePath
     }
 
-    private val tlsConfig
-        get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
 
-    private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
         try {
             block()
         } catch (e: UnsatisfiedLinkError) {
@@ -59,88 +33,18 @@ class QuicPassiveMigrationTests {
         }
     }
 
-    private suspend fun QuicByteStream.echoOnce(payload: String): String {
-        val out = BufferFactory.Default.allocate(payload.length)
-        out.writeString(payload, Charset.UTF8)
-        out.resetForRead()
-        write(out, 5.seconds)
-        val resp = read(5.seconds)
-        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
-    }
-
-    @Test
-    fun streamSurvivesPassiveSourceRebind() =
-        runBlocking(Dispatchers.IO) {
-            skipOnMissingNativeLib {
-                withTimeout(25.seconds) {
-                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
-                        val serverJob =
-                            launch(Dispatchers.IO) {
-                                connections {
-                                    val stream = acceptStream()
-                                    while (true) {
-                                        val data = stream.read(8.seconds)
-                                        if (data is ReadResult.Data) {
-                                            stream.write(data.buffer, 5.seconds)
-                                        } else {
-                                            break
-                                        }
-                                    }
-                                    stream.close()
-                                }
-                            }
-                        delay(100)
-
-                        val proxy = RebindingUdpProxy(serverPort = port)
-                        val beforeEcho = CompletableDeferred<String>()
-                        val afterEcho = CompletableDeferred<String>()
-
-                        val clientJob =
-                            launch(Dispatchers.IO) {
-                                // Client connects to the proxy, unaware of the rebind that happens
-                                // on the proxy's upstream (server-facing) socket.
-                                withQuicConnection("127.0.0.1", proxy.proxyPort, testQuicOptions, timeout = 10.seconds) {
-                                    val stream = openStream()
-                                    beforeEcho.complete(stream.echoOnce("before"))
-
-                                    // Passive rebind: the proxy's source toward the server changes,
-                                    // with NO client-side migrate(). The server must keep the stream
-                                    // alive via per-source recv_info + sendInfo.to routing.
-                                    proxy.rebind()
-
-                                    afterEcho.complete(stream.echoOnce("after"))
-                                    stream.close()
-                                }
-                            }
-
-                        try {
-                            assertEquals("before", withTimeout(12.seconds) { beforeEcho.await() })
-                            assertEquals(
-                                "after",
-                                withTimeout(15.seconds) { afterEcho.await() },
-                                "stream did not round-trip after passive source rebind",
-                            )
-                        } finally {
-                            clientJob.cancel()
-                            serverJob.cancel()
-                            proxy.close()
-                        }
-                    }
-                }
-            }
-        }
+    override fun createRebindingProxy(serverPort: Int): RebindingProxy = DatagramChannelRebindingProxy(serverPort)
 
     /**
-     * Minimal userspace UDP forwarder that simulates a NAT rebind. Client ↔ [proxyPort] ↔ server.
-     * [rebind] swaps the upstream (server-facing) socket for one with a new source port, so the
-     * server sees the same connection arrive from a new 4-tuple. Two daemon threads pump each
-     * direction with blocking [DatagramChannel]s (test-only; ByteBuffer is fine in tests).
+     * [RebindingProxy] over blocking [DatagramChannel]s. Two daemon threads pump each direction;
+     * [rebind] swaps the upstream channel for one with a new source port and closes the old one,
+     * which unblocks the server-to-client thread's read. ByteBuffer is fine here — test-only.
      */
-    private class RebindingUdpProxy(
+    private class DatagramChannelRebindingProxy(
         private val serverPort: Int,
-    ) {
+    ) : RebindingProxy {
         private val clientChannel = DatagramChannel.open().apply { bind(InetSocketAddress("127.0.0.1", 0)) }
-        val proxyPort: Int = (clientChannel.localAddress as InetSocketAddress).port
+        override val proxyPort: Int = (clientChannel.localAddress as InetSocketAddress).port
 
         @Volatile private var upstream = newUpstream()
 
@@ -183,14 +87,13 @@ class QuicPassiveMigrationTests {
                 }
             }
 
-        /** Swap the upstream socket for a fresh source port — the NAT rebind. */
-        fun rebind() {
+        override fun rebind() {
             val old = upstream
             upstream = newUpstream()
             old.close() // unblocks serverToClient's read on the old channel
         }
 
-        fun close() {
+        override suspend fun close() {
             running = false
             clientChannel.close()
             upstream.close()

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicPassiveMigrationTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicPassiveMigrationTests.kt
@@ -1,0 +1,297 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.free
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.value
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import platform.posix.AF_INET
+import platform.posix.F_OK
+import platform.posix.INADDR_LOOPBACK
+import platform.posix.SOCK_DGRAM
+import platform.posix.access
+import platform.posix.bind
+import platform.posix.close
+import platform.posix.connect
+import platform.posix.getsockname
+import platform.posix.htonl
+import platform.posix.htons
+import platform.posix.memcpy
+import platform.posix.memset
+import platform.posix.ntohs
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.sockaddr_storage
+import platform.posix.socket
+import platform.posix.socklen_tVar
+import kotlin.concurrent.AtomicInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end **passive** connection migration (RFC 9000 §9.3 NAT rebinding) on Kotlin/Native — the
+ * K/N counterpart of the JVM `QuicPassiveMigrationTests` (#69) and the linuxX64 sibling of the
+ * active-migration `LinuxQuicMigrationLoopbackTests` (#67).
+ *
+ * The client never calls [QuicScope.migrate]; instead the path's *source* address changes
+ * underneath it, as a NAT rebind would. This exercises the K/N server-side routing
+ * (`LinuxQuicServer.recvInfoFor` per-source recv_info + `ServerConnectionUdpChannel`'s `sendInfo.to`
+ * egress): quiche sees the rebound source as the same connection (unchanged DCID) and replies
+ * follow the peer to its new 4-tuple.
+ *
+ * The rebind is simulated by a userspace UDP proxy (no root / netns / tc): the client talks to the
+ * proxy, the proxy forwards to the in-repo server, and mid-stream the proxy swaps its *upstream*
+ * (server-facing) socket for one with a fresh source port. From the server's view that's a single
+ * connection whose source 4-tuple suddenly changed. We assert the stream still round-trips after.
+ *
+ * The K/N proxy is built on the same io_uring UDP primitives the server uses
+ * ([IoUringUdpServerChannel] for the unconnected client-facing socket, [IoUringUdpChannel] for the
+ * connected upstream) — fully reactive, no blocking threads. See [RebindingUdpProxy].
+ *
+ * Native targets compile quiche via cinterop, so there is no `UnsatisfiedLinkError` skip path: on
+ * Linux this test always runs (like its migration sibling). Any failure is a real failure, which is
+ * the same "must run, never silently skip" discipline `QUIC_MIGRATION_REQUIRE_RUN` enforces on JVM.
+ */
+class LinuxQuicPassiveMigrationTests {
+    private val testQuicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    private fun certPath(name: String): String {
+        val candidates = listOf("testcerts/$name", "socket-quic/testcerts/$name")
+        return candidates.firstOrNull { access(it, F_OK) == 0 }
+            ?: error("Test cert not found: $name (tried $candidates)")
+    }
+
+    private val tlsConfig
+        get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.deterministic().allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 5.seconds)
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
+    }
+
+    @Test
+    fun streamSurvivesPassiveSourceRebind() =
+        runQuicTest {
+            withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
+                // Echo loop: mirror every message back until the stream ends.
+                val serverJob =
+                    launch {
+                        connections {
+                            val stream = acceptStream()
+                            while (true) {
+                                val data = stream.read(8.seconds)
+                                if (data is ReadResult.Data) {
+                                    stream.write(data.buffer, 5.seconds)
+                                } else {
+                                    break
+                                }
+                            }
+                            stream.close()
+                        }
+                    }
+
+                val proxy = RebindingUdpProxy(serverPort = port)
+                val beforeEcho = CompletableDeferred<String>()
+                val afterEcho = CompletableDeferred<String>()
+
+                val clientJob =
+                    launch {
+                        // Client connects to the proxy, unaware of the rebind that happens on the
+                        // proxy's upstream (server-facing) socket.
+                        withQuicConnection("127.0.0.1", proxy.proxyPort, testQuicOptions, timeout = 10.seconds) {
+                            val stream = openStream()
+                            beforeEcho.complete(stream.echoOnce("before"))
+
+                            // Passive rebind: the proxy's source toward the server changes, with NO
+                            // client-side migrate(). The server must keep the stream alive via
+                            // per-source recv_info + sendInfo.to routing.
+                            proxy.rebind()
+
+                            afterEcho.complete(stream.echoOnce("after"))
+                            stream.close()
+                        }
+                    }
+
+                try {
+                    assertEquals("before", beforeEcho.await())
+                    assertEquals(
+                        "after",
+                        afterEcho.await(),
+                        "stream did not round-trip after passive source rebind",
+                    )
+                } finally {
+                    clientJob.cancel()
+                    serverJob.cancel()
+                    proxy.close()
+                }
+            }
+        }
+
+    /**
+     * Userspace UDP forwarder that simulates a NAT rebind, on Kotlin/Native. Client ↔ [proxyPort] ↔
+     * server. [rebind] swaps the upstream (server-facing) socket for one with a new source port, so
+     * the server sees the same connection arrive from a new 4-tuple.
+     *
+     * Built on the repo's io_uring UDP primitives rather than blocking sockets/threads:
+     *  - the client-facing socket is bound + unconnected, driven by [IoUringUdpServerChannel] whose
+     *    `recvFrom` yields the client's source address (so replies can be sent back to it);
+     *  - the upstream socket is `connect()`ed to the server and driven by [IoUringUdpChannel].
+     *
+     * Two suspend pump loops run on [Dispatchers.Default]. [upstreamFd] is an [AtomicInt] so the
+     * swap in [rebind] is visible to both loops; closing the old fd makes the suspended upstream
+     * `receive` return `-ECANCELED` (exactly as the server's `closeFd()` unblocks its recvmsg), so
+     * the server-to-client loop simply re-reads the new upstream and continues.
+     */
+    private class RebindingUdpProxy(
+        private val serverPort: Int,
+    ) {
+        private val bufferFactory = BufferFactory.deterministic()
+
+        // Client-facing bound socket (unconnected) — learns the client's source on the first packet.
+        private val clientFd: Int = openBoundLoopbackSocket()
+        val proxyPort: Int = boundPortOf(clientFd)
+        private val clientChannel = IoUringUdpServerChannel(clientFd)
+
+        // Upstream (server-facing) connected socket; swapped on rebind. AtomicInt gives the pump
+        // loops a consistent view of the current fd across Dispatchers.Default worker threads.
+        private val upstreamFd = AtomicInt(newUpstream())
+
+        // Pinned copy of the client's source addr (recvFrom's internal buffer is reused each call).
+        // The client-to-server loop fills it and publishes its length; >0 means "ready".
+        private val clientAddr = nativeHeap.alloc<sockaddr_storage>()
+        private val clientAddrLen = AtomicInt(0)
+
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        private val c2sJob: Job
+        private val s2cJob: Job
+
+        init {
+            memset(clientAddr.ptr, 0, sizeOf<sockaddr_storage>().convert())
+            c2sJob = scope.launch { clientToServerLoop() }
+            s2cJob = scope.launch { serverToClientLoop() }
+        }
+
+        /** Client → server: forward each datagram to the current upstream, capturing the client source. */
+        private suspend fun clientToServerLoop() {
+            val buf = bufferFactory.allocate(MAX_DATAGRAM)
+            try {
+                while (true) {
+                    val r = clientChannel.recvFrom(buf)
+                    if (r.bytesReceived <= 0) continue
+                    if (clientAddrLen.value == 0 && r.peerAddrLen.toInt() > 0) {
+                        memcpy(clientAddr.ptr, r.peerAddr, r.peerAddrLen.convert())
+                        clientAddrLen.value = r.peerAddrLen.toInt() // publish after the copy
+                    }
+                    IoUringUdpChannel(upstreamFd.value).send(buf, r.bytesReceived, dest = null)
+                }
+            } finally {
+                buf.freeNativeMemory()
+            }
+        }
+
+        /** Server → client: forward each datagram from the current upstream back to the client source. */
+        private suspend fun serverToClientLoop() {
+            val buf = bufferFactory.allocate(MAX_DATAGRAM)
+            try {
+                while (true) {
+                    // -ETIMEDOUT (idle) or -ECANCELED (fd closed by rebind) → re-read the upstream fd.
+                    val n = IoUringUdpChannel(upstreamFd.value).receive(buf)
+                    if (n <= 0) continue
+                    val len = clientAddrLen.value
+                    if (len > 0) {
+                        clientChannel.sendTo(buf, n, clientAddr.ptr.reinterpret(), len.convert())
+                    }
+                }
+            } finally {
+                buf.freeNativeMemory()
+            }
+        }
+
+        /** Swap the upstream socket for a fresh source port — the NAT rebind. */
+        fun rebind() {
+            val old = upstreamFd.value
+            upstreamFd.value = newUpstream()
+            close(old) // unblocks the in-flight upstream receive (-ECANCELED); the loop re-reads the new fd
+        }
+
+        suspend fun close() {
+            // Stop the loops before closing the client fd / freeing recv buffers — the cancellation
+            // path of submitAndWait waits for the kernel to release any in-flight buffer first.
+            c2sJob.cancelAndJoin()
+            s2cJob.cancelAndJoin()
+            clientChannel.close() // closes clientFd + frees its recv structures
+            close(upstreamFd.value)
+            nativeHeap.free(clientAddr)
+            scope.cancel()
+        }
+
+        private fun newUpstream(): Int {
+            val fd = socket(AF_INET, SOCK_DGRAM, 0)
+            check(fd >= 0) { "proxy upstream socket() failed" }
+            memScoped {
+                val addr = alloc<sockaddr_in>()
+                addr.sin_family = AF_INET.convert()
+                addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+                addr.sin_port = htons(serverPort.toUShort())
+                val rc = connect(fd, addr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert())
+                check(rc == 0) { "proxy upstream connect() failed (rc=$rc)" }
+            }
+            return fd
+        }
+
+        companion object {
+            private const val MAX_DATAGRAM = 2048
+
+            private fun openBoundLoopbackSocket(): Int {
+                val fd = socket(AF_INET, SOCK_DGRAM, 0)
+                check(fd >= 0) { "proxy client-facing socket() failed" }
+                memScoped {
+                    val addr = alloc<sockaddr_in>()
+                    addr.sin_family = AF_INET.convert()
+                    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+                    addr.sin_port = htons(0u)
+                    val rc = bind(fd, addr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert())
+                    check(rc == 0) { "proxy client-facing bind() failed (rc=$rc)" }
+                }
+                return fd
+            }
+
+            private fun boundPortOf(fd: Int): Int =
+                memScoped {
+                    val addr = alloc<sockaddr_in>()
+                    val len = alloc<socklen_tVar>()
+                    len.value = sizeOf<sockaddr_in>().convert()
+                    getsockname(fd, addr.ptr.reinterpret<sockaddr>(), len.ptr)
+                    ntohs(addr.sin_port).toInt()
+                }
+        }
+    }
+}

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicPassiveMigrationTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicPassiveMigrationTests.kt
@@ -3,9 +3,7 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.deterministic
-import com.ditchoom.buffer.flow.ReadResult
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.free
@@ -15,7 +13,6 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.sizeOf
 import kotlinx.cinterop.value
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -43,141 +40,45 @@ import platform.posix.sockaddr_storage
 import platform.posix.socket
 import platform.posix.socklen_tVar
 import kotlin.concurrent.AtomicInt
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.seconds
 
 /**
- * End-to-end **passive** connection migration (RFC 9000 §9.3 NAT rebinding) on Kotlin/Native — the
- * K/N counterpart of the JVM `QuicPassiveMigrationTests` (#69) and the linuxX64 sibling of the
- * active-migration `LinuxQuicMigrationLoopbackTests` (#67).
+ * Kotlin/Native (linuxX64) passive NAT-rebind migration test — the K/N member of the shared
+ * [QuicPassiveMigrationTestSuite], sibling of the active-migration `LinuxQuicMigrationLoopbackTests`.
  *
- * The client never calls [QuicScope.migrate]; instead the path's *source* address changes
- * underneath it, as a NAT rebind would. This exercises the K/N server-side routing
- * (`LinuxQuicServer.recvInfoFor` per-source recv_info + `ServerConnectionUdpChannel`'s `sendInfo.to`
- * egress): quiche sees the rebound source as the same connection (unchanged DCID) and replies
- * follow the peer to its new 4-tuple.
- *
- * The rebind is simulated by a userspace UDP proxy (no root / netns / tc): the client talks to the
- * proxy, the proxy forwards to the in-repo server, and mid-stream the proxy swaps its *upstream*
- * (server-facing) socket for one with a fresh source port. From the server's view that's a single
- * connection whose source 4-tuple suddenly changed. We assert the stream still round-trips after.
- *
- * The K/N proxy is built on the same io_uring UDP primitives the server uses
- * ([IoUringUdpServerChannel] for the unconnected client-facing socket, [IoUringUdpChannel] for the
- * connected upstream) — fully reactive, no blocking threads. See [RebindingUdpProxy].
- *
- * Native targets compile quiche via cinterop, so there is no `UnsatisfiedLinkError` skip path: on
- * Linux this test always runs (like its migration sibling). Any failure is a real failure, which is
- * the same "must run, never silently skip" discipline `QUIC_MIGRATION_REQUIRE_RUN` enforces on JVM.
+ * Provides the linuxX64 cert resolution and a [RebindingProxy] built on the repo's io_uring UDP
+ * primitives. Native compiles quiche via cinterop, so there is no `UnsatisfiedLinkError` skip path
+ * ([wrapTestBody] stays the default pass-through): on Linux the test always runs.
  */
-class LinuxQuicPassiveMigrationTests {
-    private val testQuicOptions =
-        QuicOptions(
-            alpnProtocols = listOf("test"),
-            verifyPeer = false,
-            idleTimeout = 10.seconds,
-        )
-
+class LinuxQuicPassiveMigrationTests : QuicPassiveMigrationTestSuite() {
     private fun certPath(name: String): String {
         val candidates = listOf("testcerts/$name", "socket-quic/testcerts/$name")
         return candidates.firstOrNull { access(it, F_OK) == 0 }
             ?: error("Test cert not found: $name (tried $candidates)")
     }
 
-    private val tlsConfig
-        get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
 
-    private suspend fun QuicByteStream.echoOnce(payload: String): String {
-        val out = BufferFactory.deterministic().allocate(payload.length)
-        out.writeString(payload, Charset.UTF8)
-        out.resetForRead()
-        write(out, 5.seconds)
-        val resp = read(5.seconds)
-        return if (resp is ReadResult.Data) resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8) else "no_data"
-    }
-
-    @Test
-    fun streamSurvivesPassiveSourceRebind() =
-        runQuicTest {
-            withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
-                // Echo loop: mirror every message back until the stream ends.
-                val serverJob =
-                    launch {
-                        connections {
-                            val stream = acceptStream()
-                            while (true) {
-                                val data = stream.read(8.seconds)
-                                if (data is ReadResult.Data) {
-                                    stream.write(data.buffer, 5.seconds)
-                                } else {
-                                    break
-                                }
-                            }
-                            stream.close()
-                        }
-                    }
-
-                val proxy = RebindingUdpProxy(serverPort = port)
-                val beforeEcho = CompletableDeferred<String>()
-                val afterEcho = CompletableDeferred<String>()
-
-                val clientJob =
-                    launch {
-                        // Client connects to the proxy, unaware of the rebind that happens on the
-                        // proxy's upstream (server-facing) socket.
-                        withQuicConnection("127.0.0.1", proxy.proxyPort, testQuicOptions, timeout = 10.seconds) {
-                            val stream = openStream()
-                            beforeEcho.complete(stream.echoOnce("before"))
-
-                            // Passive rebind: the proxy's source toward the server changes, with NO
-                            // client-side migrate(). The server must keep the stream alive via
-                            // per-source recv_info + sendInfo.to routing.
-                            proxy.rebind()
-
-                            afterEcho.complete(stream.echoOnce("after"))
-                            stream.close()
-                        }
-                    }
-
-                try {
-                    assertEquals("before", beforeEcho.await())
-                    assertEquals(
-                        "after",
-                        afterEcho.await(),
-                        "stream did not round-trip after passive source rebind",
-                    )
-                } finally {
-                    clientJob.cancel()
-                    serverJob.cancel()
-                    proxy.close()
-                }
-            }
-        }
+    override fun createRebindingProxy(serverPort: Int): RebindingProxy = IoUringRebindingProxy(serverPort)
 
     /**
-     * Userspace UDP forwarder that simulates a NAT rebind, on Kotlin/Native. Client ↔ [proxyPort] ↔
-     * server. [rebind] swaps the upstream (server-facing) socket for one with a new source port, so
-     * the server sees the same connection arrive from a new 4-tuple.
-     *
-     * Built on the repo's io_uring UDP primitives rather than blocking sockets/threads:
-     *  - the client-facing socket is bound + unconnected, driven by [IoUringUdpServerChannel] whose
-     *    `recvFrom` yields the client's source address (so replies can be sent back to it);
-     *  - the upstream socket is `connect()`ed to the server and driven by [IoUringUdpChannel].
+     * [RebindingProxy] built on the repo's io_uring UDP primitives rather than blocking
+     * sockets/threads: [IoUringUdpServerChannel] for the unconnected client-facing socket (its
+     * `recvFrom` yields the client source so replies route back), [IoUringUdpChannel] for the
+     * connected upstream.
      *
      * Two suspend pump loops run on [Dispatchers.Default]. [upstreamFd] is an [AtomicInt] so the
      * swap in [rebind] is visible to both loops; closing the old fd makes the suspended upstream
      * `receive` return `-ECANCELED` (exactly as the server's `closeFd()` unblocks its recvmsg), so
      * the server-to-client loop simply re-reads the new upstream and continues.
      */
-    private class RebindingUdpProxy(
+    private class IoUringRebindingProxy(
         private val serverPort: Int,
-    ) {
+    ) : RebindingProxy {
         private val bufferFactory = BufferFactory.deterministic()
 
         // Client-facing bound socket (unconnected) — learns the client's source on the first packet.
         private val clientFd: Int = openBoundLoopbackSocket()
-        val proxyPort: Int = boundPortOf(clientFd)
+        override val proxyPort: Int = boundPortOf(clientFd)
         private val clientChannel = IoUringUdpServerChannel(clientFd)
 
         // Upstream (server-facing) connected socket; swapped on rebind. AtomicInt gives the pump
@@ -235,14 +136,13 @@ class LinuxQuicPassiveMigrationTests {
             }
         }
 
-        /** Swap the upstream socket for a fresh source port — the NAT rebind. */
-        fun rebind() {
+        override fun rebind() {
             val old = upstreamFd.value
             upstreamFd.value = newUpstream()
             close(old) // unblocks the in-flight upstream receive (-ECANCELED); the loop re-reads the new fd
         }
 
-        suspend fun close() {
+        override suspend fun close() {
             // Stop the loops before closing the client fd / freeing recv buffers — the cancellation
             // path of submitAndWait waits for the kernel to release any in-flight buffer first.
             c2sJob.cancelAndJoin()


### PR DESCRIPTION
Closes Task 1 of #74.

## What
Ports the JVM `QuicPassiveMigrationTests` (#69) to linuxX64, closing the **Linux K/N passive-rebind** coverage gap surfaced by the post-#72 per-platform audit. It's the passive-rebind sibling of the active-migration `LinuxQuicMigrationLoopbackTests` (#67).

## How it works
The client never calls `migrate()`. A userspace `RebindingUdpProxy` sits between client and the in-repo K/N server and, mid-stream, swaps its **upstream** (server-facing) UDP socket for one with a fresh source port. From the server's view that's a single connection (unchanged DCID) whose source 4-tuple suddenly changed — a NAT rebind (RFC 9000 §9.3). The test asserts the stream still round-trips after the swap, exercising:
- `LinuxQuicServer.recvInfoFor` — per-source `recv_info` so quiche recognises the rebound source as the same connection, and
- `ServerConnectionUdpChannel`'s `sendInfo.to` egress — replies follow the peer to its new 4-tuple.

## Design notes
- The proxy is built on the repo's existing io_uring UDP primitives — `IoUringUdpServerChannel` for the unconnected client-facing socket (its `recvFrom` yields the client source so replies route back) and `IoUringUdpChannel` for the connected upstream — rather than blocking sockets/threads. Fully reactive, no polling.
- `rebind()` closes the old upstream fd; the suspended upstream `receive()` then returns `-ECANCELED` (the same mechanism the server's `closeFd()` uses to unblock its `recvmsg`), so the server→client pump loop simply re-reads the swapped fd (`AtomicInt`) and continues.
- Native compiles quiche via cinterop, so there's **no `UnsatisfiedLinkError` skip path** — on Linux the test always runs, the same "must run, never silently skip" discipline `QUIC_MIGRATION_REQUIRE_RUN` enforces on JVM.

## CI
Rides along on the existing `:socket-quic:linuxX64Test` step in `build-linux.yaml` (~line 440) — **no workflow change needed**.

## Validation (local, this WSL2 Linux box)
- `./gradlew :socket-quic:linuxX64Test --tests "*PassiveMigration*"` → **1 test, 0 skipped, passes** (~1.0s).
- 3/3 stable across `--rerun-tasks` repeats (concurrency check).
- `./gradlew :socket-quic:ktlintCheck` clean.

Coverage matrix cell **Passive rebind / Linux K/N** moves ❌ → ✅. (JS server-role, #74 Task 2, follows in a separate PR.)