### PR TITLE
fix(linux): close() promptly cancels a parked io_uring recv (#83)

### DIFF
--- a/src/linuxMain/kotlin/com/ditchoom/socket/IoUringUtils.kt
+++ b/src/linuxMain/kotlin/com/ditchoom/socket/IoUringUtils.kt
@@ -578,6 +578,38 @@ object IoUringManager {
     }
 
     /**
+     * Test-observable count of cancel SQEs submitted via [cancelOperation].
+     * A deterministic test asserts this increments when close() cancels a parked
+     * read, instead of racing close() vs read() on wall-clock timing (issue #83).
+     */
+    internal val cancelSubmitCount = AtomicInt(0)
+
+    /**
+     * Submit a fire-and-forget io_uring cancel for an in-flight operation identified
+     * by [userData], so a concurrently-parked recv completes promptly with -ECANCELED
+     * instead of waiting out its full timeout.
+     *
+     * On Linux ARM64, closing the fd alone did NOT promptly cancel a parked recv
+     * (issue #83) — the read ran out its timeout and surfaced SocketTimeoutException
+     * rather than SocketClosedException. JVM (NIO2) raises AsynchronousCloseException
+     * immediately. Submitting an explicit cancel on close() makes the behavior prompt
+     * and identical across architectures. Cancel-by-userData (not by fd) is safe even
+     * after the fd is closed/reused, since the kernel matches the in-flight SQE by its
+     * user_data, not by fd number.
+     *
+     * Non-suspend: safe to call from the non-suspend closeInternal() path. No-op if the
+     * event loop isn't running (then there is no parked op to cancel).
+     */
+    fun cancelOperation(userData: Long) {
+        if (userData == 0L) return
+        if (pollerStarted.value != 1) return
+        cancelSubmitCount.incrementAndGet()
+        submitNoWaitUnsafe { sqe ->
+            io_uring_prep_cancel64(sqe, userData.toULong(), 0)
+        }
+    }
+
+    /**
      * Cleanup resources. Call when shutting down.
      *
      * Wakes the event loop via eventfd, waits for it to exit, then tears down

--- a/src/linuxMain/kotlin/com/ditchoom/socket/LinuxClientSocket.kt
+++ b/src/linuxMain/kotlin/com/ditchoom/socket/LinuxClientSocket.kt
@@ -8,6 +8,7 @@ import com.ditchoom.buffer.managedMemoryAccess
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.linux.*
 import kotlinx.cinterop.*
+import kotlin.concurrent.AtomicLong
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.TimeSource
@@ -32,6 +33,15 @@ class LinuxClientSocket : ClientToServerSocket {
      * Can be overridden by PlatformSocketConfig.readBufferSize if configured.
      */
     private var cachedReadBufferSize: Int = DEFAULT_READ_BUFFER_SIZE
+
+    /**
+     * user_data of the recv currently parked in io_uring, or 0 when no read is in flight.
+     * Set on the event loop thread once the recv SQE is prepared (see [readWithIoUring])
+     * so a concurrent [close] can cancel it; cleared when the read returns. Lets close()
+     * promptly complete a parked recv with -ECANCELED instead of waiting out its timeout
+     * (issue #83).
+     */
+    private val pendingReadUserData = AtomicLong(0L)
 
     override fun isOpen(): Boolean = sockfd >= 0
 
@@ -483,8 +493,18 @@ class LinuxClientSocket : ClientToServerSocket {
         timeout: Duration,
     ): Int {
         val fd = sockfd
-        return IoUringManager.submitAndWait(timeout) { sqe, _ ->
-            io_uring_prep_recv(sqe, fd, ptr, size.convert(), 0)
+        // Register the userData up front so close() can cancel this recv by id. Mark
+        // it parked inside prepareOp — which runs on the event loop thread AFTER the
+        // recv is registered in pendingOps — so a concurrent close() can never enqueue
+        // its cancel ahead of this recv in the FIFO submission channel. (issue #83)
+        val (userData, deferred) = IoUringManager.registerOperation()
+        return try {
+            IoUringManager.submitRegistered(userData, deferred, timeout) { sqe ->
+                io_uring_prep_recv(sqe, fd, ptr, size.convert(), 0)
+                pendingReadUserData.value = userData
+            }
+        } finally {
+            pendingReadUserData.compareAndSet(userData, 0L)
         }
     }
 
@@ -675,6 +695,12 @@ class LinuxClientSocket : ClientToServerSocket {
 
     private fun closeInternal() {
         val wasOpen = sockfd >= 0
+        // Promptly cancel a concurrently-parked recv so it returns -ECANCELED (→
+        // SocketClosedException) instead of waiting out its full timeout. Closing the
+        // fd alone is not prompt on Linux ARM64 (issue #83). Submit the cancel before
+        // closing the fd; it targets the recv by user_data, so it is correct regardless
+        // of fd state. A same-coroutine close (read already returned) sees 0 here.
+        IoUringManager.cancelOperation(pendingReadUserData.getAndSet(0L))
         ssl?.let {
             SSL_shutdown(it)
             SSL_free(it)
@@ -698,4 +724,11 @@ class LinuxClientSocket : ClientToServerSocket {
     override suspend fun close() {
         closeInternal()
     }
+
+    /**
+     * Test hook: user_data of the recv currently parked in io_uring, or 0 if no read is
+     * in flight. Lets a deterministic test wait until a read is observably parked before
+     * racing close() against it (issue #83) instead of guessing with a fixed delay.
+     */
+    internal fun parkedReadUserDataForTest(): Long = pendingReadUserData.value
 }

--- a/src/linuxTest/kotlin/com/ditchoom/socket/LinuxCloseCancelTests.kt
+++ b/src/linuxTest/kotlin/com/ditchoom/socket/LinuxCloseCancelTests.kt
@@ -1,0 +1,88 @@
+package com.ditchoom.socket
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Deterministic tests for issue #83: [LinuxClientSocket.close] must promptly cancel a
+ * concurrently-parked io_uring recv so the read surfaces [SocketClosedException] instead
+ * of running out its full timeout (the Linux ARM64 prompt-cancel gap; JVM/NIO2 already
+ * raises AsynchronousCloseException immediately).
+ *
+ * Determinism: the test waits until the recv is *observably* parked
+ * ([LinuxClientSocket.parkedReadUserDataForTest] != 0) before closing, and asserts on a
+ * cancel-submission counter — never on wall-clock timing. The 5s [withTimeout] is only a
+ * watchdog against a hang. This is the deliberate replacement for the timing-based
+ * LinuxConcurrentCloseTests removed in #82.
+ */
+class LinuxCloseCancelTests {
+    @Test
+    fun closeSubmitsCancelForParkedReadAndCompletesPromptly() =
+        runTestNoTimeSkipping {
+            val server = ServerSocket.allocate()
+            val acceptedClientFlow = server.bind()
+            val clientConnected = Mutex(locked = true)
+
+            // Server accepts then sits idle (never sends), so the client read parks.
+            val serverJob =
+                launch(Dispatchers.Default) {
+                    acceptedClientFlow.collect { serverToClient ->
+                        clientConnected.unlock()
+                        delay(30.seconds)
+                        serverToClient.close()
+                    }
+                }
+
+            val client = ClientSocket.allocate() as LinuxClientSocket
+            client.open(server.port())
+            clientConnected.lockWithTimeout()
+
+            val readResult = CompletableDeferred<Throwable?>()
+            launch(Dispatchers.Default) {
+                try {
+                    client.read(30.seconds)
+                    readResult.complete(null) // unexpected: read returned data
+                } catch (e: Throwable) {
+                    readResult.complete(e)
+                }
+            }
+
+            // Deterministic gate: wait until the recv is actually parked in io_uring,
+            // not a fixed sleep. Only then is close() guaranteed to race a live op, and
+            // (because the parked flag is set on the event loop thread after the recv is
+            // registered) the cancel can never be enqueued ahead of the recv.
+            withTimeout(5.seconds) {
+                while (client.parkedReadUserDataForTest() == 0L) {
+                    delay(5)
+                }
+            }
+
+            val cancelsBefore = IoUringManager.cancelSubmitCount.value
+            client.close()
+
+            // Assertion #1 (the deterministic one): close() submitted an io_uring cancel
+            // for the parked recv rather than relying on fd-close to do it.
+            assertTrue(
+                IoUringManager.cancelSubmitCount.value > cancelsBefore,
+                "close() should submit an io_uring cancel for the parked read",
+            )
+
+            // Assertion #2: the parked read completes (watchdog, not the timing assertion)
+            // with SocketClosedException — NOT SocketTimeoutException, the #83 symptom.
+            val thrown = withTimeout(5.seconds) { readResult.await() }
+            assertTrue(
+                thrown is SocketClosedException,
+                "parked read should fail with SocketClosedException after close(), was: $thrown",
+            )
+
+            server.close()
+            serverJob.cancel()
+        }
+}


### PR DESCRIPTION
Closes #83.

## Problem
`LinuxClientSocket.close()` closed the fd via `closeSocket()` but never cancelled the in-flight io_uring `recv` SQE bound to it. On **Linux ARM64**, closing the fd alone did **not** promptly complete a concurrently-parked `recv` with `-ECANCELED` — the parked `read()` ran out its full timeout and threw `SocketTimeoutException` instead of `SocketClosedException`. JVM (NIO2) raises `AsynchronousCloseException` immediately, so this was a cross-platform behavior gap.

This is the follow-up to #82 (which removed the flaky timing-based `LinuxConcurrentCloseTests`) and is distinct from #77 (which mapped `EBADF`/`ECANCELED` → `SocketClosedException`); #83 is specifically about *prompt* cancellation on close.

## Fix
- Track the parked recv's `user_data` (`pendingReadUserData`) and, on `close()`, submit `io_uring_prep_cancel64` for it **before** closing the fd (`IoUringManager.cancelOperation`).
- Cancel-by-`user_data` (not by fd) is correct regardless of fd state — the kernel matches the in-flight SQE by `user_data`, so it's safe even after fd close/reuse.
- The parked flag is set **inside `prepareOp`** — on the event loop thread, *after* the recv is registered in `pendingOps` — so a concurrent `close()` can never enqueue its cancel ahead of the recv in the FIFO submission channel.
- Mirrors the existing pattern in `LinuxServerSocket.close()` (`cancelPendingAccept`).

## Test
`LinuxCloseCancelTests` is **deterministic** — the deliberate replacement for the timing-based test removed in #82:
1. Waits until the recv is *observably* parked (`parkedReadUserDataForTest() != 0`) before racing `close()` — no fixed sleep.
2. Asserts `close()` submitted a cancel via `IoUringManager.cancelSubmitCount` — a counter, **not** wall-clock timing.
3. Asserts the parked read surfaces `SocketClosedException` (the 5s `withTimeout` is only a watchdog).

Runs on `linuxX64` (the ARM64 timing symptom is CI-only on the `Linux ARM64 (native)` job). Verified: **fails** with the cancel disabled (catches the regression deterministically on x64), **15/15 green** with the fix.

## Validation
- `:linuxX64Test` full suite: only pre-existing TLS-harness `CERTIFICATE_VERIFY_FAILED` failures (confirmed identical on clean `main` — environmental cert-trust, untouched by this change).
- `ktlintCheck` clean.