### PR TITLE
test(quic): de-flake QuicStreamMuxTests.bidirectionalStreamMuxExchange

### DIFF
--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicStreamMuxTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicStreamMuxTests.kt
@@ -92,13 +92,15 @@ class QuicStreamMuxTests {
     fun bidirectionalStreamMuxExchange() =
         runBlocking(Dispatchers.IO) {
             skipOnMissingNativeLib {
-                withTimeout(15.seconds) {
+                // 30s whole-test budget: the client connect alone defaults to 15s, so the old 15s
+                // cap was inconsistent with the work below (connect + send + receive) and a
+                // slow-but-correct run could time out opaquely. (Same shape as the migration-test
+                // de-flake.)
+                withTimeout(30.seconds) {
                     withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = testQuicOptions) {
-                        val muxResult = CompletableDeferred<String>()
-
                         val opts = ConnectionOptions(readTimeout = 5.seconds, writeTimeout = 5.seconds)
 
-                        // Server: accept bidi stream via StreamMux, echo
+                        // Server: accept bidi stream via StreamMux, echo.
                         val serverDispatched = CompletableDeferred<Unit>()
                         val serverJob =
                             launch(Dispatchers.IO) {
@@ -113,24 +115,23 @@ class QuicStreamMuxTests {
                             }
                         serverDispatched.await()
 
-                        // Client: send via StreamMux
-                        val clientJob =
-                            launch(Dispatchers.IO) {
+                        try {
+                            // Run the client INLINE (not in a child launch funneling the result
+                            // through an unbounded CompletableDeferred.await): a per-op withTimeout
+                            // throws a CancellationException that would cancel a child coroutine
+                            // silently, leaving the await to time out opaquely and masking the real
+                            // cause. Inline, any failure propagates straight to the test.
+                            val response =
                                 withQuicMux("localhost", port, testQuicOptions, TestCodec, connectionOptions = opts) {
                                     val conn = openBidirectional()
                                     assertTrue(conn.id >= 0)
                                     conn.send("hello")
-                                    val response = conn.receive().first()
-                                    muxResult.complete(response)
+                                    val r = conn.receive().first()
                                     conn.close()
+                                    r
                                 }
-                            }
-
-                        try {
-                            val result = withTimeout(10.seconds) { muxResult.await() }
-                            assertEquals("echo: hello", result)
+                            assertEquals("echo: hello", response)
                         } finally {
-                            clientJob.cancel()
                             serverJob.cancel()
                         }
                     }


### PR DESCRIPTION
Proactive follow-up to #103. `QuicStreamMuxTests.bidirectionalStreamMuxExchange` used the same fragile shape as the passive-migration test that flaked on #103 CI:

- The client ran in a child `launch` funneling its result through an **unbounded** `CompletableDeferred.await()`. A per-op `withTimeout` throws a `CancellationException`, which cancels the child *silently* (cancellation ≠ failure), so the deferred never completes and the await times out opaquely — masking the real cause/phase.
- The whole-test cap was **15s**, but the client connect alone defaults to 15s (plus send/receive), so a slow-but-correct run could time out before completing its work.

**Fix:**
- Run the client **inline** (return the response from the `withQuicMux` block) so any failure propagates straight to the test with its true cause.
- Whole-test budget **15s → 30s** for consistency with the operations it performs.

No production-code change — test-only. The `QuicStreamMux` / `withQuicMux` wiring it exercises is unchanged.

Verified: 5/5 green locally, ktlint clean.