### PR TITLE
fix(linux): map EBADF/ECANCELED to SocketClosedException (deterministic fix for pendingReadDuringPeerReset flake)

### DIFF
--- a/src/linuxMain/kotlin/com/ditchoom/socket/IoUringUtils.kt
+++ b/src/linuxMain/kotlin/com/ditchoom/socket/IoUringUtils.kt
@@ -636,6 +636,15 @@ internal fun mapErrnoToException(
         ECONNREFUSED -> SocketConnectionException.Refused(null, 0, platformError = message)
         ECONNRESET, ECONNABORTED -> SocketClosedException.ConnectionReset(message)
         ENOTCONN, EPIPE, ESHUTDOWN -> SocketClosedException.BrokenPipe(message)
+        // The socket's fd is gone underneath an in-flight op — the connection is closed.
+        // EBADF: the read path won the peer-close race, ran closeInternal() (fd → -1), and a
+        //   concurrent send/recv then hit the closed fd. ECANCELED: io_uring cancels in-flight
+        //   SQEs when their fd is closed (coroutine cancellation is handled separately in
+        //   submitAndWait, which rethrows CancellationException before reaching here). Both mean
+        //   "socket closed", so they must surface as SocketClosedException — not the generic
+        //   SocketIOException — to honour the read/write contract regardless of which errno the
+        //   kernel happens to deliver. See LinuxConcurrentCloseTests + LinuxExceptionMappingTests.
+        EBADF, ECANCELED -> SocketClosedException.General(message)
         ENETUNREACH -> SocketConnectionException.NetworkUnreachable(message)
         EHOSTUNREACH -> SocketConnectionException.HostUnreachable(message)
         ETIMEDOUT, ETIME -> SocketTimeoutException("$operation timed out")

--- a/src/linuxTest/kotlin/com/ditchoom/socket/LinuxConcurrentCloseTests.kt
+++ b/src/linuxTest/kotlin/com/ditchoom/socket/LinuxConcurrentCloseTests.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.socket
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Deterministic regression for the io_uring close-during-pending-I/O race — the bug behind the
+ * intermittent `ExceptionConformanceTests.pendingReadDuringPeerReset` failure on Linux ARM64.
+ *
+ * That harness test depends on toxiproxy/kernel timing for *which* errno a peer-reset surfaces, so
+ * it can't deterministically isolate the defect. This one does, with no harness and no network
+ * timing: it closes the socket out from under a parked `read()` on plain loopback. The in-flight
+ * io_uring `recv` then completes with `-ECANCELED`/`-EBADF` (fd closed), or — if the close wins the
+ * race — the next op trips the `sockfd < 0` guard. **Every branch must surface a
+ * [SocketClosedException]**; before the EBADF/ECANCELED mapping fix, the cancelled op produced a
+ * generic [SocketIOException] instead. Paired with the pure-mapping [LinuxExceptionMappingTests]
+ * (`ebadf_producesSocketClosed`, `ecanceled_producesSocketClosed`), this locks the contract end to
+ * end with zero reliance on scheduling.
+ */
+class LinuxConcurrentCloseTests {
+    @Test
+    fun concurrentCloseDuringPendingRead_surfacesAsSocketClosed() =
+        runTestNoTimeSkipping {
+            val server = ServerSocket.allocate()
+            val flow = server.bind()
+
+            // Accept the connection and hold it open without ever writing, so the client's read
+            // genuinely parks on the kernel recv instead of returning data.
+            val serverJob =
+                launch(Dispatchers.Default) {
+                    val accepted = flow.first()
+                    // Park here; the test drives the lifecycle from the client side.
+                    try {
+                        accepted.read(10.seconds)
+                    } catch (_: Throwable) {
+                        // Connection torn down by the test — expected.
+                    } finally {
+                        accepted.close()
+                    }
+                }
+
+            val client = ClientSocket.connect(server.port(), hostname = "127.0.0.1", timeout = 5.seconds)
+            try {
+                // Park a read in a child coroutine. UNDISPATCHED runs the body up to its first real
+                // suspension — the io_uring recv submit — so the kernel-side read is registered
+                // before async() returns.
+                val parkedRead =
+                    async<Throwable?>(start = CoroutineStart.UNDISPATCHED) {
+                        try {
+                            client.read(10.seconds)
+                            null
+                        } catch (t: Throwable) {
+                            t
+                        }
+                    }
+                yield() // let the recv SQE actually reach the ring before we close the fd
+
+                // Close the fd out from under the parked recv — the deterministic trigger.
+                client.close()
+
+                val thrown = parkedRead.await()
+                assertNotNull(thrown, "expected the parked read to throw once its socket was closed")
+                assertIs<SocketClosedException>(
+                    thrown,
+                    "close-during-pending-read must surface as SocketClosedException, got " +
+                        "${thrown::class.simpleName}(${thrown.message})",
+                )
+            } finally {
+                client.close()
+                serverJob.cancel()
+                server.close()
+            }
+        }
+}

--- a/src/linuxTest/kotlin/com/ditchoom/socket/LinuxExceptionMappingTests.kt
+++ b/src/linuxTest/kotlin/com/ditchoom/socket/LinuxExceptionMappingTests.kt
@@ -51,6 +51,22 @@ class LinuxExceptionMappingTests {
     }
 
     @Test
+    fun ebadf_producesSocketClosed() {
+        // EBADF surfaces when an in-flight send/recv hits an fd the peer-close race already
+        // closed (closeInternal set sockfd = -1). The fd is gone → the socket is closed.
+        val ex = mapErrnoToException(EBADF, "send")
+        assertIs<SocketClosedException>(ex)
+    }
+
+    @Test
+    fun ecanceled_producesSocketClosed() {
+        // io_uring completes in-flight SQEs with -ECANCELED when their fd is closed (a deliberate
+        // close, not coroutine cancellation — that path rethrows CancellationException upstream).
+        val ex = mapErrnoToException(ECANCELED, "recv")
+        assertIs<SocketClosedException>(ex)
+    }
+
+    @Test
     fun enetunreach_producesNetworkUnreachable() {
         val ex = mapErrnoToException(ENETUNREACH, "connect")
         assertIs<SocketConnectionException.NetworkUnreachable>(ex)
@@ -151,6 +167,20 @@ class LinuxExceptionMappingTests {
                 e
             }
         assertIs<SocketClosedException.BrokenPipe>(ex)
+    }
+
+    @Test
+    fun throwFromResult_ebadf() {
+        // The exact path the failing harness test hit: an io_uring send returned -EBADF (the read
+        // path had already closed the fd), throwFromResult negates it and maps. Must be a clean
+        // SocketClosedException, not the generic SocketIOException that escaped the test's catch.
+        val ex =
+            try {
+                throwFromResult(-EBADF, "send")
+            } catch (e: SocketException) {
+                e
+            }
+        assertIs<SocketClosedException>(ex)
     }
 
     @Test


### PR DESCRIPTION
## Symptom
`ExceptionConformanceTests.pendingReadDuringPeerReset_producesSocketClosedException` failed intermittently on the **Linux ARM64 (native)** CI job (observed on a recent PR run). The failure looked like a flake but is a **deterministic mapping bug** the timing merely exposes.

## Root cause
From the ARM64 stack trace, the parked-read write-loop threw:
```
com.ditchoom.socket.SocketIOException: send failed: Bad file descriptor (errno=9)
  at LinuxClientSocket.handleWriteError ...
```
Sequence in `LinuxClientSocket`:
1. A parked `read()` and the concurrent `write()` loop share one `sockfd`.
2. The peer reset arrives; the **read path wins the race** and calls `closeInternal()` → fd closed, `sockfd = -1`.
3. The in-flight `write`'s io_uring `send` hits the now-closed fd → **EBADF**.
4. `mapErrnoToException` routed `EBADF` (and the sibling `ECANCELED` that io_uring delivers for in-flight SQEs when their fd is closed) to the generic `else -> SocketIOException` branch — **not** `SocketClosedException`.
5. The test only catches `SocketClosedException`, so the generic exception escaped → failed run.

Kernel scheduling only decides *which* errno surfaces (EPIPE / ECONNRESET / EBADF / ECANCELED); the missing mapping entry is the real defect.

## Fix
Map `EBADF` and `ECANCELED` → `SocketClosedException.General`. Both unambiguously mean "the socket's fd is gone" on the client path — coroutine cancellation is handled separately in `submitAndWait` (it rethrows `CancellationException` before reaching the mapping). This is consistent with the `sockfd < 0` guard already at the top of `read()`/`write()`. (`LinuxServerSocket` already treats `EBADF`/`ECANCELED` as shutdown on its accept side — same semantic.)

## Deterministic tests (the "fully deterministic testing system" ask)
The errno→exception **mapping** is the deterministic contract surface, already unit-tested per-errno with zero I/O. The bug was a *missing entry*, so the durable guarantee is to complete the mapping and lock it there:
- **`LinuxExceptionMappingTests`** (pure, no I/O): `ebadf_producesSocketClosed`, `ecanceled_producesSocketClosed`, `throwFromResult_ebadf`.
- **`LinuxConcurrentCloseTests`** (new, no toxiproxy / no kernel-timing): closes the fd under a parked `read()` on plain loopback and asserts `SocketClosedException` — reproduces the close/IO race on the affected platform deterministically.

The flaky toxiproxy integration test (`pendingReadDuringPeerReset`) now passes because *any* of those connection-gone errnos lands as `SocketClosedException`.

## Verification
- All three new tests **FAIL with the mapping reverted** and **PASS with it** (negative check run locally).
- `:linuxX64Test` mapping + concurrent-close suites green; `ktlintCheck` clean.

Independent of the #74 QUIC PRs (#75/#76) — this is a base-module fix that makes the ARM64 job reliably green for all branches.