### PR TITLE
fix(quic): exhaustive QuicError + structured QuicCloseException on the thrown channel

### DIFF
--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicCloseException.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicCloseException.kt
@@ -1,0 +1,18 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.socket.SocketClosedException
+
+/**
+ * Thrown when a QUIC stream or connection operation fails because the connection (or stream) is gone.
+ *
+ * Extends [SocketClosedException] so it is caught uniformly alongside TCP/TLS connection-lost errors
+ * (`catch (e: SocketClosedException)`, or `catch (e: IOException)` on JVM/Android), while additionally
+ * carrying the structured [QuicError] reason — so callers recover the protocol-level cause without
+ * parsing a message string. This keeps the thrown channel as type-faithful as the state channel
+ * ([QuicConnectionState.Closed.error]).
+ */
+class QuicCloseException(
+    val quicError: QuicError,
+    message: String,
+    cause: Throwable? = null,
+) : SocketClosedException(message, cause)

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicError.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicError.kt
@@ -64,6 +64,18 @@ sealed interface QuicError {
         override val code: Long = 0xB
     }
 
+    /**
+     * Transport-level APPLICATION_ERROR (RFC 9000 §20.1, code 0x0c).
+     *
+     * Signals an application-caused close in a context that only permits a *transport*
+     * CONNECTION_CLOSE frame (type 0x1c) — typically during the handshake, before the
+     * application can use a type-0x1d frame. Distinct from [ApplicationError], which carries
+     * an application-protocol-defined close code sent in a type-0x1d frame.
+     */
+    data object TransportApplicationError : QuicError {
+        override val code: Long = 0xC
+    }
+
     data class CryptoBufferExceeded(
         val detail: String,
     ) : QuicError {
@@ -81,6 +93,16 @@ sealed interface QuicError {
     data object NoViablePath : QuicError {
         override val code: Long = 0x10
     }
+
+    /**
+     * A transport error code this library does not recognize — reserved, currently unassigned,
+     * or defined by a future QUIC extension. Preserves the original wire [code] instead of
+     * collapsing it to [InternalError], so the numeric value survives decoding for diagnostics
+     * and forward compatibility.
+     */
+    data class UnknownTransport(
+        override val code: Long,
+    ) : QuicError
 
     /** TLS alert mapped to QUIC crypto error (0x100 + alert code). */
     data class CryptoError(
@@ -118,12 +140,13 @@ sealed interface QuicError {
                 0x9L -> ConnectionIdLimitError
                 0xAL -> ProtocolViolation
                 0xBL -> InvalidToken
+                0xCL -> TransportApplicationError
                 0xDL -> CryptoBufferExceeded("transport error 0xD")
                 0xEL -> KeyUpdateError
                 0xFL -> AeadLimitReached
                 0x10L -> NoViablePath
                 in 0x100L..0x1FFL -> CryptoError((code - 0x100L).toInt())
-                else -> InternalError("unknown transport error code 0x${code.toString(16)}")
+                else -> UnknownTransport(code)
             }
     }
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -9,7 +9,6 @@ import com.ditchoom.buffer.flow.ReadResult
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.buffer.pool.BufferPool
 import com.ditchoom.buffer.pool.ThreadingMode
-import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -612,7 +611,7 @@ class QuicheDriver(
         for (slot in streams.values) {
             slot.dataSignal.close()
             // Unblock any writer parked on a reopened-window signal — without this it would hang until
-            // its withTimeout fired. streamWrite maps the resulting closed-channel to SocketClosedException.
+            // its withTimeout fired. streamWrite maps the resulting closed-channel to QuicCloseException.
             slot.writableSignal.close()
         }
         streams.clear()
@@ -659,7 +658,10 @@ class QuicheDriver(
             }
             is QuicheCmd.OpenStream ->
                 cmd.result.completeExceptionally(
-                    SocketClosedException.General("connection closed"),
+                    QuicCloseException(
+                        (state.value as? QuicConnectionState.Closed)?.error ?: QuicError.NoError,
+                        "connection closed",
+                    ),
                 )
             is QuicheCmd.StreamRecv -> cmd.result.complete(StreamRecvResult.Error(-2))
             is QuicheCmd.StreamSend -> cmd.result.complete(-1)
@@ -703,6 +705,13 @@ class DriverStreamAdapter(
     private val driver: QuicheDriver,
     private val slot: StreamSlot,
 ) : QuicheStreamAdapter {
+    /**
+     * The structured QUIC reason to attach to a [QuicCloseException] thrown from this stream:
+     * the connection's recorded close error if it has reached [QuicConnectionState.Closed],
+     * otherwise [fallback]. Driver state is the single source of truth for the close reason.
+     */
+    private fun closedReason(fallback: QuicError): QuicError = (driver.state.value as? QuicConnectionState.Closed)?.error ?: fallback
+
     override suspend fun streamRead(
         streamId: QuicStreamId,
         bufferFactory: BufferFactory,
@@ -824,7 +833,10 @@ class DriverStreamAdapter(
                             if (written > 0) {
                                 return@withTimeout written
                             } else {
-                                throw SocketClosedException.General("quiche stream write error: $written")
+                                throw QuicCloseException(
+                                    closedReason(QuicError.InternalError("quiche stream write error: $written")),
+                                    "quiche stream write error: $written",
+                                )
                             }
                     }
                 }
@@ -832,10 +844,10 @@ class DriverStreamAdapter(
                 0
             }
         } catch (_: ClosedSendChannelException) {
-            throw SocketClosedException.General("connection closed")
+            throw QuicCloseException(closedReason(QuicError.NoError), "connection closed")
         } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
             // writableSignal was closed by cleanup() — the connection went away while we were parked.
-            throw SocketClosedException.General("connection closed")
+            throw QuicCloseException(closedReason(QuicError.NoError), "connection closed")
         } finally {
             // Wait — non-cancellably — for any in-flight StreamSend to finish reading `addr` before we
             // return to the caller who will free `buffer`. The driver always completes the deferred

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicErrorTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicErrorTests.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.socket.quic
 
+import com.ditchoom.socket.SocketClosedException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -155,16 +156,27 @@ class QuicErrorTests {
     // --- Unknown codes ---
 
     @Test
-    fun fromTransportCode_unknownCode_mapsToInternalError() {
+    fun fromTransportCode_unknownCode_mapsToUnknownTransport_preservingCode() {
         val error = QuicError.fromTransportCode(0xFFFF)
-        assertIs<QuicError.InternalError>(error)
+        assertIs<QuicError.UnknownTransport>(error)
+        // The wire code survives decoding instead of collapsing to InternalError.
+        assertEquals(0xFFFFL, error.code)
     }
 
     @Test
-    fun fromTransportCode_reservedCode0xC_mapsToInternalError() {
-        // 0xC is reserved/unused in RFC 9000
+    fun fromTransportCode_unassignedCodeAboveCryptoRange_mapsToUnknownTransport() {
+        // 0x200 is above the CRYPTO_ERROR range (0x100..0x1ff) and currently unassigned.
+        val error = QuicError.fromTransportCode(0x200)
+        assertIs<QuicError.UnknownTransport>(error)
+        assertEquals(0x200L, error.code)
+    }
+
+    @Test
+    fun fromTransportCode_applicationError_0xC() {
+        // RFC 9000 §20.1: 0x0c is APPLICATION_ERROR (transport-level), not reserved.
         val error = QuicError.fromTransportCode(0xC)
-        assertIs<QuicError.InternalError>(error)
+        assertIs<QuicError.TransportApplicationError>(error)
+        assertEquals(0xCL, error.code)
     }
 
     // --- Direct construction ---
@@ -187,5 +199,17 @@ class QuicErrorTests {
     fun cryptoError_codeIncludesOffset() {
         val error = QuicError.CryptoError(48) // unknown_ca
         assertEquals(0x100L + 48, error.code)
+    }
+
+    // --- Thrown channel carries the structured reason ---
+
+    @Test
+    fun quicCloseException_isSocketClosedException_andCarriesError() {
+        val ex = QuicCloseException(QuicError.ProtocolViolation, "boom")
+        // Caught uniformly with TCP/TLS connection-lost errors...
+        assertIs<SocketClosedException>(ex)
+        // ...while the structured protocol reason survives the throw.
+        assertIs<QuicError.ProtocolViolation>(ex.quicError)
+        assertEquals("boom", ex.message)
     }
 }

--- a/src/commonMain/kotlin/com/ditchoom/socket/SocketException.kt
+++ b/src/commonMain/kotlin/com/ditchoom/socket/SocketException.kt
@@ -37,9 +37,14 @@ sealed class SocketException(
  * The connection is gone — closed locally, by the peer, or due to a broken pipe / reset.
  *
  * Catch this type to handle any "connection lost" scenario uniformly.
- * Use the sealed subtypes for finer discrimination.
+ * Use the subtypes for finer discrimination.
+ *
+ * `abstract` rather than `sealed` so protocol layers built on top of this library (e.g. the QUIC
+ * module's `QuicCloseException`, which carries a structured `QuicError`) can extend it from another
+ * module and still be caught uniformly via `catch (e: SocketClosedException)`. No code relies on
+ * exhaustive `when` over the subtypes — classification uses `is` checks plus an `else`.
  */
-sealed class SocketClosedException(
+abstract class SocketClosedException(
     override val message: String,
     override val cause: Throwable? = null,
 ) : SocketException(message, cause) {


### PR DESCRIPTION
## Summary

Three type-safety fixes to the QUIC error model, bringing it up to the `socket` module's bar ahead of WebTransport work (which adds its own session-close error space). All new tests live in `commonTest`, so CI validates the same assertions across **JVM, JS/Node, Android, Apple, and Linux**.

### `QuicError` — exhaustiveness & fidelity (RFC 9000 §20.1)
- **Add `TransportApplicationError`** for transport code **0x0c** (`APPLICATION_ERROR`). It was previously absent — `0x0c` silently fell through to the `else` branch. Distinct from the existing `ApplicationError` (app-defined close code used to set quiche's `app=true` flag on `connClose`).
- **Add `UnknownTransport(code)`** and map the `else` branch to it, **preserving the wire code** instead of collapsing unrecognized/reserved/future codes into a stringly-typed `InternalError`.

### Thrown channel — structured reason survives `catch`
- **Add `QuicCloseException(quicError, message, cause)`** extending `SocketClosedException`, so QUIC closes are still caught uniformly via `catch (SocketClosedException)` / `catch (IOException)` on JVM, while carrying the structured `QuicError`.
- Convert the driver throw sites (stream-write error, connection-closed paths, open-stream-after-close) to `QuicCloseException`, sourcing the reason from the driver's `Closed` state when available.
- **Relax `SocketClosedException` from `sealed` to `abstract`** so the QUIC module can extend it cross-module. Safe: no exhaustive `when` depends on it — the only matcher (`DefaultReconnectionClassifier`) uses `is` + `else`. `SocketException` stays `sealed` (the QUIC type is a transitive, not direct, subtype).

## Tests
- Correct the test that wrongly treated `0x0c` as reserved → now asserts `TransportApplicationError`.
- Assert `UnknownTransport` preserves the code (`0xFFFF`, `0x200`).
- Assert `QuicCloseException` is-a `SocketClosedException` **and** carries the `QuicError`.

## Verification (local, JVM)
- `:socket-quic:jvmTest` — `QuicErrorTests` (all + new), `ReactiveDriverTests`, `JvmQuicConnectionTests` green. Back-compat throw sites (`streamWrite_realErrorThrows`, `streamWrite_connectionClosedWhileParked_throwsSocketClosed`, `jvmConnection_openStream_throwsAfterClose`) still pass — the `is SocketClosedException` contract holds.
- ktlint clean on changed common source sets.

Relying on CI to confirm the common tests pass identically on Apple/Linux/JS/Android.

## Follow-up (not in this PR)
Platform `connClose` impls and the Apple/Linux/JVM-server throw sites still throw plain `SocketClosedException.General`; a later sweep can convert those to `QuicCloseException` for full cross-platform consistency.