### PR TITLE
fix(quic): route all platform close throws through QuicCloseException

### DIFF
--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -11,7 +11,6 @@ import com.ditchoom.buffer.flow.BytesWritten
 import com.ditchoom.buffer.flow.ReadResult
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.ConnectionOptions
-import com.ditchoom.socket.SocketClosedException
 import com.ditchoom.socket.SocketConnectionException
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_create_quic_group
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_cancel
@@ -144,7 +143,7 @@ private suspend fun <R> connectQuicGroup(
                             ),
                         )
                     }
-                4 -> if (cont.isActive) cont.resumeWithException(SocketClosedException.General("QUIC group cancelled"))
+                4 -> if (cont.isActive) cont.resumeWithException(QuicCloseException(QuicError.NoError, "QUIC group cancelled"))
                 else -> {} // invalid=0, waiting=1 — in progress
             }
         }
@@ -197,7 +196,12 @@ private suspend fun <R> connectQuicGroup(
                                     ),
                                 )
                             }
-                        5 -> if (cont.isActive) cont.resumeWithException(SocketClosedException.General("QUIC datagram flow cancelled"))
+                        5 ->
+                            if (cont.isActive) {
+                                cont.resumeWithException(
+                                    QuicCloseException(QuicError.NoError, "QUIC datagram flow cancelled"),
+                                )
+                            }
                         else -> {}
                     }
                 }
@@ -260,7 +264,7 @@ private class AppleQuicGroupConnection(
         }
         val streamConn =
             nw_helper_quic_group_extract_stream(group)
-                ?: throw SocketClosedException.General("Failed to open QUIC stream")
+                ?: throw QuicCloseException(closeReason(), "Failed to open QUIC stream")
         nw_helper_quic_start(streamConn)
         val streamId = QuicStreamId(nextClientStreamId.getAndAdd(4))
         return QuicByteStream(streamId, NWQuicByteStream(streamConn))
