### PR TITLE
fix(quic): sync connection state before completing the Close command (deterministic fix for connection_close_sets_closed_state flake)

### DIFF
--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -273,6 +273,17 @@ class QuicheDriver(
 
             is QuicheCmd.Close -> {
                 api.connClose(conn, cmd.error)
+                // Sync state from quiche BEFORE signalling the close completed, so a caller
+                // awaiting Close() deterministically observes the resulting connection state
+                // (Closed once quiche reports the conn closed). Without this, run()'s
+                // afterCommand() -> updateState() runs only *after* execute() returns, so the
+                // result deferred could complete before the StateFlow flips — a happens-before
+                // gap that flaked ReactiveDriverTests.connection_close_sets_closed_state under
+                // Dispatchers.Default. updateState() is idempotent, so the afterCommand() call
+                // that follows is a harmless no-op; for real quiche (where connIsClosed lags
+                // connClose until the close frame drains) this is a no-op here too — state still
+                // transitions later via the normal loop, exactly as before.
+                updateState()
                 cmd.result.complete(Unit)
             }
 

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -1,9 +1,12 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.nativeMemoryAccess
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
@@ -235,6 +238,68 @@ class ReactiveDriverTests {
                 driver.destroy()
             }
             Unit
+        }
+
+    /**
+     * **Deterministic** isolation / regression guard for the Close→state ordering race that flaked
+     * [connection_close_sets_closed_state] on linuxX64 (observed in a release deploy:
+     * "Expected ... Closed, actual ... Established").
+     *
+     * Invariant: the instant the `Close` command's result deferred completes, the driver has
+     * already synced connection state — so a caller awaiting `close()` observes the resulting state
+     * with no scheduling-dependent gap. The root fix ([QuicheDriver.execute] calls `updateState()`
+     * before completing the Close deferred) establishes this happens-before *on the driver
+     * coroutine*.
+     *
+     * Rather than race the scheduler (probabilistic), this **pins** the driver: at close time the
+     * stub emits exactly one datagram (the first [connSend] after [connClose], via
+     * [StubQuicheApi.emitOneDatagramOnClose]) and the UDP channel's `send` suspends on a gate. That
+     * send is the *only* one in this test, so `afterCommand()` is parked inside `flushOutgoing` —
+     * *after* `execute()` completed the Close deferred, but *before* `afterCommand()`'s own
+     * `updateState()` can run. When `done.await()` returns, `updateState()` provably has not run
+     * yet. With the fix, state was already synced inside `execute()` → `Closed`. Without it, this
+     * reads `Established` every time — no timing luck either way. (Verified: fails deterministically
+     * when the `updateState()` call in the Close branch is removed.)
+     */
+    @Test
+    fun close_completes_only_after_state_is_synced() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            api.established = true
+            api.emitOneDatagramOnClose = true
+            val udpGate = CompletableDeferred<Unit>()
+            val gatedUdp =
+                object : UdpChannel {
+                    override suspend fun receive(buffer: PlatformBuffer): Int = awaitCancellation()
+
+                    // The only send in this test is the single close-time datagram, so pin
+                    // unconditionally — this parks the driver in afterCommand() before updateState().
+                    override suspend fun send(
+                        buffer: PlatformBuffer,
+                        len: Int,
+                        dest: PathKey?,
+                    ) = udpGate.await()
+
+                    override fun close() {}
+                }
+            val driver = createTestDriver(api, udpChannel = gatedUdp)
+            driver.start(this)
+            try {
+                // Barrier: let the startup afterCommand finish (state → Established, its flush
+                // already done) before arming `closed`, so the startup path can't see closed early.
+                withTimeout(2.seconds) { driver.state.first { it is QuicConnectionState.Established } }
+                api.closed = true
+                val done = CompletableDeferred<Unit>()
+                driver.commands.send(QuicheCmd.Close(QuicError.NoError, done))
+                withTimeout(2.seconds) { done.await() }
+                assertIs<QuicConnectionState.Closed>(
+                    driver.state.value,
+                    "Close completed before the connection state was synced to Closed",
+                )
+            } finally {
+                udpGate.complete(Unit) // release the pinned driver so it can finish + clean up
+                driver.destroy()
+            }
         }
 
     // ---- UDP send-error handling (regression: shutdown-leak flake) ----

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -21,6 +21,21 @@ internal class StubQuicheApi : QuicheApi {
      */
     @Volatile var connSendOnce: Int? = null
 
+    /**
+     * When true, the FIRST [connSend] observed *after [connClose] has been called* returns one
+     * datagram (1300B), then stops. This deterministically forces a single
+     * [QuicheDriver.flushOutgoing] -> [UdpChannel.send] during the *close* command's afterCommand —
+     * and only then, since every pre-close send happens before [connClose]. Tests gate that send to
+     * pin the driver between completing the Close deferred and running updateState(), with no
+     * dependence on connSendOnce timing or scheduler luck. See
+     * ReactiveDriverTests.close_completes_only_after_state_is_synced.
+     */
+    @Volatile var emitOneDatagramOnClose = false
+
+    @Volatile private var closeInitiated = false
+
+    @Volatile private var closeDatagramEmitted = false
+
     // --- Config (all no-ops) ---
     override fun configNew(version: Int) = QuicheConfig(1L)
 
@@ -167,6 +182,10 @@ internal class StubQuicheApi : QuicheApi {
         bufLen: Int,
         sendInfo: QuicheSendInfo,
     ): Int {
+        if (emitOneDatagramOnClose && closeInitiated && !closeDatagramEmitted) {
+            closeDatagramEmitted = true
+            return 1300
+        }
         val once = connSendOnce
         if (once != null) {
             connSendOnce = null
@@ -203,7 +222,10 @@ internal class StubQuicheApi : QuicheApi {
     override fun connClose(
         conn: QuicheConn,
         error: QuicError,
-    ) = 0
+    ): Int {
+        closeInitiated = true
+        return 0
+    }
 
     // --- Server (no-ops) ---
     override fun configLoadCertChainFromPemFile(


### PR DESCRIPTION
## Symptom
`ReactiveDriverTests.connection_close_sets_closed_state[linuxX64]` failed intermittently — it broke a **release deploy's `build-linux`** job (so no version published):
```
kotlin.AssertionError: Expected value to be of type <QuicConnectionState.Closed>, actual <Established>.
```

## Root cause (deterministic, not timing noise)
In `QuicheDriver`, `execute()` completed the `Close` command's result deferred, and only *afterwards* did `run()` → `afterCommand()` → `updateState()` flip the `StateFlow` to `Closed`:
```
execute(Close): connClose(); cmd.result.complete(Unit)   // ← deferred completes here
run(): afterCommand() -> updateState()                   // ← state flips here, later
```
So a caller awaiting `close()` could observe the *old* state — a happens-before gap. Under `Dispatchers.Default` the awaiting coroutine sometimes read `Established` before the driver loop reached `updateState()`. This is racy for any `close(); checkState()` caller in production too, not just the test.

## Fix
Call `updateState()` on the driver coroutine **before** completing the `Close` deferred, making close-completion a real synchronization point:
```kotlin
is QuicheCmd.Close -> {
    api.connClose(conn, cmd.error)
    updateState()            // sync state BEFORE signalling done
    cmd.result.complete(Unit)
}
```
It's idempotent (the subsequent `afterCommand()` `updateState()` is a no-op) and a **no-op for real quiche**, where `connIsClosed` lags `connClose` until the close frame drains — state still transitions later via the normal loop, exactly as before.

## Deterministic regression guard (no scheduler luck)
Following the same discipline as the EBADF fix (#77) — lock the contract at the source, then guard it with a test that can't pass without the fix:
- **`close_completes_only_after_state_is_synced`** *pins* the driver inside `afterCommand()`'s `flushOutgoing` — after the Close deferred completes, before `updateState()` runs — using a single close-time datagram (`StubQuicheApi.emitOneDatagramOnClose`, emitted on the first `connSend` after `connClose`) whose UDP `send` suspends on a gate. When `done.await()` returns, `updateState()` provably hasn't run. **Verified: passes with the fix, fails 3/3 with the `updateState()` call removed** — no probabilistic loop.
- `connection_close_sets_closed_state` stays as the simple contract check, now deterministic thanks to the happens-before.

## Validation (local)
- `:socket-quic:linuxX64Test` full `ReactiveDriverTests` ✅; both close tests on `:jvmTest` ✅; `ktlintCheck` ✅.
- Negative check: guard fails deterministically (3/3) when the fix is reverted.

## Why it matters now
The release deploy can flake on this until it's merged. Once on `main`, the deploy's `build-linux` native-test step is reliably green.