### PR TITLE
ci(release): raise publish job timeout-minutes to match the 2h poll ceiling

### DIFF
--- a/.github/workflows/publish-to-central.yaml
+++ b/.github/workflows/publish-to-central.yaml
@@ -29,7 +29,11 @@ jobs:
   publish:
     name: "Sign, Bundle & Upload"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Must exceed the "Poll deployment status" ceiling (240 × 30s = 2h) plus the
+    # sign/bundle/upload steps. At 30 the job was killed mid-poll while Central was
+    # still PUBLISHING — 3.2.12 published itself (publishingType=AUTOMATIC) but CI
+    # reported the deploy as failed. 150 = 2h poll + headroom.
+    timeout-minutes: 150
     outputs:
       deployment-id: ${{ steps.upload.outputs.deployment-id }}
     steps:


### PR DESCRIPTION
The `publish / Sign, Bundle & Upload` job's `Poll deployment status` step waits up to **2h** (`MAX_ATTEMPTS=240` × 30s) — added deliberately because Central "publishes sometimes sit in PUBLISHING for 40+ minutes". But the job kept **`timeout-minutes: 30`**, so the job is killed mid-poll long before the loop's own ceiling.

On the **3.2.12** deploy this is exactly what happened: the bundle uploaded fine (deployment `3b48f79f…`, `publishingType=AUTOMATIC`), Central was still `PUBLISHING`, and the job hit the 30-min wall and was cancelled — reporting the deploy as **failed** even though Central finished the AUTOMATIC publish ~58 min after upload and **3.2.12 did land on Maven Central**.

Raise `timeout-minutes` to **150** (2h poll + sign/bundle/upload + headroom) so CI can observe a slow publish to completion instead of failing spuriously. No logic change; the poll loop already self-terminates at its 240-attempt ceiling.

> Note: CI-only change — if a release shouldn't be cut for this, label/merge accordingly (relates to the open "skip release for test-only merges" item).