### PR TITLE
test(quic): harden harness cert (SKI/AKI) for Apple QUIC + add -9808 diagnostic

### DIFF
--- a/test-harness/tls/diagnose-apple-quic-trust.sh
+++ b/test-harness/tls/diagnose-apple-quic-trust.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Diagnose the Apple QUIC -9808 (errSSLBadCert) gap — macOS only.
+#
+# Background: the cross-platform `QuicHarnessIntegrationTests` runs against a LOCAL
+# quic-echo peer and is deterministic on JVM/Linux/Android, but SKIPS on Apple K/N
+# because Network.framework's QUIC TLS rejects the harness cert with errSSLBadCert
+# (-9808). We want to un-skip it (full cross-platform parity, local + deterministic),
+# which needs Apple to accept the LOCAL harness cert.
+#
+# This script pins down WHICH layer rejects, so we know the fix:
+#   * If `security verify-cert -p ssl` PASSES once the CA is system-trusted, then the
+#     cert itself is fine and Apple's *general* TLS trust accepts it — the remaining
+#     -9808 is specific to Network.framework's QUIC trust evaluation, i.e. we need a
+#     verify_block / NW trust config (Track B), NOT a cert change.
+#   * If it FAILS, `security` prints the exact reason (expired, missing AKI, CT,
+#     policy) — a LOCAL, deterministic fix in gen-certs.sh (e.g. the SKI/AKI hardening
+#     this branch adds, or whatever else it reports).
+#
+# Run on a Mac:  bash test-harness/tls/diagnose-apple-quic-trust.sh
+set -uo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "This diagnostic is macOS-only (uses the Security framework). Skipping on $(uname -s)."
+    exit 0
+fi
+
+cd "$(dirname "$0")"
+HOST="localhost" # valid.crt SANs: valid.test, localhost, 127.0.0.1 — pick one to hostname-match
+
+echo "==> 1. (Re)generate the harness cert matrix"
+bash gen-certs.sh --force
+
+CA="$PWD/certs/ca.crt"
+LEAF="$PWD/certs/valid.crt"
+KEYCHAIN="/Library/Keychains/System.keychain"
+
+echo "==> 2. Trust the harness CA in the System keychain (admin root → CT-exempt per Apple policy)"
+echo "    (sudo required; we remove it again at the end)"
+sudo security add-trusted-cert -d -r trustRoot -k "$KEYCHAIN" "$CA"
+
+cleanup() {
+    echo "==> Cleanup: remove the harness CA from the System keychain"
+    sudo security delete-certificate -c "harness-root" "$KEYCHAIN" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> 3. THE DISCRIMINATOR: evaluate the leaf under the SSL policy (this is what TLS uses)"
+echo "    security verify-cert -c valid.crt -p ssl -s $HOST"
+if security verify-cert -c "$LEAF" -p ssl -s "$HOST"; then
+    cat <<'MSG'
+
+RESULT: SSL-policy trust PASSED.
+  → The cert + chain are accepted by Apple's general TLS trust (CA trusted, CT-exempt
+    as an admin root, attributes OK). So a remaining QUIC -9808 is NOT a cert problem —
+    it is Network.framework's QUIC path not honoring system trust without a verify_block.
+  → Action: pursue Track B (make the test-only sec_protocol verify_block work without the
+    SIGABRT) — the gen-certs.sh hardening alone will not un-skip Apple. Confirm by step 4.
+MSG
+else
+    cat <<'MSG'
+
+RESULT: SSL-policy trust FAILED (reason printed above by `security`).
+  → The cert/chain itself is rejected. This is a LOCAL, deterministic fix in gen-certs.sh.
+    Common causes + fixes:
+      - "missing AuthorityKeyIdentifier"/SKI  → the SKI/AKI extensions this branch adds
+      - leaf validity > 398 days              → already capped at 397
+      - missing serverAuth EKU / SAN mismatch → already set
+      - Certificate Transparency required     → ensure the CA is an ADMIN root (trustRoot,
+                                                 System keychain) so it's CT-exempt
+  → Action: address the printed reason in gen-certs.sh, re-run this script until it PASSES,
+    THEN un-skip QuicHarnessIntegrationTests on Apple.
+MSG
+fi
+
+cat <<'MSG'
+
+==> 4. (Optional) Definitive QUIC-path check — capture the real Network.framework error.
+    In one terminal:
+      log stream --predicate 'subsystem == "com.apple.network"' --info --debug
+    In another, temporarily remove the Apple early-return in QuicHarnessIntegrationTests
+    (the `if (appleSystemTrust) { println(... SKIP ...); return }` block) and run:
+      ./gradlew :socket-quic:macosArm64Test --tests "*QuicHarnessIntegrationTests*"
+    Then read the nw_connection "failed" state — its nw_error carries the OSStatus (-9808)
+    and the underlying SecTrust result, which says definitively whether it's CT, anchor,
+    hostname, or extension related. That decides cert-fix (gen-certs.sh) vs Track B.
+MSG

