### PR TITLE
test(quic): deterministic network-impairment suite for JVM+Linux+Android (#87 suite 1)

### DIFF
--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicImpairmentTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicImpairmentTests.kt
@@ -1,0 +1,395 @@
+package com.ditchoom.socket.quic
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.flow.ReadResult
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.InetSocketAddress
+import java.net.SocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Network-impairment tests on Android — the Android port of the JVM/Linux [QuicImpairmentTestSuite]
+ * (issue #87, suite #1). `androidInstrumentedTest` is a separate on-device compilation that doesn't see
+ * `commonTest`, so this is a self-contained parallel copy (same reason
+ * [AndroidQuicPassiveMigrationTests] duplicates the passive suite). The policy, proxy, and the six test
+ * bodies are inlined; they mirror the shared suite exactly.
+ *
+ * Both ends run in one Android process via [withQuicServer]. A userspace [DatagramChannelImpairingProxy]
+ * sits between client and the in-process server and applies deterministic loss / reordering /
+ * duplication / latency+jitter / blackhole to the data path once [DatagramChannelImpairingProxy.arm]ed;
+ * we assert the connection survives and a multi-datagram payload still round-trips byte-for-byte.
+ */
+@RunWith(AndroidJUnit4::class)
+class AndroidQuicImpairmentTests {
+    // ---- inlined policy (commonTest's ImpairAction/ImpairmentPolicy/ImpairDirection) ----------------
+
+    private enum class Direction { ClientToServer, ServerToClient }
+
+    private sealed interface Action {
+        data object Forward : Action
+
+        data object Drop : Action
+
+        data object ForwardTwice : Action
+
+        data class ForwardAfter(
+            val delayMs: Long,
+        ) : Action
+
+        data object HoldUntilNext : Action
+    }
+
+    private fun interface Policy {
+        fun actionFor(
+            direction: Direction,
+            index: Int,
+        ): Action
+    }
+
+    private val testQuicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 30.seconds,
+        )
+
+    private val tlsConfig get() = AndroidTestCerts.tlsConfig
+
+    // ---- tests -------------------------------------------------------------------------------------
+
+    @Test
+    fun streamSurvivesDeterministicLoss() =
+        runImpaired(
+            policy = { _, index -> if (index % 7 == 6) Action.Drop else Action.Forward },
+            assertCounters = { proxy -> assertTrue(proxy.droppedCount > 0, "no datagram was dropped — impairment did not fire") },
+        )
+
+    @Test
+    fun streamSurvivesReordering() =
+        runImpaired(
+            policy = { _, index -> if (index % 2 == 0) Action.HoldUntilNext else Action.Forward },
+            assertCounters = { proxy -> assertTrue(proxy.reorderedCount > 0, "nothing was reordered — impairment did not fire") },
+        )
+
+    @Test
+    fun streamSurvivesDuplication() =
+        runImpaired(
+            policy = { _, _ -> Action.ForwardTwice },
+            assertCounters = { proxy -> assertTrue(proxy.duplicatedCount > 0, "nothing was duplicated — impairment did not fire") },
+        )
+
+    @Test
+    fun streamSurvivesLatencyAndJitter() =
+        runImpaired(
+            policy = { _, index -> Action.ForwardAfter(20L + (index % 5) * 10L) },
+            assertCounters = { proxy -> assertTrue(proxy.delayedCount > 0, "nothing was delayed — impairment did not fire") },
+        )
+
+    @Test
+    fun streamSurvivesBurstLossThenRecovery() =
+        runImpaired(
+            policy = { _, index -> if (index in BURST_START until BURST_START + BURST_SIZE) Action.Drop else Action.Forward },
+            assertCounters = { proxy -> assertTrue(proxy.droppedCount > 0, "burst was not dropped — impairment did not fire") },
+        )
+
+    @Test
+    fun streamStallsUnderTotalBlackhole() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib {
+                withTimeout(25.seconds) {
+                    withImpairedServerAndClient(policy = { _, _ -> Action.Drop }) { stream, proxy ->
+                        proxy.arm()
+                        var timedOut = false
+                        try {
+                            withTimeout(BLACKHOLE_TIMEOUT) { stream.echoExact("probe") }
+                        } catch (_: TimeoutCancellationException) {
+                            timedOut = true
+                        }
+                        assertTrue(
+                            timedOut,
+                            "payload round-tripped under a total blackhole — proxy is not the sole path / impairment bypassed",
+                        )
+                        assertTrue(proxy.droppedCount > 0, "blackhole dropped nothing — impairment did not fire")
+                    }
+                }
+            }
+        }
+
+    // ---- orchestration -----------------------------------------------------------------------------
+
+    private fun runImpaired(
+        policy: Policy,
+        assertCounters: (DatagramChannelImpairingProxy) -> Unit,
+    ) = runBlocking(Dispatchers.IO) {
+        skipOnMissingNativeLib {
+            withTimeout(25.seconds) {
+                withImpairedServerAndClient(policy) { stream, proxy ->
+                    proxy.arm()
+                    val expected = deterministicAscii(PAYLOAD_SIZE)
+                    val echoed = withTimeout(ECHO_TIMEOUT) { stream.echoExact(expected) }
+                    assertEquals(expected.length, echoed.length, "echoed payload truncated under impairment")
+                    assertEquals(expected, echoed, "echoed payload corrupted under impairment")
+                    assertCounters(proxy)
+                }
+            }
+        }
+    }
+
+    private suspend fun withImpairedServerAndClient(
+        policy: Policy,
+        body: suspend (stream: QuicByteStream, proxy: DatagramChannelImpairingProxy) -> Unit,
+    ) = coroutineScope {
+        withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
+            val serverJob =
+                launch(Dispatchers.IO) {
+                    connections {
+                        val stream = acceptStream()
+                        while (true) {
+                            val data = stream.read(15.seconds)
+                            if (data is ReadResult.Data) {
+                                stream.write(data.buffer, 10.seconds)
+                            } else {
+                                break
+                            }
+                        }
+                        stream.close()
+                    }
+                }
+
+            val proxy = DatagramChannelImpairingProxy(port, policy)
+            val done = CompletableDeferred<Unit>()
+
+            val clientJob =
+                launch(Dispatchers.IO) {
+                    try {
+                        withQuicConnection("127.0.0.1", proxy.proxyPort, testQuicOptions, timeout = 15.seconds) {
+                            val stream = openStream()
+                            assertEquals(WARMUP, stream.echoExact(WARMUP), "warm-up echo failed before impairment")
+                            body(stream, proxy)
+                            stream.close()
+                        }
+                        done.complete(Unit)
+                    } catch (t: Throwable) {
+                        done.completeExceptionally(t)
+                    }
+                }
+
+            try {
+                done.await()
+            } finally {
+                clientJob.cancel()
+                serverJob.cancel()
+                proxy.close()
+            }
+        }
+    }
+
+    private suspend fun QuicByteStream.echoExact(payload: String): String {
+        val out = BufferFactory.Default.allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 10.seconds)
+        return readExactly(payload.length)
+    }
+
+    private suspend fun QuicByteStream.readExactly(total: Int): String {
+        val sb = StringBuilder(total)
+        while (sb.length < total) {
+            val r = read(10.seconds)
+            if (r is ReadResult.Data) {
+                sb.append(r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+            } else {
+                break
+            }
+        }
+        return sb.toString()
+    }
+
+    private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    /**
+     * Userspace UDP forwarder that applies [policy] to the QUIC data path once [arm]ed. Two daemon
+     * threads pump each direction with blocking [DatagramChannel]s; delayed/held datagrams are copied
+     * out of the reused recv buffer before the next receive overwrites it. Test-only; `ByteBuffer` /
+     * `ByteArray` are fine. Mirrors the JVM `DatagramChannelImpairingProxy`.
+     */
+    private class DatagramChannelImpairingProxy(
+        serverPort: Int,
+        private val policy: Policy,
+    ) {
+        private val clientChannel = DatagramChannel.open().apply { bind(InetSocketAddress("127.0.0.1", 0)) }
+        val proxyPort: Int = (clientChannel.localAddress as InetSocketAddress).port
+        private val upstream = DatagramChannel.open().apply { connect(InetSocketAddress("127.0.0.1", serverPort)) }
+        private val scheduler = Executors.newSingleThreadScheduledExecutor { r -> Thread(r, "impair-sched").apply { isDaemon = true } }
+
+        @Volatile private var clientAddr: SocketAddress? = null
+
+        @Volatile private var running = true
+
+        @Volatile private var armed = false
+
+        private val dropped = AtomicInteger(0)
+        private val duplicated = AtomicInteger(0)
+        private val delayed = AtomicInteger(0)
+        private val reordered = AtomicInteger(0)
+
+        val droppedCount get() = dropped.get()
+        val duplicatedCount get() = duplicated.get()
+        val delayedCount get() = delayed.get()
+        val reorderedCount get() = reordered.get()
+
+        fun arm() {
+            armed = true
+        }
+
+        private inner class DirectionPump(
+            private val direction: Direction,
+            private val emitLive: (ByteBuffer) -> Unit,
+            private val emitBytes: (ByteArray) -> Unit,
+        ) {
+            private val index = AtomicInteger(0)
+
+            @Volatile private var held: ByteArray? = null
+
+            fun handle(
+                buf: ByteBuffer,
+                n: Int,
+            ) {
+                if (!armed) {
+                    emitLive(buf)
+                    return
+                }
+                val toRelease = held
+                held = null
+                when (val action = policy.actionFor(direction, index.getAndIncrement())) {
+                    Action.Forward -> emitLive(buf)
+                    Action.Drop -> dropped.incrementAndGet()
+                    Action.ForwardTwice -> {
+                        emitLive(buf)
+                        buf.rewind()
+                        emitLive(buf)
+                        duplicated.incrementAndGet()
+                    }
+                    is Action.ForwardAfter -> {
+                        val copy = buf.toBytes(n)
+                        scheduler.schedule({ emitBytes(copy) }, action.delayMs, TimeUnit.MILLISECONDS)
+                        delayed.incrementAndGet()
+                    }
+                    Action.HoldUntilNext -> {
+                        held = buf.toBytes(n)
+                        reordered.incrementAndGet()
+                    }
+                }
+                if (toRelease != null) emitBytes(toRelease)
+            }
+
+            private fun ByteBuffer.toBytes(n: Int): ByteArray {
+                val a = ByteArray(n)
+                duplicate().get(a)
+                return a
+            }
+        }
+
+        private fun sendUpstreamLive(b: ByteBuffer) = guarded { upstream.write(b) }
+
+        private fun sendUpstreamBytes(a: ByteArray) = guarded { upstream.write(ByteBuffer.wrap(a)) }
+
+        private fun sendClientLive(b: ByteBuffer) = guarded { clientAddr?.let { clientChannel.send(b, it) } }
+
+        private fun sendClientBytes(a: ByteArray) = guarded { clientAddr?.let { clientChannel.send(ByteBuffer.wrap(a), it) } }
+
+        private inline fun guarded(block: () -> Unit) {
+            try {
+                block()
+            } catch (_: Exception) {
+                // Best-effort forward — a closed channel during teardown is expected.
+            }
+        }
+
+        private val c2sPump = DirectionPump(Direction.ClientToServer, ::sendUpstreamLive, ::sendUpstreamBytes)
+        private val s2cPump = DirectionPump(Direction.ServerToClient, ::sendClientLive, ::sendClientBytes)
+
+        private val clientToServer =
+            thread(isDaemon = true, name = "impair-c2s") {
+                val buf = ByteBuffer.allocate(MAX_DATAGRAM)
+                while (running) {
+                    try {
+                        buf.clear()
+                        val from = clientChannel.receive(buf) ?: continue
+                        clientAddr = from
+                        buf.flip()
+                        c2sPump.handle(buf, buf.remaining())
+                    } catch (_: Exception) {
+                        if (!running) break
+                    }
+                }
+            }
+
+        private val serverToClient =
+            thread(isDaemon = true, name = "impair-s2c") {
+                val buf = ByteBuffer.allocate(MAX_DATAGRAM)
+                while (running) {
+                    try {
+                        buf.clear()
+                        val n = upstream.read(buf)
+                        if (n > 0) {
+                            buf.flip()
+                            s2cPump.handle(buf, n)
+                        }
+                    } catch (_: Exception) {
+                        if (!running) break
+                    }
+                }
+            }
+
+        fun close() {
+            running = false
+            scheduler.shutdownNow()
+            clientChannel.close()
+            upstream.close()
+            clientToServer.interrupt()
+            serverToClient.interrupt()
+        }
+    }
+
+    private companion object {
+        private const val PAYLOAD_SIZE = 8 * 1024
+        private const val MAX_DATAGRAM = 2048
+        private const val WARMUP = "warmup"
+        private const val BURST_START = 3
+        private const val BURST_SIZE = 5
+        private val ECHO_TIMEOUT = 8.seconds
+        private val BLACKHOLE_TIMEOUT = 4.seconds
+
+        private fun deterministicAscii(length: Int): String =
+            buildString(length) {
+                for (i in 0 until length) append('A' + (i % 26))
+            }
+    }
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicImpairmentTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicImpairmentTestSuite.kt
@@ -1,0 +1,309 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared **network-impairment** test suite (issue #87, suite #1). Drives deterministic packet loss /
+ * reordering / duplication / latency+jitter / burst-blackhole on the QUIC data path and asserts the
+ * connection survives and a multi-datagram payload still round-trips byte-for-byte — i.e. QUIC's
+ * retransmit / ACK / loss-recovery / reassembly / dedup logic actually works.
+ *
+ * Same 3-tier shape as [QuicPassiveMigrationTestSuite]: each platform supplies a [testTlsConfig] and a
+ * [createImpairingProxy]; the test bodies are inherited, guaranteeing parity across JVM, Linux K/N, and
+ * any future common-test platform. (Android's equivalent is a parallel copy in `androidInstrumentedTest`,
+ * which can't see `commonTest` — see `AndroidQuicImpairmentTests`.)
+ *
+ * **Determinism (hard constraint).** No randomness, no `Math.random` (unavailable on K/N), no
+ * probabilistic flake-catchers. Impairment is driven purely by a per-direction datagram **index
+ * counter** via [ImpairmentPolicy]. The proxy starts in pass-through; the test does one clean echo to
+ * prove the handshake + stream are established, then calls [ImpairingProxy.arm] — from that point the
+ * policy is applied to the *data phase* only, with indices counted from 0. This separates the variable
+ * handshake flight from the impairment under test without parsing packets. The pass/fail *outcome* is
+ * deterministic (QUIC always recovers); only latency varies, bounded by a generous `idleTimeout`.
+ *
+ * **Anti-vacuous guard.** [streamStallsUnderTotalBlackhole] is a real test (not a comment): with the
+ * policy dropping everything post-arm, the echo must time out — proving the proxy is the sole path and
+ * the suite *can* fail. Combined with the `*Count > 0` assertions (impairment provably fired on the
+ * path), this rules out a proxy bug that silently bypasses impairment and lets every positive test pass.
+ */
+abstract class QuicImpairmentTestSuite {
+    abstract fun testTlsConfig(): QuicTlsConfig
+
+    /** Platform-specific impairing proxy (blocking DatagramChannel on JVM/Android, io_uring on Linux K/N). */
+    abstract fun createImpairingProxy(
+        serverPort: Int,
+        policy: ImpairmentPolicy,
+    ): ImpairingProxy
+
+    /** Platform hook for skip-on-missing-native-lib (JVM converts `UnsatisfiedLinkError` to a skip). */
+    protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
+
+    private val impairOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            // Generous so idle-timeout never races loss/PTO recovery — the impairment is data-phase only.
+            idleTimeout = 30.seconds,
+        )
+
+    // ---- tests -------------------------------------------------------------------------------------
+
+    /** Drop every 7th post-arm datagram (both directions); QUIC retransmit must still deliver the payload. */
+    @Test
+    fun streamSurvivesDeterministicLoss() =
+        runImpaired(
+            policy = { _, index -> if (index % 7 == 6) ImpairAction.Drop else ImpairAction.Forward },
+            assertCounters = { proxy -> assertTrue(proxy.droppedCount > 0, "no datagram was dropped — impairment did not fire") },
+        )
+
+    /** Hold even-indexed post-arm datagrams and release them after the next one — a structural reorder. */
+    @Test
+    fun streamSurvivesReordering() =
+        runImpaired(
+            policy = { _, index -> if (index % 2 == 0) ImpairAction.HoldUntilNext else ImpairAction.Forward },
+            assertCounters = { proxy -> assertTrue(proxy.reorderedCount > 0, "nothing was reordered — impairment did not fire") },
+        )
+
+    /** Forward every post-arm datagram twice; QUIC must dedup so the payload is delivered exactly once. */
+    @Test
+    fun streamSurvivesDuplication() =
+        runImpaired(
+            policy = { _, _ -> ImpairAction.ForwardTwice },
+            assertCounters = { proxy -> assertTrue(proxy.duplicatedCount > 0, "nothing was duplicated — impairment did not fire") },
+        )
+
+    /** Delay every post-arm datagram by a deterministic base + per-index jitter; payload still round-trips. */
+    @Test
+    fun streamSurvivesLatencyAndJitter() =
+        runImpaired(
+            policy = { _, index -> ImpairAction.ForwardAfter(20L + (index % 5) * 10L) },
+            assertCounters = { proxy -> assertTrue(proxy.delayedCount > 0, "nothing was delayed — impairment did not fire") },
+        )
+
+    /** Drop a contiguous burst of post-arm datagrams once (partial blackhole), then pass; QUIC recovers. */
+    @Test
+    fun streamSurvivesBurstLossThenRecovery() =
+        runImpaired(
+            policy = { _, index -> if (index in BURST_START until BURST_START + BURST_SIZE) ImpairAction.Drop else ImpairAction.Forward },
+            assertCounters = { proxy -> assertTrue(proxy.droppedCount > 0, "burst was not dropped — impairment did not fire") },
+        )
+
+    /**
+     * Anti-vacuous guard: drop everything post-arm. The echo of the data payload must time out, proving
+     * the proxy carries the only path and the positive assertions are not vacuous. If the proxy ever
+     * silently bypassed impairment, this would pass (round-trip) and fail the test.
+     */
+    @Test
+    fun streamStallsUnderTotalBlackhole() =
+        runQuicTest {
+            wrapTestBody {
+                withImpairedServerAndClient(policy = { _, _ -> ImpairAction.Drop }) { stream, proxy ->
+                    proxy.arm()
+                    val expected = "probe" // small — blackhole only needs the path blocked, not bulk data
+                    var timedOut = false
+                    try {
+                        // After arm() every data datagram is dropped, so the payload can never round-trip.
+                        withTimeout(BLACKHOLE_TIMEOUT) { stream.echoExact(expected) }
+                    } catch (_: TimeoutCancellationException) {
+                        timedOut = true
+                    }
+                    assertTrue(timedOut, "payload round-tripped under a total blackhole — proxy is not the sole path / impairment bypassed")
+                    assertTrue(proxy.droppedCount > 0, "blackhole dropped nothing — impairment did not fire")
+                }
+            }
+        }
+
+    // ---- orchestration -----------------------------------------------------------------------------
+
+    private fun runImpaired(
+        policy: ImpairmentPolicy,
+        assertCounters: (ImpairingProxy) -> Unit,
+    ) = runQuicTest {
+        wrapTestBody {
+            withImpairedServerAndClient(policy) { stream, proxy ->
+                proxy.arm() // data-phase impairment starts now; handshake already completed pass-through
+                val expected = payload()
+                val echoed = withTimeout(ECHO_TIMEOUT) { stream.echoExact(expected) }
+                assertEquals(expected.length, echoed.length, "echoed payload truncated under impairment")
+                assertEquals(expected, echoed, "echoed payload corrupted under impairment")
+                assertCounters(proxy)
+            }
+        }
+    }
+
+    /**
+     * Stands up the in-process echo server, an impairing proxy in front of it, and a client that connects
+     * *through* the proxy and opens one stream. Does a clean pass-through warm-up echo (so the handshake +
+     * stream are established before any [ImpairingProxy.arm]), then hands the open stream + proxy to [body].
+     */
+    private suspend fun withImpairedServerAndClient(
+        policy: ImpairmentPolicy,
+        body: suspend (stream: QuicByteStream, proxy: ImpairingProxy) -> Unit,
+    ) = coroutineScope {
+        withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = impairOptions) {
+            // Echo loop: mirror every chunk back until the stream ends.
+            val serverJob =
+                launch {
+                    connections {
+                        val stream = acceptStream()
+                        while (true) {
+                            val data = stream.read(15.seconds)
+                            if (data is ReadResult.Data) {
+                                stream.write(data.buffer, 10.seconds)
+                            } else {
+                                break
+                            }
+                        }
+                        stream.close()
+                    }
+                }
+
+            val proxy = createImpairingProxy(port, policy)
+            val done = CompletableDeferred<Unit>()
+
+            val clientJob =
+                launch {
+                    try {
+                        withQuicConnection("127.0.0.1", proxy.proxyPort, impairOptions, timeout = 15.seconds) {
+                            val stream = openStream()
+                            // Pass-through warm-up: proves handshake + stream are up before impairment arms.
+                            assertEquals(WARMUP, stream.echoExact(WARMUP), "warm-up echo failed before impairment")
+                            body(stream, proxy)
+                            stream.close()
+                        }
+                        done.complete(Unit)
+                    } catch (t: Throwable) {
+                        done.completeExceptionally(t)
+                    }
+                }
+
+            try {
+                done.await()
+            } finally {
+                clientJob.cancel()
+                serverJob.cancel()
+                proxy.close()
+            }
+        }
+    }
+
+    /**
+     * Write [payload], then read exactly [payload].length bytes back, returning what came back. The
+     * connection's initial flow-control windows comfortably exceed [PAYLOAD_SIZE], so `write` buffers the
+     * whole payload into quiche and returns without waiting on the reader — no sequential-echo deadlock at
+     * these sizes. The write/read buffers are freed (the suite also runs on K/N, where they are native).
+     */
+    private suspend fun QuicByteStream.echoExact(payload: String): String {
+        val out = BufferFactory.deterministic().allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        try {
+            write(out, ECHO_TIMEOUT)
+        } finally {
+            out.freeNativeMemory()
+        }
+        return readExactly(payload.length, ECHO_TIMEOUT)
+    }
+
+    /** Accumulate stream reads until [total] characters have arrived (ASCII-only payloads never split a codepoint). */
+    private suspend fun QuicByteStream.readExactly(
+        total: Int,
+        timeout: Duration,
+    ): String {
+        val sb = StringBuilder(total)
+        while (sb.length < total) {
+            val r = read(timeout)
+            if (r is ReadResult.Data) {
+                sb.append(r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+                r.buffer.freeIfNeeded() // read transfers buffer ownership to us (see QuicheStreamAdapter)
+            } else {
+                break
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun payload(): String = deterministicAscii(PAYLOAD_SIZE)
+
+    companion object {
+        /** ~16 KB ⇒ ≈12–14 datagrams per direction, so impairment lands on real stream data, not just ACKs. */
+        private const val PAYLOAD_SIZE = 8 * 1024
+        private const val WARMUP = "warmup"
+        private const val BURST_START = 3
+        private const val BURST_SIZE = 5
+        private val ECHO_TIMEOUT = 8.seconds
+        private val BLACKHOLE_TIMEOUT = 4.seconds
+
+        /** Deterministic single-byte-UTF8 payload: `A B C … Z A B …` so chunk boundaries never split a codepoint. */
+        private fun deterministicAscii(length: Int): String =
+            buildString(length) {
+                for (i in 0 until length) append('A' + (i % 26))
+            }
+    }
+}
+
+/** Datagram direction through the proxy, so a policy can impair one side independently if it chooses. */
+enum class ImpairDirection { ClientToServer, ServerToClient }
+
+/** What the proxy should do with a single datagram. Deterministic; chosen purely from a per-direction index. */
+sealed interface ImpairAction {
+    /** Forward once, immediately (the no-op). */
+    data object Forward : ImpairAction
+
+    /** Drop — never forwarded. */
+    data object Drop : ImpairAction
+
+    /** Forward twice in a row (duplication). */
+    data object ForwardTwice : ImpairAction
+
+    /** Forward once after [delayMs] (latency / jitter). Requires copying the datagram out of the recv buffer. */
+    data class ForwardAfter(
+        val delayMs: Long,
+    ) : ImpairAction
+
+    /** Hold this datagram and release it *after* the next datagram in the same direction (structural reorder). */
+    data object HoldUntilNext : ImpairAction
+}
+
+/** Pure, stateless mapping `(direction, index) → action`. The proxy owns the indices and the counters. */
+fun interface ImpairmentPolicy {
+    fun actionFor(
+        direction: ImpairDirection,
+        index: Int,
+    ): ImpairAction
+}
+
+/**
+ * A userspace UDP forwarder that applies a deterministic [ImpairmentPolicy] to the QUIC data path.
+ * Client ↔ [proxyPort] ↔ server. Starts in pass-through; [arm] switches the policy on (indices reset to 0)
+ * so the handshake completes cleanly first. Each platform implements it over its native UDP API.
+ */
+interface ImpairingProxy {
+    /** The local port the client connects to (the proxy's client-facing socket). */
+    val proxyPort: Int
+
+    /** Switch from pass-through to applying the policy; resets per-direction indices to 0. */
+    fun arm()
+
+    val droppedCount: Int
+    val duplicatedCount: Int
+    val delayedCount: Int
+    val reorderedCount: Int
+
+    /** Stop the pump loops and release all sockets/resources/held buffers. */
+    suspend fun close()
+}

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicImpairmentTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicImpairmentTests.kt
@@ -1,0 +1,195 @@
+package com.ditchoom.socket.quic
+
+import org.junit.Assume.assumeTrue
+import java.net.InetSocketAddress
+import java.net.SocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+/**
+ * JVM network-impairment test — the JVM member of the shared [QuicImpairmentTestSuite].
+ *
+ * Provides JVM cert resolution (classpath `certs/`), the `UnsatisfiedLinkError → assumeTrue` skip (so a
+ * missing JNI/FFM quiche native skips cleanly), and a [DatagramChannelImpairingProxy] built on blocking
+ * [DatagramChannel]s — the impairment sibling of [QuicPassiveMigrationTests]' rebinding proxy. The test
+ * bodies live in the common suite, guaranteeing parity with the Linux K/N port.
+ */
+class QuicImpairmentTests : QuicImpairmentTestSuite() {
+    private fun certPath(name: String): String {
+        val url =
+            this::class.java.classLoader.getResource("certs/$name")
+                ?: error("Test cert not found: certs/$name")
+        return java.io.File(url.toURI()).absolutePath
+    }
+
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    override fun createImpairingProxy(
+        serverPort: Int,
+        policy: ImpairmentPolicy,
+    ): ImpairingProxy = DatagramChannelImpairingProxy(serverPort, policy)
+
+    /**
+     * [ImpairingProxy] over blocking [DatagramChannel]s. Two daemon threads pump each direction; each
+     * applies [policy] per datagram once [arm]ed. Delayed ([ImpairAction.ForwardAfter]) and held
+     * ([ImpairAction.HoldUntilNext]) datagrams are copied out of the (reused) recv buffer before the next
+     * receive overwrites it; duplicates re-send the live buffer (both sends complete before the next
+     * receive). `ByteBuffer`/`ByteArray` are fine here — test-only.
+     */
+    private class DatagramChannelImpairingProxy(
+        serverPort: Int,
+        private val policy: ImpairmentPolicy,
+    ) : ImpairingProxy {
+        private val clientChannel = DatagramChannel.open().apply { bind(InetSocketAddress("127.0.0.1", 0)) }
+        override val proxyPort: Int = (clientChannel.localAddress as InetSocketAddress).port
+        private val upstream = DatagramChannel.open().apply { connect(InetSocketAddress("127.0.0.1", serverPort)) }
+        private val scheduler = Executors.newSingleThreadScheduledExecutor { r -> Thread(r, "impair-sched").apply { isDaemon = true } }
+
+        @Volatile private var clientAddr: SocketAddress? = null
+
+        @Volatile private var running = true
+
+        @Volatile private var armed = false
+
+        private val dropped = AtomicInteger(0)
+        private val duplicated = AtomicInteger(0)
+        private val delayed = AtomicInteger(0)
+        private val reordered = AtomicInteger(0)
+
+        override val droppedCount get() = dropped.get()
+        override val duplicatedCount get() = duplicated.get()
+        override val delayedCount get() = delayed.get()
+        override val reorderedCount get() = reordered.get()
+
+        override fun arm() {
+            armed = true
+        }
+
+        /** Per-direction state + mechanics. [emitLive] sends the (positioned) recv buffer; [emitBytes] sends a copy. */
+        private inner class DirectionPump(
+            private val direction: ImpairDirection,
+            private val emitLive: (ByteBuffer) -> Unit,
+            private val emitBytes: (ByteArray) -> Unit,
+        ) {
+            private val index = AtomicInteger(0)
+
+            @Volatile private var held: ByteArray? = null
+
+            fun handle(
+                buf: ByteBuffer,
+                n: Int,
+            ) {
+                if (!armed) {
+                    emitLive(buf)
+                    return
+                }
+                val toRelease = held
+                held = null
+                when (val action = policy.actionFor(direction, index.getAndIncrement())) {
+                    ImpairAction.Forward -> emitLive(buf)
+                    ImpairAction.Drop -> dropped.incrementAndGet()
+                    ImpairAction.ForwardTwice -> {
+                        emitLive(buf)
+                        buf.rewind()
+                        emitLive(buf)
+                        duplicated.incrementAndGet()
+                    }
+                    is ImpairAction.ForwardAfter -> {
+                        val copy = buf.toBytes(n)
+                        scheduler.schedule({ emitBytes(copy) }, action.delayMs, TimeUnit.MILLISECONDS)
+                        delayed.incrementAndGet()
+                    }
+                    ImpairAction.HoldUntilNext -> {
+                        held = buf.toBytes(n)
+                        reordered.incrementAndGet()
+                    }
+                }
+                // Release the previously-held datagram AFTER the current one — the structural reorder.
+                if (toRelease != null) emitBytes(toRelease)
+            }
+
+            private fun ByteBuffer.toBytes(n: Int): ByteArray {
+                val a = ByteArray(n)
+                duplicate().get(a)
+                return a
+            }
+        }
+
+        private fun sendUpstreamLive(b: ByteBuffer) = guarded { upstream.write(b) }
+
+        private fun sendUpstreamBytes(a: ByteArray) = guarded { upstream.write(ByteBuffer.wrap(a)) }
+
+        private fun sendClientLive(b: ByteBuffer) = guarded { clientAddr?.let { clientChannel.send(b, it) } }
+
+        private fun sendClientBytes(a: ByteArray) = guarded { clientAddr?.let { clientChannel.send(ByteBuffer.wrap(a), it) } }
+
+        private inline fun guarded(block: () -> Unit) {
+            try {
+                block()
+            } catch (_: Exception) {
+                // Best-effort forward — a closed channel during teardown is expected.
+            }
+        }
+
+        private val c2sPump = DirectionPump(ImpairDirection.ClientToServer, ::sendUpstreamLive, ::sendUpstreamBytes)
+        private val s2cPump = DirectionPump(ImpairDirection.ServerToClient, ::sendClientLive, ::sendClientBytes)
+
+        private val clientToServer =
+            thread(isDaemon = true, name = "impair-c2s") {
+                val buf = ByteBuffer.allocate(MAX_DATAGRAM)
+                while (running) {
+                    try {
+                        buf.clear()
+                        val from = clientChannel.receive(buf) ?: continue
+                        clientAddr = from
+                        buf.flip()
+                        c2sPump.handle(buf, buf.remaining())
+                    } catch (_: Exception) {
+                        if (!running) break
+                    }
+                }
+            }
+
+        private val serverToClient =
+            thread(isDaemon = true, name = "impair-s2c") {
+                val buf = ByteBuffer.allocate(MAX_DATAGRAM)
+                while (running) {
+                    try {
+                        buf.clear()
+                        val n = upstream.read(buf)
+                        if (n > 0) {
+                            buf.flip()
+                            s2cPump.handle(buf, n)
+                        }
+                    } catch (_: Exception) {
+                        if (!running) break
+                    }
+                }
+            }
+
+        override suspend fun close() {
+            running = false
+            scheduler.shutdownNow()
+            clientChannel.close()
+            upstream.close()
+            clientToServer.interrupt()
+            serverToClient.interrupt()
+        }
+
+        companion object {
+            private const val MAX_DATAGRAM = 2048
+        }
+    }
+}

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicImpairmentTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicImpairmentTests.kt
@@ -1,0 +1,300 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.nativeMemoryAccess
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.free
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.toCPointer
+import kotlinx.cinterop.value
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import platform.posix.AF_INET
+import platform.posix.F_OK
+import platform.posix.INADDR_LOOPBACK
+import platform.posix.SOCK_DGRAM
+import platform.posix.access
+import platform.posix.bind
+import platform.posix.close
+import platform.posix.connect
+import platform.posix.getsockname
+import platform.posix.htonl
+import platform.posix.htons
+import platform.posix.memcpy
+import platform.posix.ntohs
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.sockaddr_storage
+import platform.posix.socket
+import platform.posix.socklen_tVar
+import kotlin.concurrent.AtomicInt
+
+/**
+ * Kotlin/Native (linuxX64) network-impairment test — the K/N member of the shared
+ * [QuicImpairmentTestSuite], sibling of [LinuxQuicPassiveMigrationTests].
+ *
+ * Provides linuxX64 cert resolution and an [ImpairingProxy] built on the repo's io_uring UDP
+ * primitives ([IoUringUdpServerChannel] for the unconnected client-facing socket, [IoUringUdpChannel]
+ * for the connected upstream). Native compiles quiche via cinterop, so there is no
+ * `UnsatisfiedLinkError` skip path ([wrapTestBody] stays the default pass-through): on Linux the test
+ * always runs.
+ */
+class LinuxQuicImpairmentTests : QuicImpairmentTestSuite() {
+    private fun certPath(name: String): String {
+        val candidates = listOf("testcerts/$name", "socket-quic/testcerts/$name")
+        return candidates.firstOrNull { access(it, F_OK) == 0 }
+            ?: error("Test cert not found: $name (tried $candidates)")
+    }
+
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    override fun createImpairingProxy(
+        serverPort: Int,
+        policy: ImpairmentPolicy,
+    ): ImpairingProxy = IoUringImpairingProxy(serverPort, policy)
+
+    /**
+     * [ImpairingProxy] over io_uring UDP primitives. Two suspend pump loops on [Dispatchers.Default]
+     * apply [policy] per datagram once [arm]ed. Datagrams that outlive the next `recvFrom`
+     * ([ImpairAction.ForwardAfter], [ImpairAction.HoldUntilNext]) are copied out of the reused recv
+     * buffer (its payload + `peerAddr` are valid only until the next recv); duplicates re-send the live
+     * buffer (both sends complete before the next recv). A delayed send runs in a child coroutine so the
+     * pump keeps draining; teardown cancels+joins every child before freeing held/recv buffers and fds —
+     * the io_uring cancellation path waits for the kernel to release in-flight buffers first.
+     */
+    private class IoUringImpairingProxy(
+        serverPort: Int,
+        private val policy: ImpairmentPolicy,
+    ) : ImpairingProxy {
+        private val bufferFactory = BufferFactory.deterministic()
+
+        private val clientFd: Int = openBoundLoopbackSocket()
+        override val proxyPort: Int = boundPortOf(clientFd)
+        private val clientChannel = IoUringUdpServerChannel(clientFd)
+
+        private val upstreamFd: Int = newUpstream(serverPort)
+        private val upstreamChannel = IoUringUdpChannel(upstreamFd)
+
+        // Pinned copy of the client's source addr — the c2s loop fills it and publishes its length.
+        private val clientAddr = nativeHeap.alloc<sockaddr_storage>()
+        private val clientAddrLen = AtomicInt(0)
+
+        private val armedFlag = AtomicInt(0)
+        private val running = AtomicInt(1)
+        private val dropped = AtomicInt(0)
+        private val duplicated = AtomicInt(0)
+        private val delayed = AtomicInt(0)
+        private val reordered = AtomicInt(0)
+
+        override val droppedCount get() = dropped.value
+        override val duplicatedCount get() = duplicated.value
+        override val delayedCount get() = delayed.value
+        override val reorderedCount get() = reordered.value
+
+        override fun arm() {
+            armedFlag.value = 1
+        }
+
+        private val supervisor = SupervisorJob()
+        private val scope = CoroutineScope(supervisor + Dispatchers.Default)
+
+        /** Per-direction index + held-datagram slot + mechanics. [send] forwards [n] bytes from a buffer. */
+        private inner class DirectionPump(
+            private val direction: ImpairDirection,
+            private val send: suspend (PlatformBuffer, Int) -> Unit,
+        ) {
+            private val index = AtomicInt(0)
+            private var held: PlatformBuffer? = null
+            private var heldLen = 0
+
+            suspend fun handle(
+                buf: PlatformBuffer,
+                n: Int,
+            ) {
+                if (armedFlag.value == 0) {
+                    send(buf, n)
+                    return
+                }
+                val toRelease = held
+                val toReleaseLen = heldLen
+                held = null
+                when (val action = policy.actionFor(direction, index.getAndIncrement())) {
+                    ImpairAction.Forward -> send(buf, n)
+                    ImpairAction.Drop -> dropped.incrementAndGet()
+                    ImpairAction.ForwardTwice -> {
+                        send(buf, n)
+                        send(buf, n)
+                        duplicated.incrementAndGet()
+                    }
+                    is ImpairAction.ForwardAfter -> {
+                        val copy = copyOf(buf, n)
+                        scope.launch {
+                            try {
+                                delay(action.delayMs)
+                                send(copy, n)
+                            } finally {
+                                copy.freeNativeMemory()
+                            }
+                        }
+                        delayed.incrementAndGet()
+                    }
+                    ImpairAction.HoldUntilNext -> {
+                        held = copyOf(buf, n)
+                        heldLen = n
+                        reordered.incrementAndGet()
+                    }
+                }
+                // Release the previously-held datagram AFTER the current one — the structural reorder.
+                if (toRelease != null) {
+                    send(toRelease, toReleaseLen)
+                    toRelease.freeNativeMemory()
+                }
+            }
+
+            fun freeHeld() {
+                held?.freeNativeMemory()
+                held = null
+            }
+        }
+
+        private val c2sPump = DirectionPump(ImpairDirection.ClientToServer) { b, n -> upstreamChannel.send(b, n, dest = null) }
+        private val s2cPump =
+            DirectionPump(ImpairDirection.ServerToClient) { b, n ->
+                if (clientAddrLen.value > 0) {
+                    clientChannel.sendTo(b, n, clientAddr.ptr.reinterpret(), clientAddrLen.value.convert())
+                }
+            }
+
+        private val c2sJob = scope.launch { clientToServerLoop() }
+        private val s2cJob = scope.launch { serverToClientLoop() }
+
+        /** Client → server: capture the client source on the first packet, then apply the policy. */
+        private suspend fun clientToServerLoop() {
+            val buf = bufferFactory.allocate(MAX_DATAGRAM)
+            try {
+                while (running.value == 1) {
+                    try {
+                        val r = clientChannel.recvFrom(buf)
+                        if (running.value == 0) break // fd closed on teardown — recv returned an error CQE
+                        if (r.bytesReceived <= 0) continue
+                        if (clientAddrLen.value == 0 && r.peerAddrLen.toInt() > 0) {
+                            memcpy(clientAddr.ptr, r.peerAddr, r.peerAddrLen.convert())
+                            clientAddrLen.value = r.peerAddrLen.toInt() // publish after the copy
+                        }
+                        c2sPump.handle(buf, r.bytesReceived)
+                    } catch (e: Throwable) {
+                        if (running.value == 0) break
+                        throw e
+                    }
+                }
+            } finally {
+                buf.freeNativeMemory()
+            }
+        }
+
+        /** Server → client: apply the policy and forward to the captured client source. */
+        private suspend fun serverToClientLoop() {
+            val buf = bufferFactory.allocate(MAX_DATAGRAM)
+            try {
+                while (running.value == 1) {
+                    try {
+                        // -ETIMEDOUT (idle) or -ECANCELED/-EBADF (fd closed on teardown) → re-check/re-read.
+                        val n = upstreamChannel.receive(buf)
+                        if (running.value == 0) break
+                        if (n <= 0) continue
+                        s2cPump.handle(buf, n)
+                    } catch (e: Throwable) {
+                        if (running.value == 0) break
+                        throw e
+                    }
+                }
+            } finally {
+                buf.freeNativeMemory()
+            }
+        }
+
+        private fun copyOf(
+            src: PlatformBuffer,
+            n: Int,
+        ): PlatformBuffer {
+            val dst = bufferFactory.allocate(n)
+            val srcPtr = src.nativeMemoryAccess!!.nativeAddress.toCPointer<ByteVar>()!!
+            val dstPtr = dst.nativeMemoryAccess!!.nativeAddress.toCPointer<ByteVar>()!!
+            memcpy(dstPtr, srcPtr, n.convert())
+            return dst
+        }
+
+        override suspend fun close() {
+            // Tear down WITHOUT the submitAndWait cancellation path: close the fds so the in-flight
+            // recvFrom/receive complete via an error CQE (the kernel releases the recv buffers FIRST),
+            // let the loops exit on the `running` flag, and only THEN free the channel's recv structures.
+            // Freeing them while a recv is still in flight is a use-after-free that glibc aborts on
+            // ("malloc(): unsorted double linked list corrupted") — see IoUringUdpServerChannel.closeFd.
+            running.value = 0
+            clientChannel.closeFd() // unblock the c2s recvFrom (error CQE) — does NOT free recv structs yet
+            close(upstreamFd) // unblock the s2c receive
+            c2sJob.join() // loops exit on `running` after their recv completes; each frees its own recv buffer
+            s2cJob.join()
+            supervisor.cancelAndJoin() // cancel any in-flight delayed-send children (the loops are already done)
+            c2sPump.freeHeld()
+            s2cPump.freeHeld()
+            clientChannel.freeBuffers() // NOW safe — the receive loop has fully exited
+            nativeHeap.free(clientAddr)
+        }
+
+        companion object {
+            private const val MAX_DATAGRAM = 2048
+
+            private fun newUpstream(serverPort: Int): Int {
+                val fd = socket(AF_INET, SOCK_DGRAM, 0)
+                check(fd >= 0) { "proxy upstream socket() failed" }
+                memScoped {
+                    val addr = alloc<sockaddr_in>()
+                    addr.sin_family = AF_INET.convert()
+                    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+                    addr.sin_port = htons(serverPort.toUShort())
+                    val rc = connect(fd, addr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert())
+                    check(rc == 0) { "proxy upstream connect() failed (rc=$rc)" }
+                }
+                return fd
+            }
+
+            private fun openBoundLoopbackSocket(): Int {
+                val fd = socket(AF_INET, SOCK_DGRAM, 0)
+                check(fd >= 0) { "proxy client-facing socket() failed" }
+                memScoped {
+                    val addr = alloc<sockaddr_in>()
+                    addr.sin_family = AF_INET.convert()
+                    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+                    addr.sin_port = htons(0u)
+                    val rc = bind(fd, addr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert())
+                    check(rc == 0) { "proxy client-facing bind() failed (rc=$rc)" }
+                }
+                return fd
+            }
+
+            private fun boundPortOf(fd: Int): Int =
+                memScoped {
+                    val addr = alloc<sockaddr_in>()
+                    val len = alloc<socklen_tVar>()
+                    len.value = sizeOf<sockaddr_in>().convert()
+                    getsockname(fd, addr.ptr.reinterpret<sockaddr>(), len.ptr)
+                    ntohs(addr.sin_port).toInt()
+                }
+        }
+    }
+}


### PR DESCRIPTION
First suite from the QUIC stability epic #87: **network-impairment**.

Generalizes the passive-migration in-process-UDP-proxy pattern into an `ImpairingProxy` that applies **deterministic** loss / reordering / duplication / latency+jitter / total blackhole to the QUIC data path, asserting the connection survives and a multi-datagram payload still round-trips byte-for-byte — exercising quiche's retransmit / ACK / loss-recovery / reassembly / dedup, which nothing else covered.

### Design (same 3-tier shape as `QuicPassiveMigrationTestSuite`, plus an Android copy)
- **commonTest** `QuicImpairmentTestSuite` — abstract suite + `ImpairingProxy` interface + pure stateless `ImpairmentPolicy`/`ImpairAction`/`Direction` + the 6 test bodies.
- **jvmTest** `DatagramChannelImpairingProxy` — blocking `DatagramChannel` + daemon threads.
- **linuxTest** `IoUringImpairingProxy` — io_uring primitives.
- **androidInstrumentedTest** `AndroidQuicImpairmentTests` — self-contained parallel copy (`androidInstrumentedTest` can't see `commonTest`).

### The 6 tests
`streamSurvivesDeterministicLoss`, `streamSurvivesReordering`, `streamSurvivesDuplication`, `streamSurvivesLatencyAndJitter`, `streamSurvivesBurstLossThenRecovery`, and the anti-vacuous guard `streamStallsUnderTotalBlackhole`.

### Determinism discipline
No randomness, no probabilistic flake-catchers. Impairment is driven purely by a per-direction datagram **index**. The proxy starts pass-through; the test does one clean warm-up echo (handshake + stream established) then `arm()`s — so only the *data phase* is impaired, with no packet parsing and no handshake-flight guessing. Reorder is a structural hold-release (not a timed delay). Each positive test asserts its impairment **counter > 0**, and `streamStallsUnderTotalBlackhole` proves the proxy is the sole path. Verified by a **negative check**: neutering `arm()` makes all 6 fail on their specific guard.

### No netem, no CI changes
Deliberately **in-process** rather than real `netem`/`tc`/`iptables` (which need NET_ADMIN, mutate the host netns, and are unreachable from the Linux K/N test process). Runs hermetically under the existing `jvmTest` / `linuxX64Test` / Android-emulator jobs — no workflow changes.

The Linux concrete tears down via `closeFd → join-loop → freeBuffers` (not the io_uring `submitAndWait` cancellation path), avoiding a use-after-free of the recv structures that glibc aborts the test process on.

### Validation (local)
- JVM: 6/6 + negative check (all 6 fail when impairment neutered)
- linuxX64: 6/6, stable across repeated fresh runs
- Android emulator: 6/6 (0 skipped)
- JS + wasmJs: compile; ktlint clean

Apple K/N + Windows concretes deferred (no local runners). Scope per #87 + discussion: JVM + Linux + Android.

Part of #87. Batches with the already-merged #84 as test-only changes.