### PR TITLE
test(quic): wire :socket-quic:jsNodeTest into CI + document JS QUIC gap (#74 Task 2)

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -318,9 +318,17 @@ jobs:
           ./gradlew :socket-quic:quicEchoJar -PquicEchoAllArches=true
           --no-configuration-cache ${{ inputs.gradle-args }}
 
+      # NOTE: :jsTest above is the ROOT project's JS suite. :socket-quic:jsNodeTest
+      # is a SEPARATE task (the socket-quic module's common QUIC suite + JS gap
+      # tests, running on Node) that was never wired in — so Node QUIC went
+      # entirely unvalidated in CI (#74 Task 2). It needs no native quiche (the
+      # JS impls are documented placeholders that throw), so it just rides the
+      # Node already on this runner. Browser/wasmJs stay out (no raw UDP / lower
+      # priority per #74).
       - name: Run checks and tests
         run: >-
           ./gradlew :jvmTest :jsTest :linuxX64Test :testDebugUnitTest :ktlintCheck
+          :socket-quic:jsNodeTest
           :socket-quic:jvmProcessResources :socket-quic:ktlintCheck
           -PquicEchoAllArches=true
           --no-configuration-cache ${{ inputs.gradle-args }}

--- a/socket-quic/src/jsTest/kotlin/com/ditchoom/socket/quic/JsQuicGapTests.kt
+++ b/socket-quic/src/jsTest/kotlin/com/ditchoom/socket/quic/JsQuicGapTests.kt
@@ -1,0 +1,68 @@
+package com.ditchoom.socket.quic
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Diagnostic / contract tests documenting the **known JS (Node) QUIC gap** (issue #74, Task 2).
+ *
+ * QUIC is not implemented on JS: a koffi-backed Node binding was explored and deferred on
+ * zero-copy grounds (see `WithQuicConnection.js.kt` + branch `feature/socket-quic-js-wip`). The
+ * `jsMain` actuals are documented placeholders that throw [UnsupportedOperationException].
+ *
+ * Task 2's first step was meant to be diagnostic — load the Node quiche binding and handshake.
+ * That step immediately surfaces the real state: there is no binding, only the documented
+ * placeholders. So per the issue's Risk flag, this scopes down to *documenting the gap with a
+ * test that actually runs* rather than forcing a non-existent client/server green.
+ *
+ * Crucially these are **not silent skips** — the failure mode #67/#72 fixed on Android, where a
+ * "green" suite actually executed zero QUIC cases. They run on `jsNode` in CI and positively
+ * assert the contract: the entry points throw [UnsupportedOperationException] (a cleanly catchable
+ * signal, deliberately not [Error]/`NotImplementedError`, so callers using `catch (Exception)` get
+ * a clean signal). If/when JS QUIC lands, these tests will fail — forcing real loopback / migration
+ * coverage to replace this placeholder, exactly as intended.
+ */
+class JsQuicGapTests {
+    private val quicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    @Test
+    fun withQuicConnection_is_an_unsupported_placeholder_on_js() =
+        runQuicTest {
+            val error =
+                assertFailsWith<UnsupportedOperationException> {
+                    withQuicConnection("127.0.0.1", 4433, quicOptions) {
+                        error("unreachable: JS QUIC client must not establish a connection")
+                    }
+                }
+            assertTrue(
+                error.message?.contains("not yet implemented", ignoreCase = true) == true,
+                "expected the documented JS placeholder message, got: ${error.message}",
+            )
+        }
+
+    @Test
+    fun withQuicServer_is_an_unsupported_placeholder_on_js() =
+        runQuicTest {
+            val error =
+                assertFailsWith<UnsupportedOperationException> {
+                    withQuicServer(
+                        port = 0,
+                        tlsConfig = QuicTlsConfig(certChainPath = "unused", privKeyPath = "unused"),
+                        quicOptions = quicOptions,
+                    ) {
+                        error("unreachable: JS QUIC server must not bind")
+                    }
+                }
+            assertTrue(
+                error.message?.contains("not supported on JS", ignoreCase = true) == true,
+                "expected the documented JS placeholder message, got: ${error.message}",
+            )
+        }
+}


### PR DESCRIPTION
Closes Task 2 of #74.

## The diagnostic finding
Task 2's first step was meant to be diagnostic — load a Node quiche binding and handshake. Running it immediately surfaces the real state: **there is no Node quiche binding.** The `jsMain` QUIC actuals (`WithQuicConnection.js.kt`, `WithQuicServer.js.kt`) are documented placeholders that throw `UnsupportedOperationException` — a koffi-backed binding was explored and deferred on zero-copy grounds (branch `feature/socket-quic-js-wip`). So there is no FFI/`dgram`/marshalling bug to find; there is a documented, unimplemented feature.

Per the issue's **Risk flag** ("if the Node binding turns out to be non-functional or absent, scope down to *document the gap + a test*, but don't make it pass by silently skipping"), this PR does exactly that.

## Two parts

### 1. Wire `:socket-quic:jsNodeTest` into CI — the real coverage win
The issue noted `build-linux.yaml` runs `:jsTest` (the **root** project) but never `:socket-quic:jsNodeTest`. It turns out the module's **common QUIC suite already runs on Node** — `:socket-quic:jsNodeTest` executes **137 tests across 13 classes, all green, 0 skipped** (QUIC API/options/stream-id/error/connection-state behavioral-parity tests). They simply were never run in CI, so all of it was unvalidated on Node. Added `:socket-quic:jsNodeTest` to the "Run checks and tests" step. No native quiche needed (placeholders throw); rides the Node already on the runner.

### 2. `JsQuicGapTests` — document the gap with tests that *run*
Two cases that positively assert the contract on `jsNode`:
- `withQuicConnection` throws `UnsupportedOperationException` (message: "not yet implemented")
- `withQuicServer` throws `UnsupportedOperationException` (message: "not supported on JS")

These are deliberately **not silent skips** — the exact failure mode #67/#72 fixed on Android, where a "green" suite ran zero cases. They assert `UnsupportedOperationException` (a cleanly catchable signal, not `Error`/`NotImplementedError`). When JS QUIC eventually lands, these tests fail and force real loopback / migration coverage to replace them.

## Out of scope
- Implementing JS QUIC (deferred; tracked on `feature/socket-quic-js-wip`).
- Browser JS (no raw UDP, unsupported by design) and wasmJs (lower priority per #74).

## Validation (local, this WSL2 box)
- `./gradlew :socket-quic:jsNodeTest` → **137 tests, 0 skipped, 0 failures** (incl. the 2 new gap tests, confirmed via the JUnit XML).
- `./gradlew :socket-quic:ktlintCheck` clean; workflow YAML validates.

Coverage matrix cell **Server role / JS** is addressed honestly: the entry points are exercised and the gap is documented + guarded, and the module's Node suite now actually runs in CI.