### PR TITLE
fix(quic): carry a FIN coalesced with the last data chunk so the stream read doesn't wedge (#91)

### DIFF
--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicLargePayloadTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicLargePayloadTests.kt
@@ -1,0 +1,150 @@
+package com.ditchoom.socket.quic
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Large-payload / flow-control integration tests on Android — the Android port of
+ * [QuicLargePayloadTestSuite] (issue #87 suite 3; unblocked by the #91 fix). Self-contained parallel
+ * copy (androidInstrumentedTest can't see commonTest).
+ */
+@RunWith(AndroidJUnit4::class)
+class AndroidQuicLargePayloadTests {
+    private val tlsConfig get() = AndroidTestCerts.tlsConfig
+
+    private val options =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 30.seconds,
+            flowControl =
+                FlowControl(
+                    initialMaxData = CONN_WINDOW,
+                    initialMaxStreamDataBidiLocal = STREAM_WINDOW,
+                    initialMaxStreamDataBidiRemote = STREAM_WINDOW,
+                    initialMaxStreamDataUni = STREAM_WINDOW,
+                    initialMaxStreamsBidi = 64,
+                ),
+        )
+
+    @Test
+    fun largePayloadTransfersIntactOnOneStream() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib { withTimeout(25.seconds) { transferAndVerify(1, SINGLE_PAYLOAD) } }
+        }
+
+    @Test
+    fun multipleInterleavedStreamsTransferIntact() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib { withTimeout(25.seconds) { transferAndVerify(MULTI_STREAMS, MULTI_PER_STREAM) } }
+        }
+
+    private suspend fun transferAndVerify(
+        streamCount: Int,
+        perStreamBytes: Int,
+    ) = coroutineScope {
+        val results = Channel<Pair<Long, Boolean>>(capacity = streamCount)
+        withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = options) {
+            val serverJob =
+                launch(Dispatchers.IO) {
+                    connections {
+                        streams().collect { stream ->
+                            launch {
+                                results.send(stream.verifyPattern())
+                                stream.close()
+                            }
+                        }
+                    }
+                }
+            try {
+                withQuicConnection("127.0.0.1", port, options, timeout = 15.seconds) {
+                    (0 until streamCount)
+                        .map {
+                            async(Dispatchers.IO) {
+                                val stream = openStream()
+                                stream.writeAllPattern(perStreamBytes)
+                                stream.close()
+                            }
+                        }.awaitAll()
+                    repeat(streamCount) {
+                        val (count, ok) = results.receive()
+                        assertEquals(perStreamBytes.toLong(), count, "stream transfer truncated/overran ($count of $perStreamBytes bytes)")
+                        assertTrue(ok, "stream payload corrupted or reordered")
+                    }
+                }
+            } finally {
+                serverJob.cancel()
+            }
+        }
+    }
+
+    private suspend fun QuicByteStream.verifyPattern(): Pair<Long, Boolean> {
+        var offset = 0L
+        var ok = true
+        while (true) {
+            val r = read(15.seconds)
+            if (r is ReadResult.Data) {
+                val bytes = r.buffer.readByteArray(r.buffer.remaining())
+                r.buffer.freeIfNeeded()
+                for (b in bytes) {
+                    if (b != ((offset % 251).toByte())) ok = false
+                    offset++
+                }
+            } else {
+                break
+            }
+        }
+        return offset to ok
+    }
+
+    private suspend fun QuicByteStream.writeAllPattern(total: Int) {
+        val pattern = ByteArray(total) { (it % 251).toByte() }
+        val buf = BufferFactory.Default.allocate(total)
+        buf.writeBytes(pattern)
+        buf.resetForRead()
+        writeAll(buf)
+    }
+
+    private suspend fun QuicByteStream.writeAll(buf: PlatformBuffer) {
+        while (buf.remaining() > 0) {
+            val n = write(buf, 15.seconds).count
+            if (n > 0) buf.position(buf.position() + n) else delay(2.milliseconds)
+        }
+    }
+
+    private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    private companion object {
+        private const val SINGLE_PAYLOAD = 1 * 1024 * 1024
+        private const val MULTI_STREAMS = 4
+        private const val MULTI_PER_STREAM = 256 * 1024
+        private const val STREAM_WINDOW = 128L * 1024
+        private const val CONN_WINDOW = 8L * 1024 * 1024
+    }
+}

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -687,22 +687,38 @@ class DriverStreamAdapter(
 
         try {
             return withTimeout(timeout) {
+                // The FIN may have arrived coalesced with the last data chunk on a previous read()
+                // (which returned that Data and recorded the FIN here). quiche has already delivered it,
+                // so there is no further data and no readable-signal coming — return End now instead of
+                // issuing a StreamRecv that returns Done and parking on dataSignal forever.
+                if (slot.finReceived) {
+                    buffer.freeNativeMemory()
+                    return@withTimeout ReadResult.End
+                }
                 while (true) {
                     val deferred = CompletableDeferred<StreamRecvResult>()
                     driver.commands.send(QuicheCmd.StreamRecv(streamId.id, addr, bufferSize, deferred))
                     when (val result = deferred.await()) {
                         is StreamRecvResult.Data -> {
-                            if (result.bytesRead == 0 && result.fin) {
-                                buffer.freeNativeMemory()
-                                return@withTimeout ReadResult.End
-                            }
+                            // Record the FIN whether or not this chunk also carried data — a coalesced
+                            // FIN (bytes > 0 && fin) is otherwise dropped, wedging the next read().
+                            if (result.fin) slot.finReceived = true
                             if (result.bytesRead > 0) {
                                 buffer.position(result.bytesRead)
                                 buffer.resetForRead()
                                 return@withTimeout ReadResult.Data(buffer)
                             }
+                            // bytesRead == 0 implies a pure FIN (fin == true) — clean end of stream.
+                            buffer.freeNativeMemory()
+                            return@withTimeout ReadResult.End
                         }
                         is StreamRecvResult.Done -> {
+                            // Defensive: if the FIN was consumed earlier (coalesced with data), no signal
+                            // is coming — end now rather than park forever.
+                            if (slot.finReceived) {
+                                buffer.freeNativeMemory()
+                                return@withTimeout ReadResult.End
+                            }
                             slot.dataSignal.receive()
                             continue
                         }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/StreamSlot.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/StreamSlot.kt
@@ -1,6 +1,7 @@
 package com.ditchoom.socket.quic
 
 import kotlinx.coroutines.channels.Channel
+import kotlin.concurrent.Volatile
 
 /**
  * Per-stream state managed by the [QuicheDriver].
@@ -12,4 +13,15 @@ class StreamSlot(
     val id: QuicStreamId,
 ) {
     val dataSignal = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Set once quiche reports the stream's FIN — even when that FIN arrived *coalesced with the last
+     * data chunk* (`stream_recv` → bytes > 0 **and** fin = true). That data chunk is returned to the
+     * caller as [com.ditchoom.buffer.flow.ReadResult.Data], so the FIN itself can't be returned in the
+     * same `read()`; this flag carries it to the next `read()`, which returns
+     * [com.ditchoom.buffer.flow.ReadResult.End]. Without it, the reader would park on [dataSignal]
+     * forever — quiche has already delivered the FIN, so no further data or readable-signal is coming.
+     */
+    @Volatile
+    var finReceived = false
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicLargePayloadTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicLargePayloadTestSuite.kt
@@ -1,0 +1,179 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared **large-payload / flow-control** integration suite (issue #87 suite 3; unblocked by the #91
+ * fix). Transfers MB-scale data — single-stream and across multiple interleaved streams — through a
+ * stream flow-control window deliberately set **smaller than the payload**, so the transfer can only
+ * complete by cycling `MAX_STREAM_DATA`. Asserts every byte arrives intact and in order.
+ *
+ * This is the end-to-end exercise of two driver fixes that this work produced:
+ *  - the `QUICHE_ERR_DONE` write back-pressure fix (#92) — a write larger than the window no longer
+ *    throws; [writeAll] retries on a 0-accept;
+ *  - the #91 FIN-coalescing fix — when the last data chunk and the FIN arrive together, the server's
+ *    read no longer wedges, so a bulk stream (single or one of several concurrent) reliably completes.
+ *
+ * Same 3-tier shape as the other suites: commonTest abstract + per-platform [testTlsConfig]; Android has
+ * a self-contained parallel copy (`AndroidQuicLargePayloadTests`).
+ *
+ * **Shape.** A one-directional bulk transfer: the client writes the pattern and FINs (`stream.close()`
+ * is a full close, and reading MB-scale back on the same stream would deadlock on the windows). The
+ * server reads each stream to FIN, verifying every byte equals `offset % 251` — a position-aware check
+ * that catches corruption, reordering, and truncation — and reports `(count, ok)`.
+ *
+ * **Determinism.** Fixed payload sizes / stream counts and an exact per-byte check; the connection
+ * window is generous so only the per-stream window cycles (a tight shared connection window across the
+ * interleaved streams turns the write retry into a load-sensitive livelock — see the suite-3 history).
+ */
+abstract class QuicLargePayloadTestSuite {
+    abstract fun testTlsConfig(): QuicTlsConfig
+
+    /** Platform hook for skip-on-missing-native-lib (JVM converts `UnsatisfiedLinkError` to a skip). */
+    protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
+
+    private val options =
+        QuicOptions(
+            alpnProtocols = listOf("test"),
+            verifyPeer = false,
+            idleTimeout = 30.seconds,
+            flowControl =
+                FlowControl(
+                    initialMaxData = CONN_WINDOW,
+                    initialMaxStreamDataBidiLocal = STREAM_WINDOW,
+                    initialMaxStreamDataBidiRemote = STREAM_WINDOW,
+                    initialMaxStreamDataUni = STREAM_WINDOW,
+                    initialMaxStreamsBidi = 64,
+                ),
+        )
+
+    @Test
+    fun largePayloadTransfersIntactOnOneStream() =
+        runQuicTest {
+            wrapTestBody { transferAndVerify(streamCount = 1, perStreamBytes = SINGLE_PAYLOAD) }
+        }
+
+    @Test
+    fun multipleInterleavedStreamsTransferIntact() =
+        runQuicTest {
+            wrapTestBody { transferAndVerify(streamCount = MULTI_STREAMS, perStreamBytes = MULTI_PER_STREAM) }
+        }
+
+    // ---- orchestration -----------------------------------------------------------------------------
+
+    private suspend fun transferAndVerify(
+        streamCount: Int,
+        perStreamBytes: Int,
+    ) = coroutineScope {
+        // Every stream carries the same pattern of the same length, so we just collect [streamCount].
+        val results = Channel<Pair<Long, Boolean>>(capacity = streamCount)
+
+        withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = options) {
+            val serverJob =
+                launch {
+                    connections {
+                        streams().collect { stream ->
+                            launch {
+                                results.send(stream.verifyPattern())
+                                stream.close()
+                            }
+                        }
+                    }
+                }
+
+            try {
+                withQuicConnection("127.0.0.1", port, options, timeout = 15.seconds) {
+                    (0 until streamCount)
+                        .map {
+                            async {
+                                val stream = openStream()
+                                stream.writeAllPattern(perStreamBytes)
+                                stream.close() // FIN
+                            }
+                        }.awaitAll()
+
+                    repeat(streamCount) {
+                        val (count, ok) = results.receive()
+                        assertEquals(perStreamBytes.toLong(), count, "stream transfer truncated/overran ($count of $perStreamBytes bytes)")
+                        assertTrue(ok, "stream payload corrupted or reordered")
+                    }
+                }
+            } finally {
+                serverJob.cancel()
+            }
+        }
+    }
+
+    // ---- helpers -----------------------------------------------------------------------------------
+
+    /** Server side: read to FIN, verifying every byte equals `offset % 251`. Returns (bytesReceived, allMatched). */
+    private suspend fun QuicByteStream.verifyPattern(): Pair<Long, Boolean> {
+        var offset = 0L
+        var ok = true
+        while (true) {
+            val r = read(15.seconds)
+            if (r is ReadResult.Data) {
+                val bytes = r.buffer.readByteArray(r.buffer.remaining())
+                r.buffer.freeIfNeeded()
+                for (b in bytes) {
+                    if (b != ((offset % 251).toByte())) ok = false
+                    offset++
+                }
+            } else {
+                break // End (FIN) or Reset
+            }
+        }
+        return offset to ok
+    }
+
+    private suspend fun QuicByteStream.writeAllPattern(total: Int) {
+        val pattern = ByteArray(total) { (it % 251).toByte() }
+        val buf = BufferFactory.deterministic().allocate(total)
+        buf.writeBytes(pattern)
+        buf.resetForRead()
+        try {
+            writeAll(buf)
+        } finally {
+            buf.freeNativeMemory()
+        }
+    }
+
+    /** Write the whole buffer, advancing by the accepted count; a 0-accept is window-full back-pressure. */
+    private suspend fun QuicByteStream.writeAll(buf: PlatformBuffer) {
+        while (buf.remaining() > 0) {
+            val n = write(buf, 15.seconds).count
+            if (n > 0) {
+                buf.position(buf.position() + n)
+            } else {
+                delay(2.milliseconds) // window full — let the peer's MAX_STREAM_DATA land, then retry
+            }
+        }
+    }
+
+    private companion object {
+        private const val SINGLE_PAYLOAD = 1 * 1024 * 1024
+        private const val MULTI_STREAMS = 4
+        private const val MULTI_PER_STREAM = 256 * 1024
+
+        /** Per-stream window below the payload so the transfer must cycle MAX_STREAM_DATA. */
+        private const val STREAM_WINDOW = 128L * 1024
+
+        /** Generous so the connection window is never the bottleneck (avoids a load-sensitive livelock). */
+        private const val CONN_WINDOW = 8L * 1024 * 1024
+    }
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -3,6 +3,8 @@ package com.ditchoom.socket.quic
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
@@ -408,6 +410,41 @@ class ReactiveDriverTests {
                 }
 
                 buf.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    // ---- streamRead FIN coalesced with data (#91) ----
+
+    /**
+     * Regression for #91: when the final stream chunk delivers data **and** the FIN together
+     * (`stream_recv` → bytes > 0 && fin), [DriverStreamAdapter.streamRead] returns that Data — and must
+     * carry the FIN forward so the *next* read returns [ReadResult.End]. It previously dropped the FIN
+     * and parked on the stream's `dataSignal` forever (quiche had already delivered the FIN, so no
+     * further data or readable-signal was coming) — an intermittent hang of one of N bulk streams,
+     * deterministic here via [StubQuicheApi.streamRecvSequence].
+     */
+    @Test
+    fun streamRead_finCoalescedWithData_yieldsEndOnNextRead() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            // Last chunk: 10 bytes + FIN together; the finished stream then reports Done.
+            api.streamRecvSequence.addLast(StreamRecvResult.Data(bytesRead = 10, fin = true))
+            api.streamRecvResult = StreamRecvResult.Done
+            val driver = createTestDriver(api)
+            driver.start(this)
+            try {
+                val adapter = DriverStreamAdapter(driver, StreamSlot(QuicStreamId(0L)))
+
+                val first = adapter.streamRead(QuicStreamId(0L), bufferFactory, 1024, 2.seconds)
+                assertIs<ReadResult.Data>(first, "first read should deliver the coalesced data chunk")
+                first.buffer.freeIfNeeded()
+
+                // With the FIN dropped this would park on dataSignal and the streamRead withTimeout would
+                // throw; the fix must return End instead.
+                val second = adapter.streamRead(QuicStreamId(0L), bufferFactory, 1024, 2.seconds)
+                assertIs<ReadResult.End>(second, "FIN coalesced with data must yield End on the next read, not hang")
             } finally {
                 driver.destroy()
             }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -194,12 +194,18 @@ internal class StubQuicheApi : QuicheApi {
         return 0
     }
 
+    /**
+     * If non-empty, each [connStreamRecv] pops the next result (modelling quiche's sequence, e.g. a
+     * data-chunk-with-FIN followed by Done). Falls back to [streamRecvResult] once drained.
+     */
+    val streamRecvSequence: ArrayDeque<StreamRecvResult> = ArrayDeque()
+
     override fun connStreamRecv(
         conn: QuicheConn,
         streamId: QuicStreamId,
         buf: Long,
         bufLen: Int,
-    ) = streamRecvResult
+    ) = streamRecvSequence.removeFirstOrNull() ?: streamRecvResult
 
     /** When set, [connStreamSend] returns this instead of [bufLen] — e.g. -1 (QUICHE_ERR_DONE) or a real error. */
     @Volatile var connStreamSendResult: Int? = null

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicLargePayloadTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicLargePayloadTests.kt
@@ -1,0 +1,23 @@
+package com.ditchoom.socket.quic
+
+import org.junit.Assume.assumeTrue
+
+/** JVM large-payload integration test — the JVM member of [QuicLargePayloadTestSuite]. */
+class QuicLargePayloadTests : QuicLargePayloadTestSuite() {
+    private fun certPath(name: String): String {
+        val url =
+            this::class.java.classLoader.getResource("certs/$name")
+                ?: error("Test cert not found: certs/$name")
+        return java.io.File(url.toURI()).absolutePath
+    }
+
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+}

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicLargePayloadTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicLargePayloadTests.kt
@@ -1,0 +1,17 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import platform.posix.F_OK
+import platform.posix.access
+
+/** Kotlin/Native (linuxX64) large-payload integration test — the K/N member of [QuicLargePayloadTestSuite]. */
+class LinuxQuicLargePayloadTests : QuicLargePayloadTestSuite() {
+    private fun certPath(name: String): String {
+        val candidates = listOf("testcerts/$name", "socket-quic/testcerts/$name")
+        return candidates.firstOrNull { access(it, F_OK) == 0 }
+            ?: error("Test cert not found: $name (tried $candidates)")
+    }
+
+    override fun testTlsConfig() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+}


### PR DESCRIPTION
Fixes #91 — the intermittent stuck-read I filed while building epic #87's large-payload suite.

### Root cause (a code bug, not a true race)
`DriverStreamAdapter.streamRead` returned a data chunk as `ReadResult.Data` but **dropped the FIN flag** when quiche delivered both together (`stream_recv` → `bytesRead > 0 && fin == true`):

```kotlin
is StreamRecvResult.Data -> {
    if (result.bytesRead == 0 && result.fin) { ... return End }
    if (result.bytesRead > 0) { ... return Data(buffer) }   // ← coalesced fin DROPPED
}
```

quiche had already consumed the FIN, so the **next** `read()` got `QUICHE_ERR_DONE` and parked on the stream's `dataSignal` **forever** — a finished stream produces no further data or readable-signal. This wedged one of N one-directional bulk streams once the connection went idle after write+FIN. The ~17% (≈50%+ with several concurrent streams) tracked how often the tail data and FIN landed in the **same packet** — intermittent by coalescing timing, which is why `println` instrumentation masked it ("Heisenbug").

### The fix
Record the FIN on `StreamSlot.finReceived` (whether or not the chunk also carried data) and return `End` on the next read instead of parking. The existing separate-FIN path (`Data(0, fin=true) → End`) is unchanged.

### Tests
- **Deterministic unit regression** (`ReactiveDriverTests`) via a new `StubQuicheApi.streamRecvSequence`: `stream_recv` yields `Data(10, fin=true)` then `Done`; the next read must be `End`, not a hang. **Negative-checked** — disabling the FIN-record line makes it time out at 2 s.
- **Re-enables the large-payload integration suite** deferred from #87 suite 3 (`QuicLargePayloadTestSuite`: single-stream 1 MB + 4 interleaved 256 KB streams through a 128 KB window, byte-exact verification) — now deterministic. commonTest + JVM/Linux concretes + a self-contained Android copy.

### Validation (local)
- Repro: **30/30** with the fix (baseline ≥8 failures in ~10 runs)
- JVM integration suite: **15/15** · linuxX64: **10/10** · Android emulator: **4/4**
- Full `jvmTest`: **185/0** · JS+wasmJs compile · ktlint clean

This also completes epic #87's one remaining gap (the deferred large-payload *integration* coverage).