@@ -431,7 +435,10 @@ private class NWQuicByteStream(
                     if (errorCode != 0) {
                         if (cont.isActive) {
                             cont.resumeWithException(
-                                SocketClosedException.General("QUIC write error: $errorCode"),
+                                QuicCloseException(
+                                    QuicError.InternalError("QUIC write error: $errorCode"),
+                                    "QUIC write error: $errorCode",
+                                ),
                             )
                         }
                     } else {

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -680,8 +680,7 @@ internal class DriverQuicConnection(
             val adapter = DriverStreamAdapter(driver, slot)
             return QuicByteStream(slot.id, QuicheStreamByteStream(slot.id, adapter, bufferFactory))
         } catch (_: ClosedSendChannelException) {
-            throw com.ditchoom.socket.SocketClosedException
-                .General("connection closed")
+            throw QuicCloseException(driver.closeReasonOr(QuicError.NoError), "connection closed")
         }
     }
 

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
@@ -2,7 +2,6 @@ package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
-import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.ClosedSendChannelException
@@ -47,7 +46,7 @@ internal class JvmQuicConnection(
             val adapter = DriverStreamAdapter(driver, slot)
             return QuicByteStream(slot.id, QuicheStreamByteStream(slot.id, adapter, bufferFactory))
         } catch (_: ClosedSendChannelException) {
-            throw SocketClosedException.General("connection closed")
+            throw QuicCloseException(driver.closeReasonOr(QuicError.NoError), "connection closed")
         }
     }
 

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -86,6 +86,15 @@ class QuicheDriver(
     private val _state = MutableStateFlow<QuicConnectionState>(QuicConnectionState.Handshaking)
     val state: StateFlow<QuicConnectionState> = _state
 
+    /**
+     * The structured QUIC reason to report when an operation fails because the connection is gone:
+     * the recorded close error if the connection has reached [QuicConnectionState.Closed], otherwise
+     * [fallback]. Connection state is the single source of truth for the close reason — the driver,
+     * [DriverStreamAdapter], and every platform facade funnel through here so a [QuicCloseException]
+     * always carries the most specific reason available.
+     */
+    fun closeReasonOr(fallback: QuicError): QuicError = (state.value as? QuicConnectionState.Closed)?.error ?: fallback
+
     val incomingStreams = Channel<QuicByteStream>(Channel.UNLIMITED)
     private val streams = mutableMapOf<Long, StreamSlot>()
     private var nextStreamId = if (isServer) 1L else 0L
@@ -710,10 +719,7 @@ class QuicheDriver(
             }
             is QuicheCmd.OpenStream ->
                 cmd.result.completeExceptionally(
-                    QuicCloseException(
-                        (state.value as? QuicConnectionState.Closed)?.error ?: QuicError.NoError,
-                        "connection closed",
-                    ),
+                    QuicCloseException(closeReasonOr(QuicError.NoError), "connection closed"),
                 )
             is QuicheCmd.StreamRecv -> cmd.result.complete(StreamRecvResult.Error(-2))
             is QuicheCmd.StreamSend -> cmd.result.complete(-1)
@@ -761,13 +767,6 @@ class DriverStreamAdapter(
     private val driver: QuicheDriver,
     private val slot: StreamSlot,
 ) : QuicheStreamAdapter {
-    /**
-     * The structured QUIC reason to attach to a [QuicCloseException] thrown from this stream:
-     * the connection's recorded close error if it has reached [QuicConnectionState.Closed],
-     * otherwise [fallback]. Driver state is the single source of truth for the close reason.
-     */
-    private fun closedReason(fallback: QuicError): QuicError = (driver.state.value as? QuicConnectionState.Closed)?.error ?: fallback
-
     override suspend fun streamRead(
         streamId: QuicStreamId,
         bufferFactory: BufferFactory,
@@ -890,7 +889,7 @@ class DriverStreamAdapter(
                                 return@withTimeout written
                             } else {
                                 throw QuicCloseException(
-                                    closedReason(QuicError.InternalError("quiche stream write error: $written")),
+                                    driver.closeReasonOr(QuicError.InternalError("quiche stream write error: $written")),
                                     "quiche stream write error: $written",
                                 )
                             }
@@ -900,10 +899,10 @@ class DriverStreamAdapter(
                 0
             }
         } catch (_: ClosedSendChannelException) {
-            throw QuicCloseException(closedReason(QuicError.NoError), "connection closed")
+            throw QuicCloseException(driver.closeReasonOr(QuicError.NoError), "connection closed")
         } catch (_: kotlinx.coroutines.channels.ClosedReceiveChannelException) {
             // writableSignal was closed by cleanup() — the connection went away while we were parked.
-            throw QuicCloseException(closedReason(QuicError.NoError), "connection closed")
+            throw QuicCloseException(driver.closeReasonOr(QuicError.NoError), "connection closed")
         } finally {
             // Wait — non-cancellably — for any in-flight StreamSend to finish reading `addr` before we
             // return to the caller who will free `buffer`. The driver always completes the deferred

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
@@ -7,7 +7,6 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.ConnectionOptions
-import com.ditchoom.socket.SocketClosedException
 import com.ditchoom.socket.SocketConnectionException
 import com.ditchoom.socket.linux.socket_getsockname
 import com.ditchoom.socket.quic.quiche.QUICHE_PROTOCOL_VERSION
@@ -252,7 +251,7 @@ private class LinuxQuicConnection(
             val adapter = DriverStreamAdapter(driver, slot)
             return QuicByteStream(slot.id, QuicheStreamByteStream(slot.id, adapter, bufferFactory))
         } catch (_: ClosedSendChannelException) {
-            throw SocketClosedException.General("connection closed")
+            throw QuicCloseException(driver.closeReasonOr(QuicError.NoError), "connection closed")
         }
     }
 

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -10,7 +10,6 @@ import com.ditchoom.buffer.bufferHashCode
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.managed
 import com.ditchoom.buffer.nativeMemoryAccess
-import com.ditchoom.socket.SocketClosedException
 import com.ditchoom.socket.linux.socket_getsockname
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.UIntVar
@@ -651,7 +650,7 @@ private class LinuxServerQuicConnection(
             val adapter = DriverStreamAdapter(driver, slot)
             return QuicByteStream(slot.id, QuicheStreamByteStream(slot.id, adapter, bufferFactory))
         } catch (_: ClosedSendChannelException) {
-            throw SocketClosedException.General("connection closed")
+            throw QuicCloseException(driver.closeReasonOr(QuicError.NoError), "connection closed")
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #106. That PR introduced `QuicCloseException` (carrying a structured `QuicError`) and converted the `commonMain` driver throw sites. This PR finishes the job: the remaining **platform facades** still threw plain `SocketClosedException.General` on connection loss, dropping the structured reason on the JVM/Linux/Apple thrown channels.

### Changes
- **Add `QuicheDriver.closeReasonOr(fallback)`** — returns the connection's recorded `Closed` error if known, else `fallback`. Centralizes the "connection state is the source of truth for the close reason" logic that had been inlined in three places.
- **Route the in-driver sites through it** (`failCommand` OpenStream, `DriverStreamAdapter` read/write); removes the duplicated private helper.
- **Convert the platform sites to `QuicCloseException`:**
  - JVM client (`JvmQuicConnection`), JVM server (`CommonJvmWithQuicServer`), Linux client/server (`WithQuicConnection/Server.linux`) — the `openStream()` → `ClosedSendChannelException` path, via `driver.closeReasonOr(NoError)`.
  - Apple (`WithQuicConnection.apple`) — connection *cancelled* → `NoError` (clean local teardown); *write error* → `InternalError` carrying the opaque `NWError` code in its detail (Network.framework doesn't surface RFC 9000 codes).
- Drop now-unused `SocketClosedException` imports.

`QuicCloseException` **is-a** `SocketClosedException`, so `catch (SocketClosedException)` / `catch (IOException)` on JVM keep working unchanged — now with the structured reason available on **every** platform, not just the common driver.

## Verification (local)
- `:socket-quic:jvmTest` — `QuicErrorTests`, `ReactiveDriverTests`, `JvmQuicConnectionTests` green.
- `:socket-quic:compileKotlinMacosArm64` compiles (validates the Apple edits).
- ktlint clean.
- Linux native target isn't registered on a macOS host (gated to CI) — relying on the `Linux ARM64 (native)` CI job; the edit is identical to the JVM one.