### PR TITLE
test(quic): malformed-packet / parser fuzz suite for JVM+Linux+Android (#87 suite 4)

### DIFF
--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicMalformedPacketTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicMalformedPacketTests.kt
@@ -1,0 +1,150 @@
+package com.ditchoom.socket.quic
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Malformed-packet / parser fuzz tests on Android — the Android port of the JVM/Linux
+ * [QuicMalformedPacketTestSuite] (issue #87, suite #4). `androidInstrumentedTest` can't see `commonTest`,
+ * so this is a self-contained parallel copy. Sends a fixed set of malformed datagrams to the server's
+ * UDP port and asserts the header-parse + recv path survives and still serves a legitimate client.
+ */
+@RunWith(AndroidJUnit4::class)
+class AndroidQuicMalformedPacketTests {
+    private val options =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    private val tlsConfig get() = AndroidTestCerts.tlsConfig
+
+    @Test
+    fun serverSurvivesMalformedDatagramsThenServesLegitClient() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib {
+                withTimeout(25.seconds) {
+                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = options) {
+                        val serverJob = launch(Dispatchers.IO) { echoEveryStream() }
+                        try {
+                            for (datagram in MALFORMED_DATAGRAMS) sendRawDatagram(port, datagram)
+                            withQuicConnection("127.0.0.1", port, options, timeout = 10.seconds) {
+                                val stream = openStream()
+                                assertEquals(
+                                    "alive",
+                                    stream.echoOnce("alive"),
+                                    "server did not serve a legit client after malformed datagrams",
+                                )
+                                stream.close()
+                            }
+                        } finally {
+                            serverJob.cancel()
+                        }
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun liveConnectionSurvivesMalformedDatagrams() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib {
+                withTimeout(25.seconds) {
+                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = options) {
+                        val serverJob = launch(Dispatchers.IO) { echoEveryStream() }
+                        try {
+                            withQuicConnection("127.0.0.1", port, options, timeout = 10.seconds) {
+                                val stream = openStream()
+                                assertEquals("before", stream.echoOnce("before"), "echo failed before the blast")
+                                for (datagram in MALFORMED_DATAGRAMS) sendRawDatagram(port, datagram)
+                                assertEquals("after", stream.echoOnce("after"), "live connection broke after malformed datagrams")
+                                stream.close()
+                            }
+                        } finally {
+                            serverJob.cancel()
+                        }
+                    }
+                }
+            }
+        }
+
+    // ---- helpers -----------------------------------------------------------------------------------
+
+    private suspend fun sendRawDatagram(
+        port: Int,
+        bytes: ByteArray,
+    ) {
+        DatagramChannel.open().use { channel ->
+            channel.send(ByteBuffer.wrap(bytes), InetSocketAddress("127.0.0.1", port))
+        }
+    }
+
+    private suspend fun QuicServer.echoEveryStream() {
+        connections {
+            val stream = acceptStream()
+            while (true) {
+                val data = stream.read(8.seconds)
+                if (data is ReadResult.Data) {
+                    stream.write(data.buffer, 5.seconds)
+                } else {
+                    break
+                }
+            }
+            stream.close()
+        }
+    }
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.Default.allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        write(out, 5.seconds)
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) {
+            val s = resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8)
+            resp.buffer.freeIfNeeded()
+            s
+        } else {
+            "no_data"
+        }
+    }
+
+    private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    private companion object {
+        private val MALFORMED_DATAGRAMS: List<ByteArray> =
+            listOf(
+                ByteArray(1),
+                ByteArray(20),
+                ByteArray(64) { 0xFF.toByte() },
+                byteArrayOf(0xC0.toByte(), 0x00, 0x00, 0x00, 0x01),
+                byteArrayOf(0xC0.toByte(), 0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(), 0x04, 1, 2, 3, 4, 0x00),
+                byteArrayOf(0xC0.toByte(), 0x00, 0x00, 0x00, 0x01, 0xFF.toByte(), 1, 2, 3),
+                byteArrayOf(0x40, 0x01, 0x02, 0x03),
+                ByteArray(2000) { (it * 31 % 256).toByte() },
+            )
+    }
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicMalformedPacketTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicMalformedPacketTestSuite.kt
@@ -1,0 +1,153 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared **malformed-packet / parser fuzz** test suite (issue #87, suite #4). Feeds a fixed set of
+ * truncated / garbage / wrong-version / over-long-CID / oversized datagrams to the server's UDP port and
+ * asserts the server's header-parse (`headerInfo`) + driver recv path survives — both before any
+ * connection and while a legitimate connection is live. High value given the K/N sockaddr / cinterop
+ * SIGABRT history: a single un-checked parse on the recv path takes down the whole process, so "the
+ * server still works after the blast" is a real crash check, not a no-op.
+ *
+ * Same 3-tier shape as the other suites: commonTest abstract + per-platform [testTlsConfig] and a
+ * [sendRawDatagram] primitive (a plain UDP send, no QUIC); Android has a self-contained parallel copy
+ * (`AndroidQuicMalformedPacketTests`).
+ *
+ * **Determinism.** The malformed datagrams are a fixed, hand-written list — not random fuzzing — and the
+ * assertion is an exact echo round-trip after the blast. A crash (SIGABRT/SIGSEGV) takes the whole test
+ * binary down; a parse that wrongly created/corrupted connection state would fail the post-blast echo.
+ */
+abstract class QuicMalformedPacketTestSuite {
+    abstract fun testTlsConfig(): QuicTlsConfig
+
+    /** Platform hook for skip-on-missing-native-lib (JVM converts `UnsatisfiedLinkError` to a skip). */
+    protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
+
+    /** Send a single raw UDP datagram (no QUIC) of [bytes] to `127.0.0.1:[port]`. */
+    abstract suspend fun sendRawDatagram(
+        port: Int,
+        bytes: ByteArray,
+    )
+
+    private val options =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    // ---- tests -------------------------------------------------------------------------------------
+
+    /** Blast malformed datagrams at the server, then a legitimate client must still connect and echo. */
+    @Test
+    fun serverSurvivesMalformedDatagramsThenServesLegitClient() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = options) {
+                    val serverJob = launch { echoEveryStream() }
+                    try {
+                        for (datagram in MALFORMED_DATAGRAMS) sendRawDatagram(port, datagram)
+
+                        withQuicConnection("127.0.0.1", port, options, timeout = 10.seconds) {
+                            val stream = openStream()
+                            assertEquals("alive", stream.echoOnce("alive"), "server did not serve a legit client after malformed datagrams")
+                            stream.close()
+                        }
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
+    /** With a live connection, blast malformed datagrams at the server; the connection must keep echoing. */
+    @Test
+    fun liveConnectionSurvivesMalformedDatagrams() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = options) {
+                    val serverJob = launch { echoEveryStream() }
+                    try {
+                        withQuicConnection("127.0.0.1", port, options, timeout = 10.seconds) {
+                            val stream = openStream()
+                            assertEquals("before", stream.echoOnce("before"), "echo failed before the blast")
+
+                            for (datagram in MALFORMED_DATAGRAMS) sendRawDatagram(port, datagram)
+
+                            assertEquals("after", stream.echoOnce("after"), "live connection broke after malformed datagrams")
+                            stream.close()
+                        }
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
+    // ---- helpers -----------------------------------------------------------------------------------
+
+    private suspend fun QuicServer.echoEveryStream() {
+        connections {
+            val stream = acceptStream()
+            while (true) {
+                val data = stream.read(8.seconds)
+                if (data is ReadResult.Data) {
+                    stream.write(data.buffer, 5.seconds)
+                } else {
+                    break
+                }
+            }
+            stream.close()
+        }
+    }
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.deterministic().allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        try {
+            write(out, 5.seconds)
+        } finally {
+            out.freeNativeMemory()
+        }
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) {
+            val s = resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8)
+            resp.buffer.freeIfNeeded()
+            s
+        } else {
+            "no_data"
+        }
+    }
+
+    companion object {
+        /**
+         * Fixed malformed datagrams targeting the server's `headerInfo` + recv path. QUIC long header =
+         * first byte `0x80 | …`, 4-byte version, 1-byte DCID len + DCID, 1-byte SCID len + SCID, …
+         * Each must be dropped (or rejected by quiche) without crashing the process.
+         */
+        private val MALFORMED_DATAGRAMS: List<ByteArray> =
+            listOf(
+                ByteArray(1), // single zero byte — far too short for any header
+                ByteArray(20), // all-zero short header — DCID routes to nothing
+                ByteArray(64) { 0xFF.toByte() }, // all-ones
+                // long header v1, truncated before DCID len
+                byteArrayOf(0xC0.toByte(), 0x00, 0x00, 0x00, 0x01),
+                // long header, unknown version 0xDEADBEEF, DCID len 4
+                byteArrayOf(0xC0.toByte(), 0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(), 0x04, 1, 2, 3, 4, 0x00),
+                // long header v1 claiming DCID len 255 but truncated
+                byteArrayOf(0xC0.toByte(), 0x00, 0x00, 0x00, 0x01, 0xFF.toByte(), 1, 2, 3),
+                byteArrayOf(0x40, 0x01, 0x02, 0x03), // short header (fixed bit) + garbage
+                ByteArray(2000) { (it * 31 % 256).toByte() }, // oversized pseudo-random payload
+            )
+    }
+}

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMalformedPacketTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicMalformedPacketTests.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.socket.quic
+
+import org.junit.Assume.assumeTrue
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+
+/**
+ * JVM malformed-packet fuzz test — the JVM member of the shared [QuicMalformedPacketTestSuite]. Provides
+ * JVM cert resolution, the `UnsatisfiedLinkError → assumeTrue` skip, and a plain [DatagramChannel]
+ * sender for the raw datagrams.
+ */
+class QuicMalformedPacketTests : QuicMalformedPacketTestSuite() {
+    private fun certPath(name: String): String {
+        val url =
+            this::class.java.classLoader.getResource("certs/$name")
+                ?: error("Test cert not found: certs/$name")
+        return java.io.File(url.toURI()).absolutePath
+    }
+
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    override suspend fun sendRawDatagram(
+        port: Int,
+        bytes: ByteArray,
+    ) {
+        DatagramChannel.open().use { channel ->
+            channel.send(ByteBuffer.wrap(bytes), InetSocketAddress("127.0.0.1", port))
+        }
+    }
+}

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicMalformedPacketTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicMalformedPacketTests.kt
@@ -1,0 +1,69 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.usePinned
+import platform.posix.AF_INET
+import platform.posix.F_OK
+import platform.posix.INADDR_LOOPBACK
+import platform.posix.SOCK_DGRAM
+import platform.posix.access
+import platform.posix.close
+import platform.posix.htonl
+import platform.posix.htons
+import platform.posix.sendto
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.socket
+
+/**
+ * Kotlin/Native (linuxX64) malformed-packet fuzz test — the K/N member of the shared
+ * [QuicMalformedPacketTestSuite]. Provides linuxX64 cert resolution and a POSIX `sendto` for the raw
+ * datagrams. Native compiles quiche via cinterop, so there is no `UnsatisfiedLinkError` skip path.
+ */
+class LinuxQuicMalformedPacketTests : QuicMalformedPacketTestSuite() {
+    private fun certPath(name: String): String {
+        val candidates = listOf("testcerts/$name", "socket-quic/testcerts/$name")
+        return candidates.firstOrNull { access(it, F_OK) == 0 }
+            ?: error("Test cert not found: $name (tried $candidates)")
+    }
+
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    override suspend fun sendRawDatagram(
+        port: Int,
+        bytes: ByteArray,
+    ) {
+        val fd = socket(AF_INET, SOCK_DGRAM, 0)
+        check(fd >= 0) { "raw datagram socket() failed" }
+        try {
+            memScoped {
+                val addr = alloc<sockaddr_in>()
+                addr.sin_family = AF_INET.convert()
+                addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK)
+                addr.sin_port = htons(port.toUShort())
+                // Empty datagrams are valid UDP; pin a 1-element backing array but send 0 bytes for those.
+                val pinnedBytes = if (bytes.isEmpty()) ByteArray(1) else bytes
+                pinnedBytes.usePinned { pinned ->
+                    sendto(
+                        fd,
+                        pinned.addressOf(0),
+                        bytes.size.convert(),
+                        0,
+                        addr.ptr.reinterpret<sockaddr>(),
+                        sizeOf<sockaddr_in>().convert(),
+                    )
+                }
+            }
+        } finally {
+            close(fd)
+        }
+    }
+}


