### PR TITLE
fix(quic): wait for in-flight stream command before releasing its buffer

### DIFF
--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
@@ -685,6 +687,16 @@ class DriverStreamAdapter(
         val buffer = bufferFactory.allocate(bufferSize)
         val addr = buffer.nativeMemoryAccess!!.nativeAddress.toLong()
 
+        // A StreamRecv we enqueued but the driver has not yet completed. While this is set, the driver may
+        // still be about to WRITE received bytes into `addr` inside connStreamRecv. The command channel is
+        // UNLIMITED so `commands.send` never suspends — by the time a timeout or external cancellation can
+        // unwind us, the command is already queued. If we let `buffer` be released here (freed below, or for
+        // a heap/GC-backed buffer simply dropped so its Cleaner reclaims the native memory) before the
+        // driver finishes, quiche writes into freed memory and corrupts the native heap (the rare
+        // "SIGSEGV in malloc" crash). So on every exit we first wait — non-cancellably — for any in-flight
+        // StreamRecv to complete, then release the buffer.
+        var inFlight: CompletableDeferred<StreamRecvResult>? = null
+        var transferred = false
         try {
             return withTimeout(timeout) {
                 // The FIN may have arrived coalesced with the last data chunk on a previous read()
@@ -692,13 +704,17 @@ class DriverStreamAdapter(
                 // so there is no further data and no readable-signal coming — return End now instead of
                 // issuing a StreamRecv that returns Done and parking on dataSignal forever.
                 if (slot.finReceived) {
-                    buffer.freeNativeMemory()
                     return@withTimeout ReadResult.End
                 }
                 while (true) {
                     val deferred = CompletableDeferred<StreamRecvResult>()
                     driver.commands.send(QuicheCmd.StreamRecv(streamId.id, addr, bufferSize, deferred))
-                    when (val result = deferred.await()) {
+                    // Mark in-flight only AFTER a successful enqueue: if send threw (channel closed) the
+                    // command never reached the driver, so there is nothing to join (joining it would hang).
+                    inFlight = deferred
+                    val result = deferred.await()
+                    inFlight = null
+                    when (result) {
                         is StreamRecvResult.Data -> {
                             // Record the FIN whether or not this chunk also carried data — a coalesced
                             // FIN (bytes > 0 && fin) is otherwise dropped, wedging the next read().
@@ -706,24 +722,23 @@ class DriverStreamAdapter(
                             if (result.bytesRead > 0) {
                                 buffer.position(result.bytesRead)
                                 buffer.resetForRead()
+                                // Ownership transfers to the caller — do not release in the finally.
+                                transferred = true
                                 return@withTimeout ReadResult.Data(buffer)
                             }
                             // bytesRead == 0 implies a pure FIN (fin == true) — clean end of stream.
-                            buffer.freeNativeMemory()
                             return@withTimeout ReadResult.End
                         }
                         is StreamRecvResult.Done -> {
                             // Defensive: if the FIN was consumed earlier (coalesced with data), no signal
                             // is coming — end now rather than park forever.
                             if (slot.finReceived) {
-                                buffer.freeNativeMemory()
                                 return@withTimeout ReadResult.End
                             }
                             slot.dataSignal.receive()
                             continue
                         }
                         is StreamRecvResult.Error -> {
-                            buffer.freeNativeMemory()
                             return@withTimeout ReadResult.End
                         }
                     }
@@ -732,11 +747,15 @@ class DriverStreamAdapter(
                 ReadResult.End
             }
         } catch (_: ClosedSendChannelException) {
-            buffer.freeNativeMemory()
             return ReadResult.End
         } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
-            buffer.freeNativeMemory()
             return ReadResult.End
+        } finally {
+            // The driver ALWAYS completes the deferred — in execute() after connStreamRecv, or in
+            // cleanup()/failCommand() on teardown (which does NOT dereference `addr`) — so this join can
+            // never hang. After it returns, quiche is provably done with `addr`; only then release.
+            inFlight?.let { withContext(NonCancellable) { it.join() } }
+            if (!transferred) buffer.freeNativeMemory()
         }
     }
 
@@ -748,10 +767,20 @@ class DriverStreamAdapter(
         val addr = buffer.nativeMemoryAccess!!.nativeAddress.toLong() + buffer.position()
         val remaining = buffer.remaining()
 
+        // A StreamSend we enqueued but the driver has not yet completed. While this is set, the driver may
+        // still READ `addr` inside connStreamSend. The caller owns `buffer` and frees it (or drops its last
+        // reference) the instant we return — so on cancellation we must wait for the in-flight send to finish
+        // first; otherwise quiche reads freed/Cleaner-reclaimed memory. (A read-after-free is less likely to
+        // corrupt the heap than the read path's write-after-free, but it can still fault on an unmapped page,
+        // and the lifetime contract must hold symmetrically.)
+        var inFlight: CompletableDeferred<Int>? = null
         return try {
             withTimeout(timeout) {
                 val deferred = CompletableDeferred<Int>()
                 driver.commands.send(QuicheCmd.StreamSend(streamId.id, addr, remaining, false, deferred))
+                // Mark in-flight only AFTER a successful enqueue (see streamRead); joining a never-enqueued
+                // deferred would hang.
+                inFlight = deferred
                 deferred.await()
             }.let { written ->
                 when {
@@ -765,6 +794,12 @@ class DriverStreamAdapter(
             }
         } catch (_: ClosedSendChannelException) {
             throw SocketClosedException.General("connection closed")
+        } finally {
+            // Wait — non-cancellably — for any in-flight StreamSend to finish reading `addr` before we
+            // return to the caller who will free `buffer`. The driver always completes the deferred
+            // (execute() after connStreamSend, or failCommand() on teardown), so this never hangs; on the
+            // normal path the deferred is already complete, so the join returns immediately.
+            inFlight?.let { withContext(NonCancellable) { it.join() } }
         }
     }
 

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -8,6 +8,7 @@ import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -21,6 +22,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -446,6 +448,101 @@ class ReactiveDriverTests {
                 val second = adapter.streamRead(QuicStreamId(0L), bufferFactory, 1024, 2.seconds)
                 assertIs<ReadResult.End>(second, "FIN coalesced with data must yield End on the next read, not hang")
             } finally {
+                driver.destroy()
+            }
+        }
+
+    // ---- stream-command buffer lifetime under cancellation (native heap-corruption regression) ----
+    //
+    // An address-bearing StreamRecv / StreamSend carries a buffer's *raw native address* into the driver's
+    // UNLIMITED command channel. The enqueue (`commands.send`) never suspends, so by the time a read/write's
+    // timeout or an external cancel can unwind the caller, the command is already queued — and the driver
+    // will later dereference that address (StreamRecv WRITES received bytes into it; StreamSend READS from
+    // it). If the caller is allowed to unwind and release the buffer first (free a deterministic buffer, or
+    // simply drop the last reference to a GC-backed one so its Cleaner reclaims the native memory), quiche
+    // then touches freed memory. For the read path that is a write-after-free → glibc free-list corruption →
+    // the rare "SIGSEGV in malloc" crash that failed the JDK17/JNI deploy step.
+    //
+    // The fix: [DriverStreamAdapter.streamRead]/[streamWrite] wait — non-cancellably — for any in-flight
+    // command to complete before unwinding, so the buffer is provably no longer referenced by quiche when it
+    // is released. These pin the driver at its startup flush (one gated UDP datagram) so the enqueued command
+    // is *guaranteed* unprocessed when the timeout fires, then assert the call does NOT unwind until the
+    // driver is released and finishes the command — deterministic, no scheduler races.
+    //
+    // Negative check: delete the `inFlight?.let { withContext(NonCancellable) { it.join() } }` guard and both
+    // `assertNull` checks fail — the call unwinds at its ~150 ms timeout, well inside the 600 ms window.
+
+    private fun gatedStartupDriver(
+        api: StubQuicheApi,
+        udpGate: CompletableDeferred<Unit>,
+    ): QuicheDriver {
+        // connSendOnce makes the startup afterCommand() emit exactly one datagram; the UDP channel's send
+        // parks on the gate, so the driver is stuck in its initial flush — *before* its loop can dequeue any
+        // stream command — until the test releases the gate.
+        api.connSendOnce = 1300
+        val gatedUdp =
+            object : UdpChannel {
+                override suspend fun receive(buffer: PlatformBuffer): Int = awaitCancellation()
+
+                override suspend fun send(
+                    buffer: PlatformBuffer,
+                    len: Int,
+                    dest: PathKey?,
+                ) = udpGate.await()
+
+                override fun close() {}
+            }
+        return createTestDriver(api, udpChannel = gatedUdp)
+    }
+
+    @Test
+    fun streamRead_cancelledWithInflightRecv_waitsForDriverBeforeReleasingBuffer() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            api.streamRecvResult = StreamRecvResult.Done
+            val udpGate = CompletableDeferred<Unit>()
+            val driver = gatedStartupDriver(api, udpGate)
+            driver.start(this)
+            val adapter = DriverStreamAdapter(driver, StreamSlot(QuicStreamId(0L)))
+            try {
+                // streamRead enqueues a StreamRecv the gated driver cannot process yet, then its 150 ms
+                // timeout fires while that command is still queued.
+                val read = async { runCatching { adapter.streamRead(QuicStreamId(0L), bufferFactory, 1024, 150.milliseconds) } }
+                // With the fix, `read` is parked in the in-flight join (driver still gated) — it must not
+                // unwind within a window well past its own timeout.
+                assertNull(
+                    withTimeoutOrNull(600) { read.await() },
+                    "streamRead unwound while its StreamRecv was still in-flight — the driver could write into the released buffer",
+                )
+                // Release the driver: it dequeues the StreamRecv, completes the deferred, and the join wakes.
+                udpGate.complete(Unit)
+                withTimeout(2.seconds) { read.await() }
+            } finally {
+                if (!udpGate.isCompleted) udpGate.complete(Unit)
+                driver.destroy()
+            }
+        }
+
+    @Test
+    fun streamWrite_cancelledWithInflightSend_waitsForDriverBeforeReturning() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            val udpGate = CompletableDeferred<Unit>()
+            val driver = gatedStartupDriver(api, udpGate)
+            driver.start(this)
+            val adapter = DriverStreamAdapter(driver, StreamSlot(QuicStreamId(0L)))
+            val buf = bufferFactory.allocate(64)
+            try {
+                val write = async { runCatching { adapter.streamWrite(QuicStreamId(0L), buf, 150.milliseconds) } }
+                assertNull(
+                    withTimeoutOrNull(600) { write.await() },
+                    "streamWrite unwound while its StreamSend was still in-flight — the driver could read the released buffer",
+                )
+                udpGate.complete(Unit)
+                withTimeout(2.seconds) { write.await() }
+            } finally {
+                if (!udpGate.isCompleted) udpGate.complete(Unit)
+                buf.freeNativeMemory()
                 driver.destroy()
             }
         }


### PR DESCRIPTION
## The crash

A rare, load-dependent JVM hard crash — `SIGSEGV (0xb) ... C [libc.so.6] malloc+0x171` (heap free-list corruption) — flaked the **JDK17/JNI `jvmTest`** step and blocked the 3.2.12 release. Crash-site ≠ bug-site: `malloc` merely *detected* an already-corrupted free-list.

## Root cause

`StreamRecv` / `StreamSend` carry a buffer's **raw native address** into the driver's `UNLIMITED` command channel. `commands.send` never suspends, so by the time a `streamRead`/`streamWrite` timeout or external cancellation unwinds the caller, the command is **already queued**. The caller then releases the buffer — frees a `deterministic()` buffer, or simply drops the last reference to a Default direct `ByteBuffer` so its `Cleaner` reclaims the native memory — while the driver still holds the address. When the driver dequeues the stale command:

- **read path** — `connStreamRecv` **writes** received bytes into the freed region → glibc free-list corruption → the `malloc` SIGSEGV.
- **write path** — `connStreamSend` **reads** freed/reclaimed memory (milder, but a fault risk).

## Fix

`DriverStreamAdapter.streamRead`/`streamWrite` track the in-flight command's deferred and, on **every** exit, `withContext(NonCancellable) { it.join() }` before releasing the buffer. The driver always completes the deferred — in `execute()` after the quiche call, or in `failCommand()` on teardown (which never dereferences the address) — so the join cannot hang. The read path also no longer leaks its buffer on cancellation.

## Evidence

Reproduced locally under glibc `malloc.check=3` + `MALLOC_PERTURB_` (faithful to CI's allocator) with a read-path cancel/GC stressor: **4× consistent** "corrupted double-linked list" `SIGABRT` (worker exit 134) at ~2 s. With the fix: **3× clean** completion, zero corruption.

(ASAN via `LD_PRELOAD` was tried first but can't see the fault — `libquiche.a` isn't ASAN-instrumented, so quiche's write-after-free isn't shadow-checked; only the glibc allocator catches it, the same way CI did.)

## Regression

Two deterministic tests in `ReactiveDriverTests` pin the driver at its startup flush (one gated UDP datagram) so a stream command is *guaranteed* in-flight when a 150 ms timeout fires, then assert the call does not unwind until the driver is released. **Negative-check:** removing the join makes both fail at their timeout. No probabilistic flake-catchers.

## Scope / sequencing

Independent of the held **PR #100** (writable-signal) — the crash is the read path, byte-identical on `main`. This lands first to unblock 3.2.12; #100 rebases on top afterward.

`./gradlew :socket-quic:jvmTest` green; `ktlintCheck` clean.