### PR TITLE
test(quic): validate FFM-on-macOS + Apple K/N migration; re-enable macOS jvmTest (#70)

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -91,23 +91,41 @@ jobs:
             cd ${{ github.workspace }}
 
             QUICHE_DYLIB="/tmp/quiche-src/target/$RUST_TARGET/release/libquiche.dylib"
+            QUICHE_STATIC="/tmp/quiche-src/target/$RUST_TARGET/release/libquiche.a"
             if [ -f "$QUICHE_DYLIB" ]; then
               mkdir -p $DEST
               cp "$QUICHE_DYLIB" "$DEST/libquiche.dylib"
               strip -x "$DEST/libquiche.dylib"
-              # Build thin JNI shim that links to quiche dynamically
-              # (static linking Rust .a into C .so breaks Rust runtime init → panic)
-              cc -shared -fPIC -Wall \
+              cp "$QUICHE_STATIC" "$DEST/libquiche.a"
+              # Build a SELF-CONTAINED JNI shim: -force_load pulls every quiche
+              # (+ vendored BoringSSL) symbol from libquiche.a into the dylib, so
+              # it re-exports the full quiche C API. This is required by BOTH
+              # backends on JDK 21+:
+              #   - JNI: resolves Java_..._n* without a runtime dep on libquiche.dylib.
+              #   - FFM: SymbolLookup.libraryLookup() only finds symbols *defined*
+              #     by the dylib, not its dynamic deps, so a thin `-lquiche` shim
+              #     would let create() succeed then throw UnsatisfiedLinkError on the
+              #     first quiche_* downcall. Mirrors createBuildJvmJniShimTask (macOS).
+              # (The old "static linking breaks Rust runtime init → panic" note was
+              # stale: quiche 0.28 + the 5e55a5f sockaddr-lifetime fix run the
+              # force_load static shim cleanly — locally verified on macos-arm64.)
+              cc -dynamiclib -O2 -Wall \
                 -o $DEST/libquiche_jni.dylib \
                 socket-quic/src/jni/quiche_jni.c \
                 -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin \
                 -I socket-quic/libs/quiche/include \
-                -L$DEST -lquiche \
-                -Wl,-rpath,@loader_path \
+                -Wl,-force_load,"$DEST/libquiche.a" \
+                -Wl,-install_name,@rpath/libquiche_jni.dylib \
                 -target $(echo $RUST_TARGET | sed 's/aarch64/arm64/;s/x86_64/x86_64/') \
                 && strip -x $DEST/libquiche_jni.dylib \
                 && echo "Built $DEST/libquiche_jni.dylib ($(du -h $DEST/libquiche_jni.dylib | cut -f1))" \
                 && echo "With $DEST/libquiche.dylib ($(du -h $DEST/libquiche.dylib | cut -f1))"
+              # Write the Gradle build markers so prepareQuicheNativeLib treats these
+              # as authoritative and does NOT trigger a second from-source quiche
+              # build inside the 60-min job. Keyed on quiche version, matching the
+              # markers createBuildJvmShared*/createBuildJvmJniShimTask write.
+              echo "quiche 0.28.0 (CI macOS prebuilt)" > "$DEST/.built-0.28.0"
+              echo "quiche 0.28.0 JNI shim (CI macOS prebuilt)" > "$DEST/.jni-built-0.28.0"
             else
               echo "WARN: libquiche.dylib not found at $QUICHE_DYLIB"
             fi
@@ -139,19 +157,48 @@ jobs:
       - name: Disable harness on macOS (no working Docker fixture)
         run: echo "HARNESS_DISABLED=true" >> $GITHUB_ENV
 
-      # :socket-quic:jvmTest is excluded on macOS for the same reason it's
-      # excluded on Windows and isolated as continue-on-error on Linux: the
-      # quiche-0.28 native panic from `quiche_conn_recv`
-      # (quiche/src/ffi.rs:2059:14). On Linux it SIGABRTs cleanly; on macOS
-      # it deadlocks the JVM, which exhausts the job's 60-min timeout
-      # without producing a useful failure mode. Tracked in TODO.md as the
-      # \"socket-quic:jvmTest quiche-0.28 panic\" item; same path forward
-      # for both platforms.
       - name: Run Apple tests
         run: >-
           ./gradlew :macosX64Test :macosArm64Test :iosSimulatorArm64Test
           :tvosSimulatorArm64Test :watchosSimulatorArm64Test :ktlintCheck
           :socket-quic:jvmProcessResources
+          --no-configuration-cache ${{ inputs.gradle-args }}
+
+      # :socket-quic:jvmTest on macOS — re-enabled (issue #70). It was excluded
+      # because of the quiche-0.28 `quiche_conn_recv` panic (quiche/src/ffi.rs:2059
+      # "unsupported address type"); that was a dangling-sockaddr GC race fixed in
+      # 5e55a5f (commonJvmMain/commonMain, so it covers the macOS JNI path too).
+      # Verified locally on macos-arm64: 166/166 green on JNI and on FFM.
+      #
+      # This is the only place FFM-on-macOS runs, and the only place the IS_BSD
+      # sockaddr paths (sin_len byte 0, AF_INET6==30, sendInfoToAddr/decodePathKey
+      # during a real migration) execute — FFM is the deterministic JDK 21+ macOS
+      # backend, so these had never run in CI before.
+      #
+      # QUIC_MIGRATION_REQUIRE_RUN=1 turns a clean skip of the active-migration test
+      # into a hard failure, so a broken native can't pass as green. The must-run
+      # case (streamSurvivesActiveMigrationToNewLocalPort) migrates to a fresh
+      # ephemeral source port on 127.0.0.1 — a distinct 4-tuple, fully validated by
+      # quiche — so it needs NO privileged loopback alias. The 127.0.0.2 variant
+      # (which would need `ifconfig lo0 alias`) stays a clean skip here.
+      - name: Run socket-quic JVM tests (JNI)
+        timeout-minutes: 8
+        env:
+          QUIC_MIGRATION_REQUIRE_RUN: "1"
+        run: >-
+          ./gradlew :socket-quic:jvmTest --continue
+          --no-configuration-cache ${{ inputs.gradle-args }}
+
+      # Same suite on the FFM backend. -PquicheJvmBackend=ffm prepends the java21
+      # (FFM) output so its loader shadows the base JNI one, then loads the
+      # self-contained shim via Panama. Exercises FfmQuicheApi's IS_BSD decode and
+      # the FFM migration flush path on BSD layout.
+      - name: Run socket-quic JVM tests (FFM backend)
+        timeout-minutes: 8
+        env:
+          QUIC_MIGRATION_REQUIRE_RUN: "1"
+        run: >-
+          ./gradlew :socket-quic:jvmTest -PquicheJvmBackend=ffm --continue
           --no-configuration-cache ${{ inputs.gradle-args }}
 
       # QUIC harness on macOS — runs the JVM `QuicEchoTestServer` natively on
@@ -160,14 +207,13 @@ jobs:
       # `:socket-quic:quicEchoJar` includes the macOS quiche dylibs from the
       # earlier build step, so it runs end-to-end with no extra runtime deps.
       #
-      # Risk: the quiche-0.28 native panic from `quiche_conn_recv` (the same
-      # one that excludes `:socket-quic:jvmTest` on macOS) might trigger
-      # server-side here too. If it does, the deadlock is bounded by the
-      # `timeout` wrapper and `kill` cleanup; the Apple QUIC tests below
-      # still attempt to connect and silently skip on connection failure
-      # via QuicHarnessIntegrationTests.withHarness's catch. The
-      # `continue-on-error` on the launch step prevents a server-side
-      # panic from failing the whole job.
+      # The quiche-0.28 `quiche_conn_recv` panic that used to threaten this
+      # server is fixed (5e55a5f) and :socket-quic:jvmTest now runs green on
+      # macOS above, so this is no longer the hazard it was. The defensive
+      # `continue-on-error` + `timeout`/`kill` cleanup stay: the Apple QUIC
+      # tests still connect and silently skip on connection failure via
+      # QuicHarnessIntegrationTests.withHarness's catch, so a server-side
+      # hiccup never fails the whole job.
       # QUIC peer TLS trust (Phase 2 macOS-peer spike). Apple's Network.framework
       # always evaluates the QUIC peer against the system trust store — a custom
       # verify_block SIGABRTs under recent macOS hardening (PR #54), so we make

--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -338,9 +338,21 @@ fun createBuildJvmJniShimTask(
         description = "Build quiche JNI shim for $os-$arch (JDK 8–20 fallback path)"
         dependsOn(buildShared)
         inputs.property("quicheVersion", quicheVersion)
-        inputs.file("src/jni/quiche_jni.c")
-        outputs.file(markerFile)
-        onlyIf { !markerFile.exists() }
+        val jniSourceFile = projectDir.resolve("src/jni/quiche_jni.c")
+        inputs.file(jniSourceFile)
+        outputs.files(outputLib, markerFile)
+        // Rebuild when the marker is missing, the shim itself is gone, OR the JNI
+        // source has been edited since the marker was written. The marker is keyed
+        // only on quiche *version*, so without the source-mtime check an edit to
+        // quiche_jni.c (e.g. #63 adding nSockAddr*) leaves a stale shim in place —
+        // exactly what made macOS jvmTest fail with UnsatisfiedLinkError on a
+        // version-matched-but-stale dylib. CI side-steps this by keying its native
+        // cache on hashFiles(quiche_jni.c); local dev needs this guard.
+        onlyIf {
+            !markerFile.exists() ||
+                !outputLib.exists() ||
+                jniSourceFile.lastModified() > markerFile.lastModified()
+        }
 
         doLast {
             val quicheStatic = outputDir.resolve("libquiche.a")

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -261,4 +261,3 @@ private fun ReadBuffer.toNSData(): NSData {
     // Last resort: empty data
     return NSData()
 }
-

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMigrationLoopbackTests.kt
@@ -20,14 +20,20 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * End-to-end active connection migration over loopback (slice 3b harness).
  *
- * The client connects on 127.0.0.1, then [QuicScope.migrate]s to the loopback
- * alias 127.0.0.2 (all of 127.0.0.0/8 is loopback on Linux — no NIC/netem/root).
- * The driver opens a second socket bound to 127.0.0.2, probes it, and on
- * validation switches the active path. We assert migration succeeds and that the
- * stream still round-trips afterwards — proving streams survive the path switch.
+ * The client connects on 127.0.0.1, then [QuicScope.migrate]s to a new local path.
+ * The driver opens a second socket bound to that path, probes it, and on validation
+ * switches the active path. We assert migration succeeds and that the stream still
+ * round-trips afterwards — proving streams survive the path switch.
  *
- * Runs in CI (needs the built quiche native lib + Linux loopback aliasing); skips
- * cleanly elsewhere.
+ * Two variants, differing only in the new local path:
+ *  - [streamSurvivesActiveMigrationToNewLocalPort] migrates to a fresh ephemeral
+ *    port on 127.0.0.1 — a distinct 4-tuple, so quiche runs full path validation.
+ *    Needs no privileged setup, so it runs everywhere (the must-run case).
+ *  - [streamSurvivesActiveMigrationToLoopbackAlias] migrates to 127.0.0.2, adding
+ *    address-change coverage. Free on Linux (all 127.0.0.0/8 is loopback); needs a
+ *    privileged `ifconfig lo0 alias` on BSD/macOS, so it skips cleanly there.
+ *
+ * Runs in CI (needs the built quiche native lib); skips cleanly without a native lib.
  *
  * Exercises the full two-party path-validation handshake: the in-repo echo server feeds quiche
  * the real per-datagram source as recvInfo.from (so a migrated client's new address is seen as a
@@ -75,15 +81,24 @@ class QuicMigrationLoopbackTests {
         }
     }
 
-    /** Verify 127.0.0.2 is bindable (Linux: yes by default; macOS needs an alias) — skip if not. */
+    /**
+     * Verify 127.0.0.2 is bindable (Linux: yes by default; macOS/BSD needs a
+     * privileged `ifconfig lo0 alias` that we don't require). This is a plain
+     * skip that QUIC_MIGRATION_REQUIRE_RUN does NOT escalate: the alias test is
+     * supplemental IP-change coverage, while [streamSurvivesActiveMigrationToNewLocalPort]
+     * carries the unprivileged must-run migration guarantee on every platform.
+     */
     private fun assumeLoopbackAliasBindable() {
-        try {
-            java.nio.channels.DatagramChannel
-                .open()
-                .use { it.bind(InetSocketAddress("127.0.0.2", 0)) }
-        } catch (e: Exception) {
-            skipOrFail("Loopback alias 127.0.0.2 not bindable on this host: ${e.message}")
-        }
+        val bindable =
+            try {
+                java.nio.channels.DatagramChannel
+                    .open()
+                    .use { it.bind(InetSocketAddress("127.0.0.2", 0)) }
+                true
+            } catch (e: Exception) {
+                false
+            }
+        assumeTrue("Loopback alias 127.0.0.2 not bindable on this host (needs a privileged alias)", bindable)
     }
 
     private suspend fun QuicByteStream.echoOnce(payload: String): String {
@@ -96,68 +111,88 @@ class QuicMigrationLoopbackTests {
     }
 
     @Test
+    fun streamSurvivesActiveMigrationToNewLocalPort() =
+        runBlocking(Dispatchers.IO) {
+            // Migrating to a fresh ephemeral source port on 127.0.0.1 is a distinct
+            // 4-tuple (PathKey includes the port — see SockAddrDecodeTest), so quiche
+            // runs the full PATH_CHALLENGE/RESPONSE validation exactly as it would for
+            // a new IP. Unlike the 127.0.0.2 variant this needs no loopback alias, so
+            // it runs unprivileged on every platform — including BSD/macOS, where only
+            // 127.0.0.1 is bound by default. This is the path #70 wanted exercised on
+            // BSD layout (sendInfoToAddr/decodePathKey during a real flush).
+            migrationTest(localHost = "127.0.0.1", localPort = 0)
+        }
+
+    @Test
     fun streamSurvivesActiveMigrationToLoopbackAlias() =
         runBlocking(Dispatchers.IO) {
             assumeLoopbackAliasBindable()
-            skipOnMissingNativeLib {
-                withTimeout(20.seconds) {
-                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
-                        // Echo loop: mirror every message back until the stream ends.
-                        val serverJob =
-                            launch(Dispatchers.IO) {
-                                connections {
-                                    val stream = acceptStream()
-                                    while (true) {
-                                        val data = stream.read(8.seconds)
-                                        if (data is ReadResult.Data) {
-                                            stream.write(data.buffer, 5.seconds)
-                                        } else {
-                                            break
-                                        }
+            migrationTest(localHost = "127.0.0.2", localPort = 0)
+        }
+
+    private suspend fun migrationTest(
+        localHost: String,
+        localPort: Int,
+    ) {
+        skipOnMissingNativeLib {
+            withTimeout(20.seconds) {
+                withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
+                    // Echo loop: mirror every message back until the stream ends.
+                    val serverJob =
+                        launch(Dispatchers.IO) {
+                            connections {
+                                val stream = acceptStream()
+                                while (true) {
+                                    val data = stream.read(8.seconds)
+                                    if (data is ReadResult.Data) {
+                                        stream.write(data.buffer, 5.seconds)
+                                    } else {
+                                        break
                                     }
-                                    stream.close()
                                 }
+                                stream.close()
                             }
-                        delay(100)
-
-                        val migrationResult = CompletableDeferred<MigrationResult>()
-                        val beforeEcho = CompletableDeferred<String>()
-                        val afterEcho = CompletableDeferred<String>()
-
-                        val clientJob =
-                            launch(Dispatchers.IO) {
-                                // Connect on 127.0.0.1 so the peer is reachable from the 127.0.0.2 path too.
-                                withQuicConnection("127.0.0.1", port, testQuicOptions, timeout = 10.seconds) {
-                                    val stream = openStream()
-                                    beforeEcho.complete(stream.echoOnce("before"))
-
-                                    // Active migration to a different loopback source address.
-                                    val result = migrate(localHost = "127.0.0.2", localPort = 0)
-                                    migrationResult.complete(result)
-
-                                    afterEcho.complete(stream.echoOnce("after"))
-                                    stream.close()
-                                }
-                            }
-
-                        try {
-                            assertEquals("before", withTimeout(12.seconds) { beforeEcho.await() })
-                            val result = withTimeout(12.seconds) { migrationResult.await() }
-                            assertTrue(
-                                result is MigrationResult.Succeeded,
-                                "expected migration to succeed, got $result",
-                            )
-                            assertEquals(
-                                "after",
-                                withTimeout(12.seconds) { afterEcho.await() },
-                                "stream did not round-trip after migration",
-                            )
-                        } finally {
-                            clientJob.cancel()
-                            serverJob.cancel()
                         }
+                    delay(100)
+
+                    val migrationResult = CompletableDeferred<MigrationResult>()
+                    val beforeEcho = CompletableDeferred<String>()
+                    val afterEcho = CompletableDeferred<String>()
+
+                    val clientJob =
+                        launch(Dispatchers.IO) {
+                            // Connect on 127.0.0.1 so the peer is reachable from the migrated path too.
+                            withQuicConnection("127.0.0.1", port, testQuicOptions, timeout = 10.seconds) {
+                                val stream = openStream()
+                                beforeEcho.complete(stream.echoOnce("before"))
+
+                                // Active migration to a new local source (different port and/or address).
+                                val result = migrate(localHost = localHost, localPort = localPort)
+                                migrationResult.complete(result)
+
+                                afterEcho.complete(stream.echoOnce("after"))
+                                stream.close()
+                            }
+                        }
+
+                    try {
+                        assertEquals("before", withTimeout(12.seconds) { beforeEcho.await() })
+                        val result = withTimeout(12.seconds) { migrationResult.await() }
+                        assertTrue(
+                            result is MigrationResult.Succeeded,
+                            "expected migration to succeed, got $result",
+                        )
+                        assertEquals(
+                            "after",
+                            withTimeout(12.seconds) { afterEcho.await() },
+                            "stream did not round-trip after migration",
+                        )
+                    } finally {
+                        clientJob.cancel()
+                        serverJob.cancel()
                     }
                 }
             }
         }
+    }
 }


### PR DESCRIPTION
Closes #70 (QUIC Gap 5 — the last migration follow-up, which needed Apple hardware).

## Validated locally on `macos-arm64` (Gradle on JDK 21)
| Check | Result |
|---|---|
| `:socket-quic:jvmTest` (JNI, `QUIC_MIGRATION_REQUIRE_RUN=1`) | **166/166, 0 fail** — `quiche_conn_recv` panic gone (covered by `5e55a5f`) |
| `:socket-quic:jvmTest -PquicheJvmBackend=ffm` | **166/166, 0 fail** — first run of FFM + the `IS_BSD` sockaddr paths; no SIGSEGV, no silent fallback |
| `macosArm64Test` / `iosSimulatorArm64Test` | **135 each, 0 fail** — `migrate()` → `Unsupported` by the common default, no crash |

## Migration test no longer needs a privileged loopback alias
The active-migration test hardcoded `127.0.0.2`, free on Linux but needing a privileged `ifconfig lo0 alias` on BSD/macOS. Migrating to a fresh ephemeral **port** on `127.0.0.1` is an equally valid migration (distinct 4-tuple → full PATH_CHALLENGE/RESPONSE — what NAT-rebind does):

- **`streamSurvivesActiveMigrationToNewLocalPort`** — new must-run, unprivileged case; runs everywhere under `QUIC_MIGRATION_REQUIRE_RUN`, including BSD.
- **`streamSurvivesActiveMigrationToLoopbackAlias`** — kept for supplemental address-change coverage; its precondition is now a clean skip that `REQUIRE_RUN` does not escalate.

Net: the BSD `sendInfoToAddr`/`decodePathKey` migration path is proven with **no sudo/alias**, locally or in CI.

## CI / build fixes
- **`build-apple.yaml`** — re-enable `:socket-quic:jvmTest` on macOS (JNI + FFM, both with `QUIC_MIGRATION_REQUIRE_RUN=1`). Switch the CI JNI shim to a self-contained `-force_load` static link — FFM's `SymbolLookup.libraryLookup` only finds symbols *defined* by the dylib, so a thin `-lquiche` shim would let `create()` succeed then throw `UnsatisfiedLinkError` on the first `quiche_*` downcall. Write the Gradle build markers so `prepareQuicheNativeLib` doesn't trigger a second from-source quiche build inside the 60-min job. Refresh stale "panic" comments.
- **`socket-quic/build.gradle.kts`** — fix `createBuildJvmJniShimTask`'s `onlyIf` so it honors the declared `quiche_jni.c` input. The version-keyed marker pinned a stale shim (missing #63's `nSockAddr*` exports) and the task never rebuilt locally — the cause of the first run's 5 `SockAddrDecodeTest` failures.
- **`WithQuicConnection.apple.kt`** — drop pre-existing trailing blank lines that would fail the re-enabled macOS `ktlintCheck`.

> Note: the macOS-runner shim link change can only be fully proven by CI on the macOS runner — same posture the earlier Gap PRs took.

Follow-up (not in this PR): `MIGRATION_FOLLOWUPS.md` lives on the `docs/quic-migration-followups` branch; its Gap 5 row should be flipped to ✅ there.