--- a/test-harness/tls/gen-certs.sh
+++ b/test-harness/tls/gen-certs.sh
@@ -31,11 +31,17 @@ mkdir -p "$CERT_DIR"
 cd "$CERT_DIR"
 
 # ── harness-root CA — the cert authority we want every platform to TRUST ──────
+# subjectKeyIdentifier on the CA is required so leaves can carry a matching
+# authorityKeyIdentifier=keyid (below): Apple's Security/Network.framework trust
+# evaluation expects the SKI/AKI pair to chain a leaf to its issuer, and a
+# missing AKI is a known errSSLBadCert (-9808) trigger on the macOS QUIC path.
+# Harmless on BoringSSL/JVM — they don't require it.
 openssl genrsa -out ca.key 2048 2>/dev/null
 openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt \
     -subj "/CN=harness-root" \
     -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
-    -addext "keyUsage=critical,keyCertSign,cRLSign"
+    -addext "keyUsage=critical,keyCertSign,cRLSign" \
+    -addext "subjectKeyIdentifier=hash"
 
 # ── untrusted-root CA — a DIFFERENT CA, deliberately not given to platforms ───
 openssl genrsa -out untrusted-ca.key 2048 2>/dev/null
@@ -49,11 +55,21 @@ sign_leaf() {
     local name="$1" cn="$2" sans="$3" ca_crt="$4" ca_key="$5"
     openssl genrsa -out "$name.key" 2048 2>/dev/null
     openssl req -new -key "$name.key" -out "$name.csr" -subj "/CN=$cn"
+    # subjectKeyIdentifier + authorityKeyIdentifier: Apple's modern TLS trust
+    # evaluation (Security.framework, used by Network.framework's QUIC path)
+    # expects leaves to carry an SKI and an AKI that keyid-matches the issuer's
+    # SKI; a missing AKI is a documented errSSLBadCert (-9808) cause. authorityKey
+    # Identifier=keyid:always resolves the keyid from the -CA cert (which now has
+    # an SKI). serverAuth EKU + SAN + <=397d validity (below) round out the
+    # attributes Apple requires of a server leaf. All additive + ignored by
+    # BoringSSL/JVM, so the Linux/Android/JS harness is unaffected.
     cat > "$name.ext" <<EOF
 basicConstraints = critical,CA:FALSE
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = $sans
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always
 EOF
     # 397 days: Apple's TLS stack (Network.framework / Security) rejects any
     # server *leaf* cert with validity > 398 days (errSSLBadCert / -9808),


### PR DESCRIPTION
## Why
Per review: the QUIC client integration suite should be **one common, local, deterministic suite that runs on every platform** — not an Apple-specific workaround. We already have that suite: `QuicHarnessIntegrationTests` (commonTest) hits a **local** `quic-echo` peer and runs on JVM/Linux/Android. The **only** platform that skips it is Apple, solely because Network.framework's QUIC TLS rejects the **local** harness cert with `errSSLBadCert` (-9808).

So instead of adding an Apple-only public-endpoint test (wrong layer — that behavior isn't Apple-specific), this works toward **un-skipping the common suite on Apple**: make Apple accept the local cert.

## What this PR does (staged + safe)
**`gen-certs.sh` hardening** — add `subjectKeyIdentifier` to the harness-root CA and a matching `subjectKeyIdentifier` + `authorityKeyIdentifier=keyid` to every leaf. Apple's Security/Network.framework trust evaluation expects the SKI/AKI issuer link on a server leaf, and a missing AKI is a documented `-9808` trigger. This complements the Apple-specific constraints already encoded here (≤397-day leaf validity, `serverAuth` EKU, SAN). **Additive and ignored by BoringSSL/JVM**, so Linux/Android/JS are unaffected.

Verified locally on Linux:
- `openssl verify -CAfile ca.crt valid.crt` → OK
- `valid.crt` now has SKI + AKI that keyid-matches the CA's SKI
- negative certs (`wrong-host`, `untrusted-root`, `expired`, `self-signed`) keep their fail semantics

**It does not change test behavior yet** — Apple still skips the harness suite. Un-skipping is intentionally gated on confirming the fix on real hardware (see below), so this PR can't introduce an Apple flake.

## The Mac diagnostic (`diagnose-apple-quic-trust.sh`)
I can't run Apple K/N from Linux, so this script pins down `-9808` on a Mac. It trusts the CA as a System-keychain **admin root** (CT-exempt per Apple policy) and runs the discriminator:
```
security verify-cert -c valid.crt -p ssl -s localhost
```
- **PASS** → cert/chain are accepted by Apple's general TLS trust → the remaining `-9808` is **QUIC-path-specific** → the fix is **Track B** (a working test-only `verify_block`), not certs.
- **FAIL** → `security` prints the exact reason → a **local, deterministic** fix in `gen-certs.sh`.

Step 4 captures the real `nw_connection` failure (`log stream … com.apple.network`) for the definitive call.

## Next step (separate, needs a Mac)
Run the diagnostic → either confirm the SKI/AKI hardening is enough and **un-skip `QuicHarnessIntegrationTests` on Apple** (full parity, local + deterministic), or pivot to Track B if it's a QUIC-path trust issue.

No workflow change; certs are generated on demand (gitignored).