### PR DESCRIPTION
Fourth suite from the QUIC stability epic #87: **malformed-packet / parser fuzz**.

Feeds a fixed set of malformed datagrams to the server's UDP port and asserts the **header-parse (`headerInfo`) + driver recv path survives** — both before any connection and while a legitimate connection is live, after which a real client must still echo.

### The malformed inputs (deterministic, fixed list — not random fuzzing)
single zero byte · all-zero short header · all-ones · long-header truncated before DCID len · long header with unknown version `0xDEADBEEF` · long header claiming DCID len 255 but truncated · short-header + garbage · 2 KB pseudo-random payload.

### The 2 tests (commonTest abstract + JVM/Linux concretes + self-contained Android copy)
- **`serverSurvivesMalformedDatagramsThenServesLegitClient`** — blast the datagrams, then a legit client must connect + echo.
- **`liveConnectionSurvivesMalformedDatagrams`** — establish a connection, echo, blast the datagrams, echo again — the live connection must keep working.

### Why it matters
Given the K/N sockaddr/cinterop SIGABRT history, an un-checked parse on the recv path takes the **whole process** down. So "the server still echoes after the blast" is a real crash check — a SIGABRT/SIGSEGV fails the test binary, and a parse that wrongly created/corrupted connection state fails the post-blast echo. The JVM server already drops malformed packets cleanly (`headerInfo` `rc < 0 → continue`); this proves the Linux K/N recv path does too.

### `sendRawDatagram` primitive
Plain UDP send (no QUIC): `DatagramChannel` on JVM/Android, POSIX `sendto` on Linux K/N.

### Validation (local)
- JVM: 2/2 · linuxX64: 2/2 (no SIGABRT through the cinterop sockaddr path) · Android emulator: 2/2 (0 skipped) · JS+wasmJs compile; ktlint clean.

No production change, no CI change. Part of #87, after suites #1 (#89), #2 (#90), and the #3 driver fix (#92), all merged.