### PR TITLE
test(quic): wasmJs QUIC-gap contract tests — close the zero-test coverage hole (#87 suite 6)

### DIFF
--- a/socket-quic/src/wasmJsTest/kotlin/com/ditchoom/socket/quic/WasmJsQuicGapTests.kt
+++ b/socket-quic/src/wasmJsTest/kotlin/com/ditchoom/socket/quic/WasmJsQuicGapTests.kt
@@ -1,0 +1,62 @@
+package com.ditchoom.socket.quic
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Diagnostic / contract tests documenting the **known wasmJs QUIC gap** (issue #87, suite #6).
+ *
+ * `wasmJsTest` previously had **zero** tests — a silently-uncovered target, exactly the failure mode
+ * #67/#72 fixed on Android where a "green" suite executed zero cases. QUIC is unsupported on wasmJs for
+ * the same reason as JS plus more: the browser sandbox has no raw UDP access. The `wasmJsMain` actuals
+ * are documented placeholders that throw [UnsupportedOperationException].
+ *
+ * These mirror [com.ditchoom.socket.quic.JsQuicGapTests] (the JS Node gap tests): they **run** on wasmJs
+ * (not a silent skip) and positively assert the contract — the public entry points throw a cleanly
+ * catchable [UnsupportedOperationException] (deliberately not `Error`/`NotImplementedError`). If/when
+ * wasmJs QUIC ever lands, these tests fail, forcing real coverage to replace this placeholder.
+ */
+class WasmJsQuicGapTests {
+    private val quicOptions =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 10.seconds,
+        )
+
+    @Test
+    fun withQuicConnection_is_an_unsupported_placeholder_on_wasmJs() =
+        runQuicTest {
+            val error =
+                assertFailsWith<UnsupportedOperationException> {
+                    withQuicConnection("127.0.0.1", 4433, quicOptions) {
+                        error("unreachable: wasmJs QUIC client must not establish a connection")
+                    }
+                }
+            assertTrue(
+                error.message?.contains("not supported", ignoreCase = true) == true,
+                "expected the documented wasmJs placeholder message, got: ${error.message}",
+            )
+        }
+
+    @Test
+    fun withQuicServer_is_an_unsupported_placeholder_on_wasmJs() =
+        runQuicTest {
+            val error =
+                assertFailsWith<UnsupportedOperationException> {
+                    withQuicServer(
+                        port = 0,
+                        tlsConfig = QuicTlsConfig(certChainPath = "unused", privKeyPath = "unused"),
+                        quicOptions = quicOptions,
+                    ) {
+                        error("unreachable: wasmJs QUIC server must not bind")
+                    }
+                }
+            assertTrue(
+                error.message?.contains("not supported", ignoreCase = true) == true,
+                "expected the documented wasmJs placeholder message, got: ${error.message}",
+            )
+        }
+}


### PR DESCRIPTION
Sixth and **final** suite from the QUIC stability epic #87: the **wasmJs gap test**.

`wasmJsTest` previously had **zero** tests — a silently-uncovered target (the #67/#72 failure mode where a "green" suite executes nothing). QUIC is unsupported on wasmJs (the browser sandbox has no raw UDP access); the `wasmJsMain` actuals are documented placeholders that throw `UnsupportedOperationException`.

### The test
`WasmJsQuicGapTests` mirrors `JsQuicGapTests`: it **runs** on wasmJs (not a silent skip) and positively asserts the contract — `withQuicConnection` and `withQuicServer` throw a cleanly catchable `UnsupportedOperationException` ("not supported …"). If/when wasmJs QUIC ever lands, these tests fail, forcing real loopback coverage to replace the placeholder — exactly as intended.

### Validation (local)
- `:socket-quic:wasmJsTest` 2/2 (browser + node); ktlint clean.

Test-only, no production/CI change. **This closes out epic #87** — all six suites done:
| Suite | PR |
|---|---|
| #1 impairment | #89 ✅ |
| #2 concurrency+soak | #90 ✅ |
| #3 large-payload → `QUICHE_ERR_DONE` driver fix | #92 ✅ |
| #4 malformed-packet fuzz | #93 ✅ |
| #5 idle-timeout/keepalive | #94 ✅ |
| #6 wasmJs gap | this PR |

Plus filed #91 (concurrent-bulk readable-signal race) for the deferred large-payload *integration* suite.