### PR TITLE
feat(quic): reactive writable-signal for the stream write path

### DIFF
--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicLargePayloadTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicLargePayloadTests.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -20,7 +19,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -125,10 +123,12 @@ class AndroidQuicLargePayloadTests {
         writeAll(buf)
     }
 
+    // No delay-poll on back-pressure: a full flow-control window makes `write` park reactively on the
+    // stream's writable-signal and resume when the peer's MAX_STREAM_DATA reopens it.
     private suspend fun QuicByteStream.writeAll(buf: PlatformBuffer) {
         while (buf.remaining() > 0) {
             val n = write(buf, 15.seconds).count
-            if (n > 0) buf.position(buf.position() + n) else delay(2.milliseconds)
+            buf.position(buf.position() + n)
         }
     }
 

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -302,7 +302,29 @@ class QuicheDriver(
         flushOutgoing()
         if (migrationEnabled) drainPathEvents()
         discoverNewStreams()
+        signalWritableStreams()
         updateState()
+    }
+
+    /**
+     * Wake any writer parked on a stream whose flow-control window just reopened. The write-path mirror
+     * of [discoverNewStreams]: quiche surfaces newly-writable streams via [QuicheApi.connWritable] (e.g.
+     * after a `MAX_STREAM_DATA` / `MAX_DATA` frame arrived in the command we just processed). Unlike the
+     * read path this **never creates a slot** — a writable stream we don't track is one nobody is writing
+     * to, so there is nothing to wake and a phantom slot would be an impossible state. The signal is
+     * CONFLATED, so signalling a stream with no parked writer is a harmless no-op.
+     */
+    private fun signalWritableStreams() {
+        val iter = api.connWritable(conn)
+        if (iter.isExhausted) return
+        try {
+            while (true) {
+                val streamId = api.streamIterNext(iter) ?: break
+                streams[streamId.id]?.writableSignal?.trySend(Unit)
+            }
+        } finally {
+            api.streamIterFree(iter)
+        }
     }
 
     private fun discoverNewStreams() {
@@ -589,6 +611,9 @@ class QuicheDriver(
 
         for (slot in streams.values) {
             slot.dataSignal.close()
+            // Unblock any writer parked on a reopened-window signal — without this it would hang until
+            // its withTimeout fired. streamWrite maps the resulting closed-channel to SocketClosedException.
+            slot.writableSignal.close()
         }
         streams.clear()
         api.connFree(conn)
@@ -764,41 +789,57 @@ class DriverStreamAdapter(
         buffer: ReadBuffer,
         timeout: Duration,
     ): Int {
-        val addr = buffer.nativeMemoryAccess!!.nativeAddress.toLong() + buffer.position()
         val remaining = buffer.remaining()
+        // Empty input: nothing to send (quiche would report 0). Return before touching the buffer's
+        // native address — a zero-length buffer may not expose one — and never park on an empty write.
+        if (remaining == 0) return 0
+        val addr = buffer.nativeMemoryAccess!!.nativeAddress.toLong() + buffer.position()
 
         // A StreamSend we enqueued but the driver has not yet completed. While this is set, the driver may
         // still READ `addr` inside connStreamSend. The caller owns `buffer` and frees it (or drops its last
-        // reference) the instant we return — so on cancellation we must wait for the in-flight send to finish
+        // reference) the instant we return — so on cancellation we must wait for any in-flight send to finish
         // first; otherwise quiche reads freed/Cleaner-reclaimed memory. (A read-after-free is less likely to
         // corrupt the heap than the read path's write-after-free, but it can still fault on an unmapped page,
         // and the lifetime contract must hold symmetrically.)
         var inFlight: CompletableDeferred<Int>? = null
         return try {
             withTimeout(timeout) {
-                val deferred = CompletableDeferred<Int>()
-                driver.commands.send(QuicheCmd.StreamSend(streamId.id, addr, remaining, false, deferred))
-                // Mark in-flight only AFTER a successful enqueue (see streamRead); joining a never-enqueued
-                // deferred would hang.
-                inFlight = deferred
-                deferred.await()
-            }.let { written ->
-                when {
-                    // Flow-control blocked: 0 bytes accepted. Report back-pressure (not an error) so the
-                    // caller retries when the window reopens — otherwise a write larger than the current
-                    // window throws. Symmetric with the read path's StreamRecvResult.Done handling.
-                    written == QuicheDriver.QUICHE_ERR_DONE -> 0
-                    written < 0 -> throw SocketClosedException.General("quiche stream write error: $written")
-                    else -> written
+                while (true) {
+                    val deferred = CompletableDeferred<Int>()
+                    driver.commands.send(QuicheCmd.StreamSend(streamId.id, addr, remaining, false, deferred))
+                    // Mark in-flight only AFTER a successful enqueue (see streamRead).
+                    inFlight = deferred
+                    val written = deferred.await()
+                    inFlight = null
+                    when (written) {
+                        // Flow-control blocked (QUICHE_ERR_DONE, or a defensive 0 with bytes still pending):
+                        // the stream's window is full. Park on writableSignal until the driver observes the
+                        // stream become writable again (a MAX_STREAM_DATA / MAX_DATA frame reopened it), then
+                        // retry. Reactive — no delay-poll. The CONFLATED signal makes this lost-wakeup-free:
+                        // any signal fired after this `await` returned DONE is buffered until we receive it.
+                        QuicheDriver.QUICHE_ERR_DONE, 0 -> slot.writableSignal.receive()
+                        // Progress: quiche accepted ≥1 byte. Return the (possibly partial) count — the buffer
+                        // is untouched (zero-copy); the caller advances by it and re-enters for the remainder.
+                        else ->
+                            if (written > 0) {
+                                return@withTimeout written
+                            } else {
+                                throw SocketClosedException.General("quiche stream write error: $written")
+                            }
+                    }
                 }
+                @Suppress("UNREACHABLE_CODE")
+                0
             }
         } catch (_: ClosedSendChannelException) {
+            throw SocketClosedException.General("connection closed")
+        } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
+            // writableSignal was closed by cleanup() — the connection went away while we were parked.
             throw SocketClosedException.General("connection closed")
         } finally {
             // Wait — non-cancellably — for any in-flight StreamSend to finish reading `addr` before we
             // return to the caller who will free `buffer`. The driver always completes the deferred
-            // (execute() after connStreamSend, or failCommand() on teardown), so this never hangs; on the
-            // normal path the deferred is already complete, so the join returns immediately.
+            // (execute() after connStreamSend, or failCommand() on teardown), so this never hangs.
             inFlight?.let { withContext(NonCancellable) { it.join() } }
         }
     }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/StreamSlot.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/StreamSlot.kt
@@ -15,6 +15,17 @@ class StreamSlot(
     val dataSignal = Channel<Unit>(Channel.CONFLATED)
 
     /**
+     * Wakes a pending *write* when quiche reports the stream's flow-control window has reopened
+     * (it appears in `quiche_conn_writable`). The write-path mirror of [dataSignal]: a writer that
+     * gets `QUICHE_ERR_DONE` (window full, 0 bytes accepted) parks here instead of delay-polling, and
+     * the driver signals it from `signalWritableStreams()` once a `MAX_STREAM_DATA` / `MAX_DATA` frame
+     * reopens the window. CONFLATED: multiple signals before the writer wakes coalesce into one, and a
+     * signal sent *after* the driver-computed `DONE` but before the writer parks is buffered — so there
+     * is no lost-wakeup window (same guarantee [dataSignal] relies on).
+     */
+    val writableSignal = Channel<Unit>(Channel.CONFLATED)
+
+    /**
      * Set once quiche reports the stream's FIN — even when that FIN arrived *coalesced with the last
      * data chunk* (`stream_recv` → bytes > 0 **and** fin = true). That data chunk is returned to the
      * caller as [com.ditchoom.buffer.flow.ReadResult.Data], so the FIN itself can't be returned in the

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicLargePayloadTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicLargePayloadTestSuite.kt
@@ -9,12 +9,10 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -153,15 +151,15 @@ abstract class QuicLargePayloadTestSuite {
         }
     }
 
-    /** Write the whole buffer, advancing by the accepted count; a 0-accept is window-full back-pressure. */
+    /**
+     * Write the whole buffer, advancing by the accepted count. No delay-poll on back-pressure: a full
+     * flow-control window makes `write` park reactively on the stream's writable-signal and resume when
+     * the peer's `MAX_STREAM_DATA` reopens it, so each call returns only once it has made progress.
+     */
     private suspend fun QuicByteStream.writeAll(buf: PlatformBuffer) {
         while (buf.remaining() > 0) {
             val n = write(buf, 15.seconds).count
-            if (n > 0) {
-                buf.position(buf.position() + n)
-            } else {
-                delay(2.milliseconds) // window full — let the peer's MAX_STREAM_DATA land, then retry
-            }
+            buf.position(buf.position() + n)
         }
     }
 

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -378,43 +378,123 @@ class ReactiveDriverTests {
             Unit
         }
 
-    // ---- streamWrite back-pressure (QUICHE_ERR_DONE) ----
+    // ---- streamWrite reactive back-pressure (writable-signal) ----
 
     /**
-     * Regression for the write-path back-pressure fix (#87 suite 3): quiche returns `QUICHE_ERR_DONE`
-     * (-1) from `conn_stream_send` when the stream is flow-control blocked with no capacity. That is
-     * back-pressure, not failure — [DriverStreamAdapter.streamWrite] must report 0 bytes accepted so the
-     * caller retries, NOT throw. It previously threw `SocketClosedException` on any `written < 0`, which
-     * made a write larger than the current window fail. A real (more-negative) error still throws.
+     * The write-path mirror of the read-path `dataSignal` tests. quiche returns `QUICHE_ERR_DONE` (-1)
+     * from `conn_stream_send` when the stream's flow-control window is full. That is back-pressure, not
+     * failure — and rather than surface a spurious 0 for the caller to delay-poll on (the old behaviour),
+     * [DriverStreamAdapter.streamWrite] now **parks reactively** on [StreamSlot.writableSignal] until the
+     * driver observes the stream become writable again (`signalWritableStreams` drains
+     * [QuicheApi.connWritable]), then retries. Deterministic via [StubQuicheApi.connStreamSendResult] +
+     * [StubQuicheApi.writableStreams]; negative-check = drop the `signalWritableStreams()` wiring and this
+     * hangs to the `withTimeout`.
      */
     @Test
-    fun streamWrite_mapsQuicheErrDoneToZeroBackpressure() =
+    fun streamWrite_parksOnFullWindow_thenProgressesWhenWritableSignalFires() =
         runQuicTest {
             val api = StubQuicheApi()
             val driver = createTestDriver(api)
             driver.start(this)
             try {
-                val adapter = DriverStreamAdapter(driver, StreamSlot(QuicStreamId(0L)))
+                val slot = sendOpenStream(driver) // registered in the driver's streams map, so it can be signalled
+                val adapter = DriverStreamAdapter(driver, slot)
                 val buf = bufferFactory.allocate(64)
 
-                // QUICHE_ERR_DONE (-1) -> 0 bytes accepted (back-pressure), no throw.
+                // Window full: every StreamSend returns QUICHE_ERR_DONE -> the writer must PARK, not return 0.
                 api.connStreamSendResult = -1
-                assertEquals(0, adapter.streamWrite(QuicStreamId(0L), buf, 2.seconds), "Done must map to 0, not throw")
+                val write = async { adapter.streamWrite(slot.id, buf, 5.seconds) }
+                yield()
+                assertNull(
+                    withTimeoutOrNull(200) { write.await() },
+                    "writer must park on a full window, not return 0",
+                )
 
-                // A normal (partial or full) accept passes through unchanged.
+                // Reopen the window AND report the stream writable, then run one afterCommand (any command):
+                // the driver drains connWritable -> writableSignal.trySend -> the parked writer wakes & retries.
                 api.connStreamSendResult = 64
-                assertEquals(64, adapter.streamWrite(QuicStreamId(0L), buf, 2.seconds))
+                api.writableStreams.addLast(slot.id.id)
+                sendOpenStream(driver)
 
-                // A real negative error code still throws.
+                assertEquals(64, withTimeout(2.seconds) { write.await() }, "writer must resume once the window reopens")
+
+                buf.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    /** A real (more-negative) quiche stream error is not back-pressure — it must still throw, not park. */
+    @Test
+    fun streamWrite_realErrorThrows() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api)
+            driver.start(this)
+            try {
+                val slot = sendOpenStream(driver)
+                val adapter = DriverStreamAdapter(driver, slot)
+                val buf = bufferFactory.allocate(64)
+
                 api.connStreamSendResult = -7
                 assertFailsWith<SocketClosedException>("a real error must still throw") {
-                    adapter.streamWrite(QuicStreamId(0L), buf, 2.seconds)
+                    withTimeout(2.seconds) { adapter.streamWrite(slot.id, buf, 2.seconds) }
                 }
 
                 buf.freeNativeMemory()
             } finally {
                 driver.destroy()
             }
+        }
+
+    /** An empty write is a 0-byte no-op — it must never park, even when the window is full. */
+    @Test
+    fun streamWrite_emptyBuffer_returnsZeroWithoutParking() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api)
+            driver.start(this)
+            try {
+                val slot = sendOpenStream(driver)
+                val adapter = DriverStreamAdapter(driver, slot)
+                val empty = bufferFactory.allocate(0)
+
+                api.connStreamSendResult = -1 // "window full" — an empty write must still return 0 immediately
+                assertEquals(0, withTimeout(2.seconds) { adapter.streamWrite(slot.id, empty, 2.seconds) })
+
+                empty.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    /** A writer parked on a full window must wake into [SocketClosedException] when the connection closes. */
+    @Test
+    fun streamWrite_connectionClosedWhileParked_throwsSocketClosed() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api)
+            driver.start(this)
+            val slot = sendOpenStream(driver)
+            val adapter = DriverStreamAdapter(driver, slot)
+            val buf = bufferFactory.allocate(64)
+
+            api.connStreamSendResult = -1 // window full -> writer parks on writableSignal
+            // runCatching so the eventual SocketClosedException is captured in the result, not propagated
+            // to this scope as an uncaught async-child failure (which would fail the test before we assert).
+            val write = async { runCatching { adapter.streamWrite(slot.id, buf, 5.seconds) } }
+            yield()
+            assertNull(withTimeoutOrNull(200) { write.await() }, "writer should be parked")
+
+            driver.destroy() // closes commands -> cleanup() closes writableSignal -> parked writer unblocks
+
+            val result = withTimeout(2.seconds) { write.await() }
+            assertIs<SocketClosedException>(
+                result.exceptionOrNull(),
+                "closing while parked must surface as SocketClosedException",
+            )
+
+            buf.freeNativeMemory()
         }
 
     // ---- streamRead FIN coalesced with data (#91) ----

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -285,9 +285,18 @@ internal class StubQuicheApi : QuicheApi {
     // --- Stream iteration ---
     override fun connReadable(conn: QuicheConn) = QuicheStreamIter(0L)
 
-    override fun connWritable(conn: QuicheConn) = QuicheStreamIter(0L)
+    /**
+     * Stream IDs to report as writable on the next [connWritable] poll, drained by [streamIterNext].
+     * The driver calls `connWritable` once per `afterCommand` and drains the iterator, so a test arms
+     * this right before triggering one command to fire exactly one `writableSignal` wakeup. Non-empty
+     * ⇒ [connWritable] returns a live iterator handle (1L). (The stub's `connReadable` stays exhausted,
+     * so `streamIterNext` is only ever exercised by the writable path.)
+     */
+    val writableStreams: ArrayDeque<Long> = ArrayDeque()
 
-    override fun streamIterNext(iter: QuicheStreamIter): QuicStreamId? = null
+    override fun connWritable(conn: QuicheConn) = if (writableStreams.isEmpty()) QuicheStreamIter(0L) else QuicheStreamIter(1L)
+
+    override fun streamIterNext(iter: QuicheStreamIter): QuicStreamId? = writableStreams.removeFirstOrNull()?.let { QuicStreamId(it) }
 
     override fun streamIterFree(iter: QuicheStreamIter) {}
 


### PR DESCRIPTION
## What

Replaces the QUIC write-path's **delay-poll back-pressure** with a **reactive writable-signal** — the write-path mirror of the read path's `dataSignal`.

When a stream's flow-control window is full, quiche's `conn_stream_send` returns `QUICHE_ERR_DONE`. The driver previously surfaced that as a spurious `0`-byte write, forcing callers to `delay(2ms)`-poll until the window reopened (`QuicLargePayloadTestSuite.writeAll`). That polling hack violated the repo's reactive-only discipline and added latency to every bulk transfer.

## How

- **`StreamSlot`** gains a CONFLATED `writableSignal` (mirror of `dataSignal`).
- **`QuicheDriver.afterCommand()`** calls a new `signalWritableStreams()` that drains quiche's already-bound `connWritable` iterator and signals each *known* slot. **No C/cinterop/FFM/JNI changes** — the binding exists on all four backends + the stub.
- **`DriverStreamAdapter.streamWrite`** parks on `writableSignal` when blocked and retries when the window reopens, instead of returning `0`.

## Design guarantees

- **No lost wakeup** — the writer parks only on a driver-computed `DONE`, then waits on a CONFLATED channel; any signal fired after the `DONE` is buffered, so `receive()` returns immediately even if it races the park. Signals fire only when the window is actually open → no hot spin. (Same mechanism the proven `dataSignal` relies on.)
- **No impossible state** — `signalWritableStreams` never *creates* a slot (a writable stream we don't track has no parked writer; a phantom slot would be the impossible state). `cleanup()` closes `writableSignal` so a parked writer unblocks into `SocketClosedException`.
- **Zero-copy** — `streamWrite` allocates nothing and never touches the caller's buffer; the signal is `Channel<Unit>`.

## Contract change (deliberate, strictly safer)

`write()` no longer returns a spurious `0` on a full window — it blocks until ≥1 byte is accepted, the timeout elapses, or the connection closes (empty input still returns `0` without parking). Audited: no production caller depended on the `0`-return; the test `writeAll` loops shed their now-dead delay-poll branch. `streamClose`/FIN left untouched (out of scope; not a current bug).

## Tests (deterministic, `StubQuicheApi`-driven; negative-checked)

- `streamWrite_parksOnFullWindow_thenProgressesWhenWritableSignalFires`
- `streamWrite_realErrorThrows` / `streamWrite_emptyBuffer_returnsZeroWithoutParking`
- `streamWrite_connectionClosedWhileParked_throwsSocketClosed`

New stub knob `writableStreams` drives `connWritable`/`streamIterNext`.

## Validation

- JVM: `ReactiveDriverTests` 20/20 + real-quiche large-payload 2/2
- linuxX64 (io_uring, `--rerun-tasks`): same, 2/2
- **Negative check**: park test times out (~2.3s) with `signalWritableStreams()` disabled → confirmed it exercises the fix
- `ktlintCheck` clean; JS + wasmJs test compile clean