### PR TITLE
fix(quic): QUICHE_ERR_DONE on stream write is back-pressure, not a fatal error (#87 suite 3)

### DIFF
--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -657,6 +657,14 @@ class QuicheDriver(
 
         /** Cap on spare source CIDs issued per connection (bounded further by connScidsLeft). */
         const val MAX_SPARE_SCIDS = 3
+
+        /**
+         * `QUICHE_ERR_DONE` (RFC-agnostic quiche sentinel). On a stream *write* it means the stream is
+         * flow-control blocked with no capacity right now — back-pressure, not failure — and the caller
+         * should retry once the peer's `MAX_STREAM_DATA` / `MAX_DATA` reopens the window. (The read path
+         * already maps it to [StreamRecvResult.Done].)
+         */
+        const val QUICHE_ERR_DONE = -1
     }
 }
 
@@ -729,9 +737,14 @@ class DriverStreamAdapter(
                 val deferred = CompletableDeferred<Int>()
                 driver.commands.send(QuicheCmd.StreamSend(streamId.id, addr, remaining, false, deferred))
                 deferred.await()
-            }.also { written ->
-                if (written < 0) {
-                    throw SocketClosedException.General("quiche stream write error: $written")
+            }.let { written ->
+                when {
+                    // Flow-control blocked: 0 bytes accepted. Report back-pressure (not an error) so the
+                    // caller retries when the window reopens — otherwise a write larger than the current
+                    // window throws. Symmetric with the read path's StreamRecvResult.Done handling.
+                    written == QuicheDriver.QUICHE_ERR_DONE -> 0
+                    written < 0 -> throw SocketClosedException.General("quiche stream write error: $written")
+                    else -> written
                 }
             }
         } catch (_: ClosedSendChannelException) {

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -4,6 +4,7 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.nativeMemoryAccess
+import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.first
@@ -371,6 +372,45 @@ class ReactiveDriverTests {
 
             driver.destroy()
             Unit
+        }
+
+    // ---- streamWrite back-pressure (QUICHE_ERR_DONE) ----
+
+    /**
+     * Regression for the write-path back-pressure fix (#87 suite 3): quiche returns `QUICHE_ERR_DONE`
+     * (-1) from `conn_stream_send` when the stream is flow-control blocked with no capacity. That is
+     * back-pressure, not failure — [DriverStreamAdapter.streamWrite] must report 0 bytes accepted so the
+     * caller retries, NOT throw. It previously threw `SocketClosedException` on any `written < 0`, which
+     * made a write larger than the current window fail. A real (more-negative) error still throws.
+     */
+    @Test
+    fun streamWrite_mapsQuicheErrDoneToZeroBackpressure() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api)
+            driver.start(this)
+            try {
+                val adapter = DriverStreamAdapter(driver, StreamSlot(QuicStreamId(0L)))
+                val buf = bufferFactory.allocate(64)
+
+                // QUICHE_ERR_DONE (-1) -> 0 bytes accepted (back-pressure), no throw.
+                api.connStreamSendResult = -1
+                assertEquals(0, adapter.streamWrite(QuicStreamId(0L), buf, 2.seconds), "Done must map to 0, not throw")
+
+                // A normal (partial or full) accept passes through unchanged.
+                api.connStreamSendResult = 64
+                assertEquals(64, adapter.streamWrite(QuicStreamId(0L), buf, 2.seconds))
+
+                // A real negative error code still throws.
+                api.connStreamSendResult = -7
+                assertFailsWith<SocketClosedException>("a real error must still throw") {
+                    adapter.streamWrite(QuicStreamId(0L), buf, 2.seconds)
+                }
+
+                buf.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
         }
 
     // ---- Helpers ----

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -201,13 +201,16 @@ internal class StubQuicheApi : QuicheApi {
         bufLen: Int,
     ) = streamRecvResult
 
+    /** When set, [connStreamSend] returns this instead of [bufLen] — e.g. -1 (QUICHE_ERR_DONE) or a real error. */
+    @Volatile var connStreamSendResult: Int? = null
+
     override fun connStreamSend(
         conn: QuicheConn,
         streamId: QuicStreamId,
         buf: Long,
         bufLen: Int,
         fin: Boolean,
-    ) = bufLen
+    ) = connStreamSendResult ?: bufLen
 
     override fun connIsEstablished(conn: QuicheConn) = established
 


### PR DESCRIPTION
While building epic #87's large-payload / flow-control suite (#3), the suite immediately surfaced a real driver bug and this PR lands the well-scoped fix for it.

### The bug
quiche returns `QUICHE_ERR_DONE` (-1) from `conn_stream_send` when a stream is flow-control blocked with no capacity — that's **back-pressure, not failure**. The read path already maps it to `StreamRecvResult.Done`, but `DriverStreamAdapter.streamWrite` treated any `written < 0` as fatal and threw `SocketClosedException`. So **a single write larger than the current flow-control window failed** — any MB-scale single-stream send was impossible (the first window-fill threw).

### The fix
Map `Done` to "0 bytes accepted" so the caller retries when the peer's `MAX_STREAM_DATA` / `MAX_DATA` reopens the window; a real (more-negative) error still throws. Symmetric with the existing read-path `Done` handling. ~4 lines in `QuicheDriver.streamWrite`.

### Test
Deterministic unit test in `ReactiveDriverTests` via a new `StubQuicheApi.connStreamSendResult` knob: drive `conn_stream_send` to return `Done` / a normal count / a real error and assert `streamWrite` returns `0` / `N` / throws. **Negative-checked**: reverting the fix fails the test on `-1`.

### Why no integration suite (yet)
The large-payload integration suite (single + multiple interleaved streams) is **deferred to #91** — a separate, deeper driver readable-signal/flush race that intermittently (~17%) wedges a one-directional bulk stream's server-side read once the connection goes idle after write+FIN. It's a Heisenbug (instrumentation masks it), and the bidirectional echo suites (#1, #2) never expose it because their constant packet exchange re-triggers delivery. There's no clean bidirectional bulk alternative (large bidirectional echo deadlocks on the windows, per suite #1), so the integration suite can't be deterministic until #91 is fixed. This PR deliberately lands only the deterministic fix + unit test.

### Validation (local)
- JVM full suite: 178/0
- linuxX64: unit test green
- JS + wasmJs: compile; ktlint clean

Part of #87. Follows suites #1 (#89) and #2 (#90), both merged.