### PR TITLE
feat(quic): RFC 9221 unreliable datagrams + dev-container (WebTransport Phase 0)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,73 @@
+# Canonical Linux build toolchain for com.ditchoom:socket (incl. socket-quic).
+#
+# This is the single source of truth for the native toolchain the build needs —
+# Rust → quiche → BoringSSL, cargo-ndk, cross-compilers, liburing, JDK 17+21.
+# It mirrors .github/workflows/build-linux.yaml so local dev, Codespaces, and a
+# future CI base image all share one definition. CI workflows are NOT changed by
+# adding this file (see .devcontainer/README.md).
+#
+# Multi-arch: builds natively on linux/amd64 and linux/arm64 (e.g. Apple's
+# `container` CLI on Apple silicon). Caveat: the Android NDK ships x86_64-only
+# Linux host tools, so Android JNI builds require an amd64 image — see README.
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# --- Base build toolchain (mirrors build-linux.yaml "Install ... toolchains") ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential perl pkg-config cmake nasm \
+        git curl wget ca-certificates gnupg unzip zip xz-utils \
+        gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+        gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 \
+        liburing-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- JDK 17 + 21 (Temurin). Build/toolchain runs on 21 (FFM bindings); 17 lets
+#     the JNI test step run on a JDK < 21 launcher, as build-linux.yaml does. ---
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public \
+        | gpg --dearmor -o /etc/apt/keyrings/adoptium.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" \
+        > /etc/apt/sources.list.d/adoptium.list \
+    && apt-get update && apt-get install -y --no-install-recommends temurin-17-jdk temurin-21-jdk \
+    && rm -rf /var/lib/apt/lists/* \
+    # Arch-independent symlinks so JAVA_HOME is stable across amd64/arm64.
+    && ln -s /usr/lib/jvm/temurin-17-jdk-* /opt/java-17 \
+    && ln -s /usr/lib/jvm/temurin-21-jdk-* /opt/java-21
+
+# Default to JDK 21 (required to compile the FFM/Panama quiche bindings).
+ENV JAVA_HOME=/opt/java-21
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+# --- Rust stable + cross targets + cargo-ndk (mirrors build-linux.yaml) ---
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:${PATH}
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal \
+    && rustup target add \
+        aarch64-unknown-linux-gnu x86_64-pc-windows-gnu \
+        aarch64-linux-android armv7-linux-androideabi \
+        x86_64-linux-android i686-linux-android \
+    && cargo install cargo-ndk --quiet \
+    && chmod -R a+rwX /usr/local/rustup /usr/local/cargo
+
+# --- Android SDK + NDK (compileSdk 36, minSdk 21/24). cmdline-tools + sdkmanager
+#     are Java-based (arch-independent); the NDK host toolchain is x86_64-only. ---
+ENV ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk
+ARG ANDROID_NDK_VERSION=27.2.12479018
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools \
+    && cd ${ANDROID_HOME}/cmdline-tools \
+    && curl -fsSL -o tools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+    && unzip -q tools.zip && rm tools.zip && mv cmdline-tools latest \
+    && yes | ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null \
+    && ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager \
+        "platform-tools" "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}" > /dev/null
+ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}
+ENV PATH=${PATH}:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/latest/bin
+
+# Kotlin/JS tests: Gradle provisions its own Node; browser tests additionally
+# need a Chrome/Chromium on PATH (install per host if you run jsBrowserTest).
+
+WORKDIR /workspace

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,52 @@
+# Dev container — canonical Linux build toolchain
+
+[`Dockerfile`](./Dockerfile) is the **single source of truth** for the native
+toolchain this project's build needs (Rust → quiche → BoringSSL, `cargo-ndk`,
+cross-compilers, `liburing`, JDK 17 + 21). It mirrors the steps in
+[`.github/workflows/build-linux.yaml`](../.github/workflows/build-linux.yaml) so
+local dev, Codespaces, and (later) CI can share one definition.
+
+> **CI is intentionally unchanged.** `build-linux.yaml` still installs its own
+> toolchain today. This image is the canonical list to keep it in sync against,
+> and a future change can have CI build/run inside this image — one place to edit
+> for both GitHub and local. Editing the toolchain? Update this `Dockerfile`.
+
+## Run it
+
+Apple silicon (native `linux/arm64`, no Docker Desktop) — Apple's `container` CLI:
+
+```sh
+container build -t ditchoom-socket -f .devcontainer/Dockerfile .
+container run --rm -it -v "$PWD":/workspace -w /workspace ditchoom-socket \
+  ./gradlew :socket-quic:jvmTest jsNodeTest
+```
+
+Docker (any host):
+
+```sh
+docker build -t ditchoom-socket -f .devcontainer/Dockerfile .
+docker run --rm -it -v "$PWD":/workspace -w /workspace ditchoom-socket \
+  ./gradlew :socket-quic:jvmTest jsNodeTest
+```
+
+VS Code / Codespaces: "Reopen in Container" picks up `devcontainer.json`
+(JDK 21 default, cached `~/.gradle` / `~/.konan` / cargo registry volumes).
+
+`JAVA_HOME` defaults to **JDK 21** (required to compile the FFM/Panama quiche
+bindings). JDK 17 is at `/opt/java-17` for the JNI-on-JDK<21 test path.
+
+## What builds where (architecture note)
+
+| Target | linux/arm64 (Apple `container`, native) | linux/amd64 |
+| --- | --- | --- |
+| JVM (JNI + FFM), Kotlin/Native Linux, Kotlin/JS (`jsNodeTest`) | ✅ native | ✅ |
+| Android JNI (`buildAndroidJni*`, `cargo-ndk`) | ⚠️ NDK host tools are **x86_64-only** | ✅ |
+| Apple targets (macOS/iOS) | ❌ needs a macOS host (Xcode / Network.framework) | ❌ |
+
+Android NDK ships no `linux-aarch64` host toolchain, so on a native arm64
+container Android JNI builds won't run. For Android work, use an amd64 image
+(`--platform linux/amd64`, emulated on Apple silicon) or build Android on an
+x86_64 host / CI. Everything else builds natively on arm64.
+
+Browser-based Kotlin/JS tests (`jsBrowserTest`) additionally need Chrome/Chromium
+on `PATH`; `jsNodeTest` uses the Node that Gradle provisions.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "ditchoom-socket",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "containerEnv": {
+    "JAVA_HOME": "/opt/java-21"
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "mounts": [
+    "source=ditchoom-gradle,target=/root/.gradle,type=volume",
+    "source=ditchoom-konan,target=/root/.konan,type=volume",
+    "source=ditchoom-cargo-registry,target=/usr/local/cargo/registry,type=volume"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "fwcd.kotlin",
+        "rust-lang.rust-analyzer"
+      ]
+    }
+  }
+}

--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicDatagramTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicDatagramTests.kt
@@ -1,0 +1,123 @@
+package com.ditchoom.socket.quic
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * In-process unreliable-datagram (RFC 9221) coverage on the Android/JNI runtime — the Android
+ * counterpart of [QuicDatagramTestSuite] (JVM/Linux). Runs BOTH ends via [withQuicServer] over
+ * loopback (no docker), exercising the Android cargo-ndk JNI datagram bindings end-to-end.
+ */
+@RunWith(AndroidJUnit4::class)
+class AndroidQuicDatagramTests {
+    private val tlsConfig get() = AndroidTestCerts.tlsConfig
+
+    private val noDgramOptions =
+        QuicOptions(alpnProtocols = listOf("test"), verifyPeer = false, idleTimeout = 10.seconds)
+    private val dgramOptions = noDgramOptions.copy(datagrams = DatagramOptions())
+
+    private suspend fun skipOnMissingNativeLib(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+
+    @Test
+    fun datagramRoundTrip() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib {
+                withTimeout(20.seconds) {
+                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = dgramOptions) {
+                        val echoed = CompletableDeferred<String>()
+                        val serverJob =
+                            launch(Dispatchers.IO) {
+                                connections {
+                                    when (val r = receiveDatagram()) {
+                                        is DatagramReceiveResult.Received -> {
+                                            val text = r.buffer.readString(r.buffer.remaining(), Charset.UTF8)
+                                            r.buffer.freeIfNeeded()
+                                            val out = BufferFactory.Default.allocate(text.length)
+                                            out.writeString(text, Charset.UTF8)
+                                            out.resetForRead()
+                                            sendDatagram(out)
+                                            out.freeNativeMemory()
+                                        }
+                                        is DatagramReceiveResult.ConnectionClosed -> {}
+                                    }
+                                }
+                            }
+                        delay(100)
+
+                        val clientJob =
+                            launch(Dispatchers.IO) {
+                                withQuicConnection("127.0.0.1", port, dgramOptions, timeout = 10.seconds) {
+                                    assertTrue(maxDatagramSize() is MaxDatagramSize.Bytes)
+                                    val sendBuf = BufferFactory.Default.allocate(13)
+                                    sendBuf.writeString("hello-android", Charset.UTF8)
+                                    sendBuf.resetForRead()
+                                    sendDatagram(sendBuf)
+                                    sendBuf.freeNativeMemory()
+                                    when (val r = receiveDatagram()) {
+                                        is DatagramReceiveResult.Received -> {
+                                            echoed.complete(r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+                                            r.buffer.freeIfNeeded()
+                                        }
+                                        is DatagramReceiveResult.ConnectionClosed -> echoed.complete("connection_closed")
+                                    }
+                                }
+                            }
+
+                        try {
+                            assertEquals("hello-android", withTimeout(12.seconds) { echoed.await() })
+                        } finally {
+                            clientJob.cancel()
+                            serverJob.cancel()
+                        }
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun datagramsDisabledByDefault() =
+        runBlocking(Dispatchers.IO) {
+            skipOnMissingNativeLib {
+                withTimeout(20.seconds) {
+                    withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = noDgramOptions) {
+                        val serverJob = launch(Dispatchers.IO) { connections { /* return immediately */ } }
+                        delay(100)
+                        try {
+                            withQuicConnection("127.0.0.1", port, noDgramOptions, timeout = 10.seconds) {
+                                assertEquals(MaxDatagramSize.Unavailable, maxDatagramSize())
+                                val buf = BufferFactory.Default.allocate(4)
+                                buf.writeInt(1)
+                                buf.resetForRead()
+                                assertFailsWith<IllegalStateException> { sendDatagram(buf) }
+                                buf.freeNativeMemory()
+                            }
+                        } finally {
+                            serverJob.cancel()
+                        }
+                    }
+                }
+            }
+        }
+}

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
@@ -220,4 +220,9 @@ internal class CommonJvmQuicConfigCalls(
     override fun enableEarlyData() = api.configEnableEarlyData(cfg)
 
     override fun grease(v: Boolean) = api.configGrease(cfg, v)
+
+    override fun enableDgram(
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    ) = api.configEnableDgram(cfg, true, recvQueueLen, sendQueueLen)
 }

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -670,6 +670,8 @@ internal class DriverQuicConnection(
 
     private val bufferFactory = BufferFactory.Default
 
+    private val datagramAdapter = DriverDatagramAdapter(driver, bufferFactory)
+
     override suspend fun openStream(): QuicByteStream {
         try {
             val deferred = CompletableDeferred<StreamSlot>()
@@ -686,6 +688,14 @@ internal class DriverQuicConnection(
     override suspend fun acceptStream(): QuicByteStream = driver.incomingStreams.receive()
 
     override fun streams(): Flow<QuicByteStream> = driver.incomingStreams.consumeAsFlow()
+
+    override suspend fun sendDatagram(buffer: com.ditchoom.buffer.ReadBuffer) = datagramAdapter.sendDatagram(buffer)
+
+    override suspend fun receiveDatagram(): DatagramReceiveResult = datagramAdapter.receiveDatagram()
+
+    override fun datagrams(): Flow<com.ditchoom.buffer.ReadBuffer> = datagramAdapter.datagrams()
+
+    override fun maxDatagramSize(): MaxDatagramSize = datagramAdapter.maxDatagramSize()
 
     override suspend fun close(error: QuicError) {
         try {

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -204,6 +204,42 @@ object JniQuicheApi : QuicheApi {
         fin: Boolean,
     ): Int = nConnStreamSend(conn.handle, streamId.id, buf, bufLen, fin)
 
+    // --- Unreliable datagrams (RFC 9221) ---
+
+    override fun configEnableDgram(
+        config: QuicheConfig,
+        enabled: Boolean,
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    ) = nConfigEnableDgram(config.handle, enabled, recvQueueLen, sendQueueLen)
+
+    override fun connDgramSend(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): Int = nConnDgramSend(conn.handle, buf, bufLen)
+
+    override fun connDgramRecv(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): StreamRecvResult {
+        // ssize_t: >= 0 length (datagrams have no FIN), QUICHE_ERR_DONE when none queued, else error.
+        val raw = nConnDgramRecv(conn.handle, buf, bufLen)
+        return when {
+            raw >= 0 -> StreamRecvResult.Data(raw.toInt(), false)
+            raw == QUICHE_ERR_DONE -> StreamRecvResult.Done
+            else -> StreamRecvResult.Error(raw.toInt())
+        }
+    }
+
+    override fun hasReadableDgram(conn: QuicheConn): Boolean = nConnDgramRecvFrontLen(conn.handle) >= 0
+
+    override fun connDgramMaxWritableLen(conn: QuicheConn): MaxDatagramSize {
+        val raw = nConnDgramMaxWritableLen(conn.handle)
+        return if (raw < 0) MaxDatagramSize.Unavailable else MaxDatagramSize.Bytes(raw.toInt())
+    }
+
     override fun connIsEstablished(conn: QuicheConn): Boolean = nConnIsEstablished(conn.handle)
 
     override fun connIsClosed(conn: QuicheConn): Boolean = nConnIsClosed(conn.handle)
@@ -564,6 +600,38 @@ object JniQuicheApi : QuicheApi {
         bufLen: Int,
         fin: Boolean,
     ): Int
+
+    @JvmStatic
+    private external fun nConfigEnableDgram(
+        config: Long,
+        enabled: Boolean,
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    )
+
+    @FastNative
+    @JvmStatic
+    private external fun nConnDgramSend(
+        conn: Long,
+        buf: Long,
+        bufLen: Int,
+    ): Int
+
+    @FastNative
+    @JvmStatic
+    private external fun nConnDgramRecv(
+        conn: Long,
+        buf: Long,
+        bufLen: Int,
+    ): Long
+
+    @FastNative
+    @JvmStatic
+    private external fun nConnDgramRecvFrontLen(conn: Long): Long
+
+    @FastNative
+    @JvmStatic
+    private external fun nConnDgramMaxWritableLen(conn: Long): Long
 
     @FastNative
     @JvmStatic

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
@@ -1,6 +1,7 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -25,6 +26,8 @@ internal class JvmQuicConnection(
 ) : QuicConnection,
     CoroutineScope by scope {
     override val state: StateFlow<QuicConnectionState> = driver.state
+
+    private val datagramAdapter = DriverDatagramAdapter(driver, bufferFactory)
 
     internal fun start() {
         driver.start(scope)
@@ -51,6 +54,14 @@ internal class JvmQuicConnection(
     override suspend fun acceptStream(): QuicByteStream = driver.incomingStreams.receive()
 
     override fun streams(): Flow<QuicByteStream> = driver.incomingStreams.consumeAsFlow()
+
+    override suspend fun sendDatagram(buffer: ReadBuffer) = datagramAdapter.sendDatagram(buffer)
+
+    override suspend fun receiveDatagram(): DatagramReceiveResult = datagramAdapter.receiveDatagram()
+
+    override fun datagrams(): Flow<ReadBuffer> = datagramAdapter.datagrams()
+
+    override fun maxDatagramSize(): MaxDatagramSize = datagramAdapter.maxDatagramSize()
 
     override val pathState: StateFlow<PathInfo> = driver.pathState
 

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/DatagramReceiveResult.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/DatagramReceiveResult.kt
@@ -1,0 +1,30 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.ReadBuffer
+import kotlin.jvm.JvmInline
+
+/**
+ * Outcome of [QuicScope.receiveDatagram]. Exhaustive — a `when` over it forces callers to handle
+ * both the data case and the connection-closed case, so there is no nullable/primitive sentinel to
+ * misread (mirrors the sealed style of [QuicError] / [StreamRecvResult] / [MigrationResult]).
+ *
+ * Single-field variants are `@JvmInline value class` for consistency with [QuicStreamId]; note that
+ * when returned through the [DatagramReceiveResult] supertype they box at that boundary, so this is
+ * for descriptiveness, not a zero-allocation guarantee.
+ */
+sealed interface DatagramReceiveResult {
+    /**
+     * A datagram arrived. Ownership of [buffer] transfers to the caller, who must release it
+     * (`freeNativeMemory()`); for a pooled [com.ditchoom.buffer.BufferFactory] that returns it to the pool.
+     */
+    @JvmInline
+    value class Received(
+        val buffer: ReadBuffer,
+    ) : DatagramReceiveResult
+
+    /** The connection is gone; no further datagrams will arrive. [error] is the structured close reason. */
+    @JvmInline
+    value class ConnectionClosed(
+        val error: QuicError,
+    ) : DatagramReceiveResult
+}

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/DriverDatagramAdapter.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/DriverDatagramAdapter.kt
@@ -1,0 +1,129 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.nativeMemoryAccess
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+
+/**
+ * Implements the [QuicScope] datagram surface (RFC 9221) on top of [QuicheDriver].
+ *
+ * Shared by every quiche-backed platform connection (JVM/Android/Linux) so the buffer-ownership and
+ * native-lifetime rules live in one place. The logic mirrors [DriverStreamAdapter] for streams:
+ *
+ * - **receive**: allocate from [bufferFactory] (pool-aware — `freeNativeMemory()` returns a pooled
+ *   buffer to its pool), let quiche write into it, transfer ownership to the caller on success and
+ *   free it otherwise. A [NonCancellable] join on the in-flight command guarantees quiche has finished
+ *   writing `addr` before the buffer can be released (the read-after-free guard from [DriverStreamAdapter]).
+ * - **send**: the caller owns the buffer; the driver only reads its native address. The same in-flight
+ *   join guarantees quiche finished reading before the caller frees/recycles it.
+ */
+internal class DriverDatagramAdapter(
+    private val driver: QuicheDriver,
+    private val bufferFactory: BufferFactory,
+) {
+    /** The structured close reason if the connection has closed, else [fallback]. */
+    private fun closedReason(fallback: QuicError): QuicError = (driver.state.value as? QuicConnectionState.Closed)?.error ?: fallback
+
+    suspend fun sendDatagram(buffer: ReadBuffer) {
+        val remaining = buffer.remaining()
+        when (val max = driver.lastMaxDatagramSize) {
+            is MaxDatagramSize.Unavailable ->
+                throw IllegalStateException("QUIC datagrams are not enabled, or the peer did not advertise support")
+            is MaxDatagramSize.Bytes ->
+                require(remaining <= max.bytes) { "datagram too large: $remaining > ${max.bytes} bytes" }
+        }
+        // A zero-length datagram is valid (RFC 9221); a 0-remaining buffer may not expose a native
+        // address, so pass a null pointer in that case (the backends send NULL/len 0).
+        val addr = if (remaining > 0) buffer.nativeMemoryAccess!!.nativeAddress.toLong() + buffer.position() else 0L
+
+        // See DriverStreamAdapter.streamWrite: keep the buffer alive until any in-flight send finishes
+        // reading `addr`, since the caller frees it the instant we return.
+        var inFlight: CompletableDeferred<Int>? = null
+        try {
+            while (true) {
+                val deferred = CompletableDeferred<Int>()
+                driver.commands.send(QuicheCmd.DgramSend(addr, remaining, deferred))
+                inFlight = deferred
+                val written = deferred.await()
+                inFlight = null
+                when {
+                    // All-or-nothing: quiche accepted the whole datagram (returns its length, 0 for empty).
+                    written >= 0 -> return
+                    // Send queue full — backpressure. Park until flushOutgoing drains it, then retry.
+                    written == QuicheDriver.QUICHE_ERR_DONE -> driver.dgramWritableSignal.receive()
+                    else ->
+                        throw QuicCloseException(
+                            closedReason(QuicError.InternalError("quiche datagram send error: $written")),
+                            "quiche datagram send error: $written",
+                        )
+                }
+            }
+        } catch (_: ClosedSendChannelException) {
+            throw QuicCloseException(closedReason(QuicError.NoError), "connection closed")
+        } catch (_: ClosedReceiveChannelException) {
+            // dgramWritableSignal was closed by cleanup() — the connection went away while parked.
+            throw QuicCloseException(closedReason(QuicError.NoError), "connection closed")
+        } finally {
+            inFlight?.let { withContext(NonCancellable) { it.join() } }
+        }
+    }
+
+    suspend fun receiveDatagram(): DatagramReceiveResult {
+        val buffer = bufferFactory.allocate(QuicheDriver.MAX_DATAGRAM_SIZE)
+        val addr = buffer.nativeMemoryAccess!!.nativeAddress.toLong()
+
+        // See DriverStreamAdapter.streamRead: the driver may still be writing into `addr` inside
+        // connDgramRecv when we unwind, so wait (non-cancellably) for any in-flight recv before freeing.
+        var inFlight: CompletableDeferred<StreamRecvResult>? = null
+        var transferred = false
+        try {
+            while (true) {
+                val deferred = CompletableDeferred<StreamRecvResult>()
+                driver.commands.send(QuicheCmd.DgramRecv(addr, QuicheDriver.MAX_DATAGRAM_SIZE, deferred))
+                inFlight = deferred
+                val result = deferred.await()
+                inFlight = null
+                when (result) {
+                    is StreamRecvResult.Data -> {
+                        // bytesRead may be 0 — a valid empty datagram. Ownership transfers either way.
+                        buffer.position(result.bytesRead)
+                        buffer.resetForRead()
+                        transferred = true
+                        return DatagramReceiveResult.Received(buffer)
+                    }
+                    is StreamRecvResult.Done -> driver.dgramSignal.receive() // park until one arrives, then retry
+                    is StreamRecvResult.Error -> return DatagramReceiveResult.ConnectionClosed(closedReason(QuicError.NoError))
+                }
+            }
+            @Suppress("UNREACHABLE_CODE")
+            DatagramReceiveResult.ConnectionClosed(closedReason(QuicError.NoError))
+        } catch (_: ClosedSendChannelException) {
+            return DatagramReceiveResult.ConnectionClosed(closedReason(QuicError.NoError))
+        } catch (_: ClosedReceiveChannelException) {
+            return DatagramReceiveResult.ConnectionClosed(closedReason(QuicError.NoError))
+        } finally {
+            inFlight?.let { withContext(NonCancellable) { it.join() } }
+            if (!transferred) buffer.freeNativeMemory()
+        }
+    }
+
+    /** Thin loop over [receiveDatagram] for parity with `streams()`; completes when the connection closes. */
+    fun datagrams(): Flow<ReadBuffer> =
+        flow {
+            while (true) {
+                when (val result = receiveDatagram()) {
+                    is DatagramReceiveResult.Received -> emit(result.buffer)
+                    is DatagramReceiveResult.ConnectionClosed -> return@flow
+                }
+            }
+        }
+
+    fun maxDatagramSize(): MaxDatagramSize = driver.lastMaxDatagramSize
+}

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/MaxDatagramSize.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/MaxDatagramSize.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.socket.quic
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Result of [QuicScope.maxDatagramSize]. Sealed instead of a nullable `Int?` so the
+ * "datagrams unavailable" case is explicit and a `when` forces callers to handle it —
+ * consistent with [DatagramReceiveResult] / [QuicError] / [MigrationResult].
+ */
+sealed interface MaxDatagramSize {
+    /** A datagram of up to [bytes] can be sent right now. Tracks the current path MTU. */
+    @JvmInline
+    value class Bytes(
+        val bytes: Int,
+    ) : MaxDatagramSize {
+        init {
+            require(bytes > 0) { "max datagram size must be positive" }
+        }
+    }
+
+    /**
+     * Datagrams cannot be sent: either [QuicOptions.datagrams] was not set locally, or the peer
+     * never advertised `max_datagram_frame_size`.
+     */
+    data object Unavailable : MaxDatagramSize
+}

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicConfigApplicator.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicConfigApplicator.kt
@@ -51,6 +51,12 @@ internal interface QuicConfigCalls {
     fun enableEarlyData()
 
     fun grease(v: Boolean)
+
+    /** Enable unreliable DATAGRAM frames (RFC 9221) with the given receive/send queue lengths. */
+    fun enableDgram(
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    )
 }
 
 /**
@@ -104,4 +110,7 @@ internal fun applyQuicOptions(
     calls.discoverPmtu(options.enablePmtuDiscovery)
     if (options.enableEarlyData) calls.enableEarlyData()
     calls.grease(options.enableGrease)
+
+    // Unreliable datagrams (RFC 9221) — only when explicitly enabled.
+    options.datagrams?.let { calls.enableDgram(it.recvQueueLen.toLong(), it.sendQueueLen.toLong()) }
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicOptions.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicOptions.kt
@@ -77,6 +77,26 @@ data class FlowControl(
 }
 
 /**
+ * Unreliable DATAGRAM frame support (RFC 9221). Present (non-null on [QuicOptions.datagrams])
+ * means the endpoint advertises `max_datagram_frame_size` and maintains datagram queues.
+ *
+ * Both queues are bounded; when full, quiche drops the **oldest** datagram — the unreliable,
+ * lossy semantics RFC 9221 and WebTransport expect. This is also the backpressure mechanism:
+ * a slow receiver simply loses old datagrams rather than growing memory without bound.
+ */
+data class DatagramOptions(
+    /** Max datagrams buffered for receive before quiche drops the oldest. */
+    val recvQueueLen: Int = 1024,
+    /** Max datagrams buffered for send before quiche drops the oldest. */
+    val sendQueueLen: Int = 1024,
+) {
+    init {
+        require(recvQueueLen > 0) { "recvQueueLen must be positive" }
+        require(sendQueueLen > 0) { "sendQueueLen must be positive" }
+    }
+}
+
+/**
  * QUIC-specific transport configuration.
  *
  * Uses sealed interfaces for [congestionControl] and [pacing] so `when` expressions
@@ -132,6 +152,12 @@ data class QuicOptions(
     val enableEarlyData: Boolean = false,
     /** Enable GREASE (Generate Random Extensions And Sustain Extensibility). */
     val enableGrease: Boolean = true,
+    /**
+     * Unreliable DATAGRAM frame support (RFC 9221). Null (the default) leaves datagrams disabled,
+     * so [QuicScope.sendDatagram] throws and [QuicScope.maxDatagramSize] returns null. Set a
+     * [DatagramOptions] to advertise `max_datagram_frame_size` and enable the datagram queues.
+     */
+    val datagrams: DatagramOptions? = null,
 ) {
     init {
         require(alpnProtocols.isNotEmpty()) { "QUIC requires at least one ALPN protocol" }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicScope.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicScope.kt
@@ -1,9 +1,11 @@
 package com.ditchoom.socket.quic
 
+import com.ditchoom.buffer.ReadBuffer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 
 /**
  * A QUIC connection scope — the receiver inside [withQuicConnection] and [QuicServer.connections].
@@ -48,4 +50,44 @@ interface QuicScope : CoroutineScope {
     /** Current migration/path state. Defaults to a never-migrating [PathInfo]. */
     val pathState: StateFlow<PathInfo>
         get() = MutableStateFlow(PathInfo())
+
+    // --- Unreliable datagrams (RFC 9221) ---
+    // Available only when [QuicOptions.datagrams] was set. The default implementations make a
+    // non-datagram connection behave correctly: send throws, receive throws, the flow is empty,
+    // and the max size is null. Platforms that support datagrams override all four.
+
+    /**
+     * Send one unreliable datagram (RFC 9221). The whole [buffer] is one datagram; it is delivered
+     * at most once, unordered, with no retransmission. Suspends only while the send queue is full
+     * (backpressure); the bytes are read zero-copy and the caller retains ownership of [buffer].
+     *
+     * @throws IllegalArgumentException if `buffer.remaining()` exceeds the current [maxDatagramSize].
+     * @throws IllegalStateException if datagrams are [MaxDatagramSize.Unavailable] (not enabled).
+     * @throws QuicCloseException if the connection is closed.
+     */
+    suspend fun sendDatagram(buffer: ReadBuffer): Unit =
+        throw UnsupportedOperationException("QUIC datagrams are not supported on this platform")
+
+    /**
+     * Receive the next unreliable datagram. Suspends until one arrives or the connection closes.
+     * Returns [DatagramReceiveResult.Received] (ownership of the buffer transfers to the caller) or
+     * [DatagramReceiveResult.ConnectionClosed] — never null.
+     */
+    suspend fun receiveDatagram(): DatagramReceiveResult =
+        throw UnsupportedOperationException("QUIC datagrams are not supported on this platform")
+
+    /**
+     * Flow of incoming unreliable datagrams — a thin loop over [receiveDatagram] for parity with
+     * [streams]. Completes when the connection closes. Each emitted buffer is owned by the collector,
+     * which must release it (same contract as [com.ditchoom.data.Reader.readFlow]).
+     */
+    fun datagrams(): Flow<ReadBuffer> = emptyFlow()
+
+    /**
+     * Maximum payload a single [sendDatagram] may carry right now — [MaxDatagramSize.Bytes] when
+     * datagrams can be sent, or [MaxDatagramSize.Unavailable] when they cannot (not enabled locally,
+     * or the peer never advertised `max_datagram_frame_size`). Tracks the current path MTU, so the
+     * byte count can change over the connection's life.
+     */
+    fun maxDatagramSize(): MaxDatagramSize = MaxDatagramSize.Unavailable
 }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -192,6 +192,47 @@ interface QuicheApi {
         fin: Boolean,
     ): Int
 
+    // --- Unreliable datagrams (RFC 9221) ---
+
+    /** Enable DATAGRAM frames on the config with the given receive/send queue lengths. */
+    fun configEnableDgram(
+        config: QuicheConfig,
+        enabled: Boolean,
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    )
+
+    /**
+     * Send one datagram from [buf]. Returns the number of bytes written (== [bufLen] on success),
+     * or a negative quiche error code ([QuicheDriver.QUICHE_ERR_DONE] when the send queue is full).
+     */
+    fun connDgramSend(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): Int
+
+    /**
+     * Receive one datagram into [buf]. Decoded like [connStreamRecv]: [StreamRecvResult.Data] (always
+     * `fin = false` — datagrams have no stream end), [StreamRecvResult.Done] when none is queued, or
+     * [StreamRecvResult.Error] on a negative quiche code.
+     */
+    fun connDgramRecv(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): StreamRecvResult
+
+    /** True when at least one datagram is queued for receive. (Wraps `dgram_recv_front_len`.) */
+    fun hasReadableDgram(conn: QuicheConn): Boolean
+
+    /**
+     * Maximum payload one [connDgramSend] can carry on the current path, as a [MaxDatagramSize]:
+     * [MaxDatagramSize.Bytes] when sendable, or [MaxDatagramSize.Unavailable] when the peer never
+     * advertised `max_datagram_frame_size`. Backends normalize quiche's negative/none into the sealed type.
+     */
+    fun connDgramMaxWritableLen(conn: QuicheConn): MaxDatagramSize
+
     fun connIsEstablished(conn: QuicheConn): Boolean
 
     fun connIsClosed(conn: QuicheConn): Boolean

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
@@ -56,6 +56,29 @@ sealed interface QuicheCmd {
         val result: CompletableDeferred<Int>,
     ) : QuicheCmd
 
+    /**
+     * Send one unreliable datagram (RFC 9221) from [addr]..[addr]+[bufLen]. [result] is the quiche
+     * return: bytes written (== [bufLen]) on success, or a negative code ([QuicheDriver.QUICHE_ERR_DONE]
+     * when the send queue is full — backpressure). The caller owns the buffer; the driver only reads it.
+     */
+    class DgramSend(
+        val addr: Long,
+        val bufLen: Int,
+        val result: CompletableDeferred<Int>,
+    ) : QuicheCmd
+
+    /**
+     * Receive one unreliable datagram into [addr]..[addr]+[bufLen]. Decoded into [StreamRecvResult]
+     * (always `fin = false`): [StreamRecvResult.Data] with the datagram length, [StreamRecvResult.Done]
+     * when none is queued, or [StreamRecvResult.Error]. The driver writes into [addr]; the caller must
+     * keep that buffer alive until [result] completes (see the lifetime guard in receiveDatagram).
+     */
+    class DgramRecv(
+        val addr: Long,
+        val bufLen: Int,
+        val result: CompletableDeferred<StreamRecvResult>,
+    ) : QuicheCmd
+
     /** Gracefully close the connection. */
     class Close(
         val error: QuicError,

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlin.concurrent.Volatile
 import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
 import kotlin.time.Duration
@@ -88,6 +89,30 @@ class QuicheDriver(
     val incomingStreams = Channel<QuicByteStream>(Channel.UNLIMITED)
     private val streams = mutableMapOf<Long, StreamSlot>()
     private var nextStreamId = if (isServer) 1L else 0L
+
+    // --- Unreliable datagrams (RFC 9221) ---
+
+    /**
+     * Conflated readiness signal tickled in [afterCommand] when quiche has a datagram queued.
+     * A parked [DriverDatagramAdapter.receiveDatagram] waits on it. Conflation makes it
+     * lost-wakeup-free: a tickle fired before the receiver parks is buffered until it receives.
+     */
+    val dgramSignal = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Conflated signal tickled in [afterCommand] after [flushOutgoing] drains the datagram send
+     * queue, releasing send backpressure. A [DriverDatagramAdapter.sendDatagram] that got
+     * `QUICHE_ERR_DONE` (queue full) parks on it and retries.
+     */
+    val dgramWritableSignal = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Latest max writable datagram size, refreshed each [afterCommand] (path MTU / negotiation can
+     * change it). Read cross-coroutine by `QuicScope.maxDatagramSize()`, hence [Volatile].
+     */
+    @Volatile
+    var lastMaxDatagramSize: MaxDatagramSize = MaxDatagramSize.Unavailable
+        private set
 
     private val udpSendBuf: PlatformBuffer = bufferFactory.allocate(MAX_DATAGRAM_SIZE)
     private val sendAddr = udpSendBuf.nativeMemoryAccess!!.nativeAddress.toLong()
@@ -272,6 +297,16 @@ class QuicheDriver(
                 cmd.result.complete(written)
             }
 
+            is QuicheCmd.DgramSend -> {
+                val written = api.connDgramSend(conn, cmd.addr, cmd.bufLen)
+                cmd.result.complete(written)
+            }
+
+            is QuicheCmd.DgramRecv -> {
+                val result = api.connDgramRecv(conn, cmd.addr, cmd.bufLen)
+                cmd.result.complete(result)
+            }
+
             is QuicheCmd.Close -> {
                 api.connClose(conn, cmd.error)
                 // Sync state from quiche BEFORE signalling the close completed, so a caller
@@ -302,7 +337,20 @@ class QuicheDriver(
         if (migrationEnabled) drainPathEvents()
         discoverNewStreams()
         signalWritableStreams()
+        signalDatagrams()
         updateState()
+    }
+
+    /**
+     * Datagram-path mirror of [discoverNewStreams] / [signalWritableStreams]. Refreshes the cached
+     * max writable size (read by `maxDatagramSize()`), wakes a parked receiver when quiche has a
+     * datagram queued, and — since [flushOutgoing] just drained the datagram send queue — releases
+     * any send backpressure. All signals are CONFLATED, so tickling with no parked waiter is a no-op.
+     */
+    private fun signalDatagrams() {
+        lastMaxDatagramSize = api.connDgramMaxWritableLen(conn)
+        if (api.hasReadableDgram(conn)) dgramSignal.trySend(Unit)
+        dgramWritableSignal.trySend(Unit)
     }
 
     /**
@@ -615,6 +663,10 @@ class QuicheDriver(
             slot.writableSignal.close()
         }
         streams.clear()
+        // Unblock any datagram receiver/sender parked on these signals — the closed-channel unwinds
+        // them to ConnectionClosed / QuicCloseException (see DriverDatagramAdapter).
+        dgramSignal.close()
+        dgramWritableSignal.close()
         api.connFree(conn)
         // Tear down any non-primary migration paths: cancel reader, close socket, free
         // recv_info before its sockaddr. Iterate a copy — teardown logic mutates `paths`.
@@ -665,6 +717,10 @@ class QuicheDriver(
                 )
             is QuicheCmd.StreamRecv -> cmd.result.complete(StreamRecvResult.Error(-2))
             is QuicheCmd.StreamSend -> cmd.result.complete(-1)
+            // Datagrams: receive → Error maps to ConnectionClosed; send → -1 parks on the (now-closed)
+            // dgramWritableSignal, which throws QuicCloseException. Mirrors the stream cases above.
+            is QuicheCmd.DgramRecv -> cmd.result.complete(StreamRecvResult.Error(-2))
+            is QuicheCmd.DgramSend -> cmd.result.complete(-1)
             is QuicheCmd.Close -> cmd.result.complete(Unit)
             is QuicheCmd.Migrate -> cmd.result.complete(MigrationResult.Failed("connection closed"))
         }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicDatagramAdapterTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicDatagramAdapterTests.kt
@@ -1,0 +1,182 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Deterministic unit tests for the datagram surface ([DriverDatagramAdapter] over a [QuicheDriver]
+ * driven by [StubQuicheApi]). No native lib / network — these run on every platform and exercise the
+ * control flow, backpressure parking, close handling, and buffer ownership directly.
+ *
+ * Byte-level round-trip (real encryption over UDP) is covered by [QuicDatagramTestSuite].
+ */
+class QuicDatagramAdapterTests {
+    private val bufferFactory = BufferFactory.deterministic()
+
+    private fun driverWith(
+        api: StubQuicheApi,
+        factory: BufferFactory = bufferFactory,
+    ): QuicheDriver =
+        QuicheDriver(
+            api = api,
+            conn = QuicheConn(1L),
+            bufferFactory = factory,
+            recvInfo = QuicheRecvInfo(1L),
+            sendInfo = QuicheSendInfo(1L),
+            udpChannel = StubUdpChannel(),
+            clientMode = false,
+            isServer = false,
+        )
+
+    /** Suspend until the driver has published [MaxDatagramSize] from [afterCommand]. */
+    private suspend fun awaitMaxSizePublished(driver: QuicheDriver) =
+        withTimeout(2.seconds) {
+            while (driver.lastMaxDatagramSize !is MaxDatagramSize.Bytes) yield()
+        }
+
+    @Test
+    fun receiveDatagram_returnsReceived_whenDataAvailable() =
+        runQuicTest {
+            val api = StubQuicheApi().apply { dgramRecvResult = StreamRecvResult.Data(5, false) }
+            val driver = driverWith(api)
+            val adapter = DriverDatagramAdapter(driver, bufferFactory)
+            driver.start(this)
+            try {
+                val result = withTimeout(2.seconds) { adapter.receiveDatagram() }
+                assertIs<DatagramReceiveResult.Received>(result)
+                assertEquals(5, result.buffer.remaining(), "received buffer should expose the datagram length")
+                result.buffer.freeIfNeeded()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    @Test
+    fun receiveDatagram_parksOnDone_thenWakesOnSignal() =
+        runQuicTest {
+            // First poll returns Done (queue empty), then a datagram arrives. hasReadableDgram=true makes
+            // afterCommand tickle dgramSignal, waking the parked receiver to retry and get the Data.
+            val api =
+                StubQuicheApi().apply {
+                    hasReadableDgram = true
+                    dgramRecvSequence.addAll(listOf(StreamRecvResult.Done, StreamRecvResult.Data(3, false)))
+                }
+            val driver = driverWith(api)
+            val adapter = DriverDatagramAdapter(driver, bufferFactory)
+            driver.start(this)
+            try {
+                val result = withTimeout(2.seconds) { adapter.receiveDatagram() }
+                assertIs<DatagramReceiveResult.Received>(result)
+                assertEquals(3, result.buffer.remaining())
+                result.buffer.freeIfNeeded()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    @Test
+    fun receiveDatagram_returnsConnectionClosed_onClose() =
+        runQuicTest {
+            // Done + no readable signal → the receiver parks on dgramSignal; destroy() closes it.
+            val api = StubQuicheApi().apply { dgramRecvResult = StreamRecvResult.Done }
+            val driver = driverWith(api)
+            val adapter = DriverDatagramAdapter(driver, bufferFactory)
+            driver.start(this)
+            val pending = async { adapter.receiveDatagram() }
+            yield() // let it park
+            driver.destroy()
+            val result = withTimeout(2.seconds) { pending.await() }
+            assertIs<DatagramReceiveResult.ConnectionClosed>(result)
+        }
+
+    @Test
+    fun sendDatagram_throwsWhenUnavailable() =
+        runQuicTest {
+            val api = StubQuicheApi().apply { dgramMaxWritableLen = MaxDatagramSize.Unavailable }
+            val driver = driverWith(api)
+            val adapter = DriverDatagramAdapter(driver, bufferFactory)
+            driver.start(this)
+            try {
+                val buf =
+                    bufferFactory.allocate(4).apply {
+                        writeInt(1)
+                        resetForRead()
+                    }
+                assertFailsWith<IllegalStateException> { adapter.sendDatagram(buf) }
+                buf.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    @Test
+    fun sendDatagram_succeedsWhenAvailable() =
+        runQuicTest {
+            val api = StubQuicheApi().apply { dgramMaxWritableLen = MaxDatagramSize.Bytes(1200) }
+            val driver = driverWith(api)
+            val adapter = DriverDatagramAdapter(driver, bufferFactory)
+            driver.start(this)
+            try {
+                awaitMaxSizePublished(driver)
+                val buf =
+                    bufferFactory.allocate(5).apply {
+                        repeat(5) { writeByte(it.toByte()) }
+                        resetForRead()
+                    }
+                withTimeout(2.seconds) { adapter.sendDatagram(buf) } // returns normally on success
+                buf.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    @Test
+    fun sendDatagram_throwsWhenTooLarge() =
+        runQuicTest {
+            val api = StubQuicheApi().apply { dgramMaxWritableLen = MaxDatagramSize.Bytes(4) }
+            val driver = driverWith(api)
+            val adapter = DriverDatagramAdapter(driver, bufferFactory)
+            driver.start(this)
+            try {
+                awaitMaxSizePublished(driver)
+                val buf =
+                    bufferFactory.allocate(8).apply {
+                        repeat(8) { writeByte(0) }
+                        resetForRead()
+                    }
+                assertFailsWith<IllegalArgumentException> { adapter.sendDatagram(buf) }
+                buf.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
+    @Test
+    fun receiveDatagram_transfersOwnership_noLeaks() =
+        runQuicTest {
+            // TrackingBufferFactory verifies the adapter frees the recv buffer on the caller's release,
+            // and the driver frees its own scratch buffers on cleanup — nothing leaks.
+            val factory = TrackingBufferFactory()
+            val api = StubQuicheApi().apply { dgramRecvResult = StreamRecvResult.Data(3, false) }
+            val driver = driverWith(api, factory)
+            val adapter = DriverDatagramAdapter(driver, factory)
+            driver.start(this)
+            try {
+                val result = withTimeout(2.seconds) { adapter.receiveDatagram() }
+                assertIs<DatagramReceiveResult.Received>(result)
+                result.buffer.freeIfNeeded() // caller owns the received buffer
+            } finally {
+                driver.destroy()
+            }
+            factory.assertNoLeaks()
+        }
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicDatagramTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicDatagramTestSuite.kt
@@ -1,0 +1,152 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.freeIfNeeded
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Shared end-to-end test suite for unreliable datagrams (RFC 9221). Each platform extends it with a
+ * [testTlsConfig]; the bodies run real encrypted datagrams over loopback UDP, guaranteeing parity
+ * across JVM, Linux, and Apple.
+ *
+ * Datagrams are unreliable, but a single datagram over loopback with no impairment does not drop, so
+ * the round-trip assertions are deterministic. Control-flow/ownership edge cases live in the
+ * platform-agnostic [QuicDatagramAdapterTests].
+ */
+abstract class QuicDatagramTestSuite {
+    abstract fun testTlsConfig(): QuicTlsConfig
+
+    protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
+
+    /** Datagrams disabled — the default. */
+    private val noDgramOptions =
+        QuicOptions(alpnProtocols = listOf("test"), verifyPeer = false, idleTimeout = 10.seconds)
+
+    /** Datagrams enabled on both ends. */
+    private val dgramOptions = noDgramOptions.copy(datagrams = DatagramOptions())
+
+    @Test
+    fun datagramRoundTrip() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = dgramOptions) {
+                    val echoed = CompletableDeferred<String>()
+
+                    val serverJob =
+                        launch {
+                            connections {
+                                when (val r = receiveDatagram()) {
+                                    is DatagramReceiveResult.Received -> {
+                                        val text = r.buffer.readString(r.buffer.remaining(), Charset.UTF8)
+                                        r.buffer.freeIfNeeded()
+                                        val out = BufferFactory.deterministic().allocate(text.length)
+                                        out.writeString(text, Charset.UTF8)
+                                        out.resetForRead()
+                                        sendDatagram(out)
+                                        out.freeNativeMemory()
+                                    }
+                                    is DatagramReceiveResult.ConnectionClosed -> {}
+                                }
+                            }
+                        }
+                    delay(100)
+
+                    val clientJob =
+                        launch {
+                            withQuicConnection("localhost", port, dgramOptions, timeout = 10.seconds) {
+                                assertIs<MaxDatagramSize.Bytes>(maxDatagramSize(), "datagrams should be sendable")
+                                val sendBuf = BufferFactory.deterministic().allocate(11)
+                                sendBuf.writeString("hello dgram", Charset.UTF8)
+                                sendBuf.resetForRead()
+                                sendDatagram(sendBuf)
+                                sendBuf.freeNativeMemory()
+
+                                when (val r = receiveDatagram()) {
+                                    is DatagramReceiveResult.Received -> {
+                                        echoed.complete(r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+                                        r.buffer.freeIfNeeded()
+                                    }
+                                    is DatagramReceiveResult.ConnectionClosed -> echoed.complete("connection_closed")
+                                }
+                            }
+                        }
+
+                    try {
+                        assertEquals("hello dgram", withTimeout(10.seconds) { echoed.await() })
+                    } finally {
+                        clientJob.cancel()
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun datagramsDisabledByDefault() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = noDgramOptions) {
+                    val ready = CompletableDeferred<Unit>()
+                    val serverJob =
+                        launch {
+                            connections {
+                                ready.complete(Unit)
+                                // Return immediately; framework closes the connection.
+                            }
+                        }
+                    delay(100)
+
+                    try {
+                        withQuicConnection("localhost", port, noDgramOptions, timeout = 10.seconds) {
+                            assertEquals(MaxDatagramSize.Unavailable, maxDatagramSize())
+                            val buf = BufferFactory.deterministic().allocate(4)
+                            buf.writeInt(1)
+                            buf.resetForRead()
+                            assertFailsWith<IllegalStateException> { sendDatagram(buf) }
+                            buf.freeNativeMemory()
+                        }
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun datagramTooLargeThrows() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = dgramOptions) {
+                    val ready = CompletableDeferred<Unit>()
+                    val serverJob = launch { connections { ready.complete(Unit) } }
+                    delay(100)
+
+                    try {
+                        withQuicConnection("localhost", port, dgramOptions, timeout = 10.seconds) {
+                            val max = maxDatagramSize()
+                            assertIs<MaxDatagramSize.Bytes>(max)
+                            assertTrue(max.bytes > 0)
+                            val tooBig = BufferFactory.deterministic().allocate(max.bytes + 1)
+                            repeat(max.bytes + 1) { tooBig.writeByte(0) }
+                            tooBig.resetForRead()
+                            assertFailsWith<IllegalArgumentException> { sendDatagram(tooBig) }
+                            tooBig.freeNativeMemory()
+                        }
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -218,6 +218,48 @@ internal class StubQuicheApi : QuicheApi {
         fin: Boolean,
     ) = connStreamSendResult ?: bufLen
 
+    // --- Unreliable datagrams (RFC 9221) ---
+
+    /** Records the last [configEnableDgram] call so tests can assert it was wired. */
+    @Volatile var dgramEnabled: Boolean = false
+
+    override fun configEnableDgram(
+        config: QuicheConfig,
+        enabled: Boolean,
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    ) {
+        dgramEnabled = enabled
+    }
+
+    /** When set, [connDgramSend] returns this instead of [bufLen] — e.g. -1 (QUICHE_ERR_DONE) or a real error. */
+    @Volatile var connDgramSendResult: Int? = null
+
+    override fun connDgramSend(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ) = connDgramSendResult ?: bufLen
+
+    /** Drained first by [connDgramRecv]; falls back to [dgramRecvResult] when empty. */
+    val dgramRecvSequence: ArrayDeque<StreamRecvResult> = ArrayDeque()
+
+    @Volatile var dgramRecvResult: StreamRecvResult = StreamRecvResult.Done
+
+    override fun connDgramRecv(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ) = dgramRecvSequence.removeFirstOrNull() ?: dgramRecvResult
+
+    @Volatile var hasReadableDgram: Boolean = false
+
+    override fun hasReadableDgram(conn: QuicheConn) = hasReadableDgram
+
+    @Volatile var dgramMaxWritableLen: MaxDatagramSize = MaxDatagramSize.Unavailable
+
+    override fun connDgramMaxWritableLen(conn: QuicheConn) = dgramMaxWritableLen
+
     override fun connIsEstablished(conn: QuicheConn) = established
 
     override fun connIsClosed(conn: QuicheConn) = closed

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -214,6 +214,40 @@ JNIEXPORT jint JNICALL JNI_FN(nConnStreamSend)(
         (bool)fin, &error_code);
 }
 
+/* --- Unreliable datagrams (RFC 9221) --- */
+
+JNIEXPORT void JNICALL JNI_FN(nConfigEnableDgram)(
+    JNIEnv *env, jclass cls,
+    jlong config, jboolean enabled, jlong recv_queue_len, jlong send_queue_len) {
+    quiche_config_enable_dgram(
+        (quiche_config *)(uintptr_t)config, (bool)enabled,
+        (size_t)recv_queue_len, (size_t)send_queue_len);
+}
+
+JNIEXPORT jint JNICALL JNI_FN(nConnDgramSend)(
+    JNIEnv *env, jclass cls, jlong conn, jlong buf, jint buf_len) {
+    return (jint)quiche_conn_dgram_send(
+        (quiche_conn *)(uintptr_t)conn,
+        (const uint8_t *)(uintptr_t)buf, (size_t)buf_len);
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nConnDgramRecv)(
+    JNIEnv *env, jclass cls, jlong conn, jlong buf, jint buf_len) {
+    return (jlong)quiche_conn_dgram_recv(
+        (quiche_conn *)(uintptr_t)conn,
+        (uint8_t *)(uintptr_t)buf, (size_t)buf_len);
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nConnDgramRecvFrontLen)(JNIEnv *env, jclass cls, jlong conn) {
+    /* quiche FFI returns ssize_t -1 when the recv queue is empty, else the front datagram length. */
+    return (jlong)quiche_conn_dgram_recv_front_len((quiche_conn *)(uintptr_t)conn);
+}
+
+JNIEXPORT jlong JNICALL JNI_FN(nConnDgramMaxWritableLen)(JNIEnv *env, jclass cls, jlong conn) {
+    /* quiche FFI returns ssize_t -1 when datagrams are not negotiated, else the max writable length. */
+    return (jlong)quiche_conn_dgram_max_writable_len((quiche_conn *)(uintptr_t)conn);
+}
+
 JNIEXPORT jboolean JNICALL JNI_FN(nConnIsEstablished)(JNIEnv *env, jclass cls, jlong conn) {
     return (jboolean)quiche_conn_is_established((const quiche_conn *)(uintptr_t)conn);
 }

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -108,6 +108,21 @@ class FfmQuicheApi private constructor(
     private val hGrease by lazy {
         downcall("quiche_config_grease", FunctionDescriptor.ofVoid(ADDRESS, JAVA_BOOLEAN))
     }
+    private val hConfigEnableDgram by lazy {
+        downcall("quiche_config_enable_dgram", FunctionDescriptor.ofVoid(ADDRESS, JAVA_BOOLEAN, JAVA_LONG, JAVA_LONG))
+    }
+    private val hConnDgramSend by lazy {
+        downcall("quiche_conn_dgram_send", FunctionDescriptor.of(JAVA_LONG, ADDRESS, ADDRESS, JAVA_LONG))
+    }
+    private val hConnDgramRecv by lazy {
+        downcall("quiche_conn_dgram_recv", FunctionDescriptor.of(JAVA_LONG, ADDRESS, ADDRESS, JAVA_LONG))
+    }
+    private val hConnDgramRecvFrontLen by lazy {
+        downcall("quiche_conn_dgram_recv_front_len", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
+    }
+    private val hConnDgramMaxWritableLen by lazy {
+        downcall("quiche_conn_dgram_max_writable_len", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
+    }
     private val hConnect by lazy {
         downcall(
             "quiche_connect",
@@ -449,6 +464,44 @@ class FfmQuicheApi private constructor(
             val errOut = arena.allocate(JAVA_LONG)
             (hStreamSend.invokeExact(seg(conn.handle), streamId.id, seg(buf), bufLen.toLong(), fin, errOut) as Long).toInt()
         }
+
+    // --- Unreliable datagrams (RFC 9221) ---
+
+    override fun configEnableDgram(
+        config: QuicheConfig,
+        enabled: Boolean,
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    ) {
+        hConfigEnableDgram.invokeExact(seg(config.handle), enabled, recvQueueLen, sendQueueLen)
+    }
+
+    override fun connDgramSend(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): Int = (hConnDgramSend.invokeExact(seg(conn.handle), seg(buf), bufLen.toLong()) as Long).toInt()
+
+    override fun connDgramRecv(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): StreamRecvResult {
+        // ssize_t: >= 0 length (datagrams have no FIN), QUICHE_ERR_DONE when none queued, else error.
+        val raw = hConnDgramRecv.invokeExact(seg(conn.handle), seg(buf), bufLen.toLong()) as Long
+        return when {
+            raw >= 0 -> StreamRecvResult.Data(raw.toInt(), false)
+            raw == QUICHE_ERR_DONE -> StreamRecvResult.Done
+            else -> StreamRecvResult.Error(raw.toInt())
+        }
+    }
+
+    override fun hasReadableDgram(conn: QuicheConn): Boolean = (hConnDgramRecvFrontLen.invokeExact(seg(conn.handle)) as Long) >= 0
+
+    override fun connDgramMaxWritableLen(conn: QuicheConn): MaxDatagramSize {
+        val raw = hConnDgramMaxWritableLen.invokeExact(seg(conn.handle)) as Long
+        return if (raw < 0) MaxDatagramSize.Unavailable else MaxDatagramSize.Bytes(raw.toInt())
+    }
 
     override fun connIsEstablished(conn: QuicheConn): Boolean = hIsEstablished.invokeExact(seg(conn.handle)) as Boolean
 

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/JvmQuicDatagramTests.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/JvmQuicDatagramTests.kt
@@ -1,0 +1,27 @@
+package com.ditchoom.socket.quic
+
+import org.junit.Assume.assumeTrue
+
+/** JVM member of [QuicDatagramTestSuite] — classpath cert resolution + UnsatisfiedLinkError skip. */
+class JvmQuicDatagramTests : QuicDatagramTestSuite() {
+    private fun certPath(name: String): String {
+        val url =
+            this::class.java.classLoader.getResource("certs/$name")
+                ?: error("Test cert not found: certs/$name")
+        return java.io.File(url.toURI()).absolutePath
+    }
+
+    override fun testTlsConfig() =
+        QuicTlsConfig(
+            certChainPath = certPath("cert.crt"),
+            privKeyPath = certPath("cert.key"),
+        )
+
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: UnsatisfiedLinkError) {
+            assumeTrue("Native lib not available: ${e.message}", false)
+        }
+    }
+}

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -47,6 +47,11 @@ import com.ditchoom.socket.quic.quiche.quiche_conn_readable
 import com.ditchoom.socket.quic.quiche.quiche_conn_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_scids_left
 import com.ditchoom.socket.quic.quiche.quiche_conn_send
+import com.ditchoom.socket.quic.quiche.quiche_config_enable_dgram
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_max_writable_len
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_recv
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_recv_front_len
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_timeout_as_nanos
@@ -214,6 +219,13 @@ internal object CinteropQuicheApi : QuicheApi {
         v: Boolean,
     ) = quiche_config_grease(config.handle.toCPointer()!!, v)
 
+    override fun configEnableDgram(
+        config: QuicheConfig,
+        enabled: Boolean,
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    ) = quiche_config_enable_dgram(config.handle.toCPointer()!!, enabled, recvQueueLen.convert(), sendQueueLen.convert())
+
     // --- Connection ---
 
     override fun connect(
@@ -314,6 +326,46 @@ internal object CinteropQuicheApi : QuicheApi {
                 errorCode.ptr,
             ).toInt()
         }
+    }
+
+    // --- Unreliable datagrams (RFC 9221) ---
+
+    override fun connDgramSend(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): Int =
+        quiche_conn_dgram_send(
+            conn.handle.toCPointer()!!,
+            if (bufLen > 0) buf.toCPointer<UByteVar>() else null,
+            bufLen.convert(),
+        ).toInt()
+
+    override fun connDgramRecv(
+        conn: QuicheConn,
+        buf: Long,
+        bufLen: Int,
+    ): StreamRecvResult {
+        // ssize_t: >= 0 length (datagrams have no FIN), QUICHE_ERR_DONE when none queued, else error.
+        val result =
+            quiche_conn_dgram_recv(
+                conn.handle.toCPointer()!!,
+                buf.toCPointer<UByteVar>()!!,
+                bufLen.convert(),
+            )
+        return when {
+            result >= 0 -> StreamRecvResult.Data(result.toInt(), false)
+            result.toInt() == QUICHE_ERR_DONE -> StreamRecvResult.Done
+            else -> StreamRecvResult.Error(result.toInt())
+        }
+    }
+
+    override fun hasReadableDgram(conn: QuicheConn): Boolean =
+        quiche_conn_dgram_recv_front_len(conn.handle.toCPointer()!!) >= 0
+
+    override fun connDgramMaxWritableLen(conn: QuicheConn): MaxDatagramSize {
+        val raw = quiche_conn_dgram_max_writable_len(conn.handle.toCPointer()!!)
+        return if (raw < 0) MaxDatagramSize.Unavailable else MaxDatagramSize.Bytes(raw.toInt())
     }
 
     override fun connIsEstablished(conn: QuicheConn): Boolean = quiche_conn_is_established(conn.handle.toCPointer()!!)

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -5,6 +5,7 @@ package com.ditchoom.socket.quic
 import com.ditchoom.socket.quic.quiche.QUICHE_PROTOCOL_VERSION
 import com.ditchoom.socket.quic.quiche.quiche_accept
 import com.ditchoom.socket.quic.quiche.quiche_config_discover_pmtu
+import com.ditchoom.socket.quic.quiche.quiche_config_enable_dgram
 import com.ditchoom.socket.quic.quiche.quiche_config_enable_early_data
 import com.ditchoom.socket.quic.quiche.quiche_config_enable_hystart
 import com.ditchoom.socket.quic.quiche.quiche_config_enable_pacing
@@ -33,6 +34,10 @@ import com.ditchoom.socket.quic.quiche.quiche_config_set_max_stream_window
 import com.ditchoom.socket.quic.quiche.quiche_config_verify_peer
 import com.ditchoom.socket.quic.quiche.quiche_conn_available_dcids
 import com.ditchoom.socket.quic.quiche.quiche_conn_close
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_max_writable_len
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_recv
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_recv_front_len
+import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_free
 import com.ditchoom.socket.quic.quiche.quiche_conn_is_closed
 import com.ditchoom.socket.quic.quiche.quiche_conn_is_established
@@ -47,11 +52,6 @@ import com.ditchoom.socket.quic.quiche.quiche_conn_readable
 import com.ditchoom.socket.quic.quiche.quiche_conn_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_scids_left
 import com.ditchoom.socket.quic.quiche.quiche_conn_send
-import com.ditchoom.socket.quic.quiche.quiche_config_enable_dgram
-import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_max_writable_len
-import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_recv
-import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_recv_front_len
-import com.ditchoom.socket.quic.quiche.quiche_conn_dgram_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_timeout_as_nanos
@@ -360,8 +360,7 @@ internal object CinteropQuicheApi : QuicheApi {
         }
     }
 
-    override fun hasReadableDgram(conn: QuicheConn): Boolean =
-        quiche_conn_dgram_recv_front_len(conn.handle.toCPointer()!!) >= 0
+    override fun hasReadableDgram(conn: QuicheConn): Boolean = quiche_conn_dgram_recv_front_len(conn.handle.toCPointer()!!) >= 0
 
     override fun connDgramMaxWritableLen(conn: QuicheConn): MaxDatagramSize {
         val raw = quiche_conn_dgram_max_writable_len(conn.handle.toCPointer()!!)

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
@@ -3,6 +3,7 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.ConnectionOptions
@@ -231,6 +232,8 @@ private class LinuxQuicConnection(
     CoroutineScope by scope {
     override val state: StateFlow<QuicConnectionState> = driver.state
 
+    private val datagramAdapter = DriverDatagramAdapter(driver, bufferFactory)
+
     fun start() {
         driver.start(scope)
     }
@@ -256,6 +259,14 @@ private class LinuxQuicConnection(
     override suspend fun acceptStream(): QuicByteStream = driver.incomingStreams.receive()
 
     override fun streams(): Flow<QuicByteStream> = driver.incomingStreams.consumeAsFlow()
+
+    override suspend fun sendDatagram(buffer: ReadBuffer) = datagramAdapter.sendDatagram(buffer)
+
+    override suspend fun receiveDatagram(): DatagramReceiveResult = datagramAdapter.receiveDatagram()
+
+    override fun datagrams(): Flow<ReadBuffer> = datagramAdapter.datagrams()
+
+    override fun maxDatagramSize(): MaxDatagramSize = datagramAdapter.maxDatagramSize()
 
     override val pathState: StateFlow<PathInfo> = driver.pathState
 
@@ -374,4 +385,10 @@ internal class LinuxQuicConfigCalls(
     override fun grease(v: Boolean) =
         com.ditchoom.socket.quic.quiche
             .quiche_config_grease(cfg, v)
+
+    override fun enableDgram(
+        recvQueueLen: Long,
+        sendQueueLen: Long,
+    ) = com.ditchoom.socket.quic.quiche
+        .quiche_config_enable_dgram(cfg, true, recvQueueLen.convert(), sendQueueLen.convert())
 }

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -3,6 +3,7 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.bufferHashCode
@@ -640,6 +641,8 @@ private class LinuxServerQuicConnection(
     CoroutineScope by connectionScope {
     override val state: StateFlow<QuicConnectionState> = driver.state
 
+    private val datagramAdapter = DriverDatagramAdapter(driver, bufferFactory)
+
     override suspend fun openStream(): QuicByteStream {
         try {
             val deferred = CompletableDeferred<StreamSlot>()
@@ -655,6 +658,14 @@ private class LinuxServerQuicConnection(
     override suspend fun acceptStream(): QuicByteStream = driver.incomingStreams.receive()
 
     override fun streams(): Flow<QuicByteStream> = driver.incomingStreams.consumeAsFlow()
+
+    override suspend fun sendDatagram(buffer: ReadBuffer) = datagramAdapter.sendDatagram(buffer)
+
+    override suspend fun receiveDatagram(): DatagramReceiveResult = datagramAdapter.receiveDatagram()
+
+    override fun datagrams(): Flow<ReadBuffer> = datagramAdapter.datagrams()
+
+    override fun maxDatagramSize(): MaxDatagramSize = datagramAdapter.maxDatagramSize()
 
     override suspend fun close(error: QuicError) {
         try {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -3,9 +3,9 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
-import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.bufferHashCode
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.managed

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicDatagramTests.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/LinuxQuicDatagramTests.kt
@@ -1,0 +1,25 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import platform.posix.F_OK
+import platform.posix.access
+
+/** Linux K/Native member of [QuicDatagramTestSuite]. cinterop is fixed at compile time — no skip needed. */
+class LinuxQuicDatagramTests : QuicDatagramTestSuite() {
+    private fun certPath(name: String): String {
+        val candidates =
+            listOf(
+                "testcerts/$name",
+                "socket-quic/testcerts/$name",
+            )
+        return candidates.firstOrNull { access(it, F_OK) == 0 }
+            ?: error("Test cert not found: $name (tried $candidates)")
+    }
+
+    override fun testTlsConfig() =
+        QuicTlsConfig(
+            certChainPath = certPath("cert.crt"),
+            privKeyPath = certPath("cert.key"),
+        )
+}


### PR DESCRIPTION
## WebTransport Phase 0

Adds **QUIC DATAGRAM frame support (RFC 9221)** on the quiche-backed targets (JVM JNI+FFM, Android, Linux-native) plus a centralized Linux **dev-container**. First step of the WebTransport roadmap (Phase 1 = HTTP/3 + QPACK codec).

### Public API (`QuicScope`)
Sealed/value types throughout — no nullable/primitive sentinels:
- `suspend fun sendDatagram(buffer: ReadBuffer)` — zero-copy, caller-owned, backpressure-aware
- `suspend fun receiveDatagram(): DatagramReceiveResult` → `Received(buffer)` | `ConnectionClosed(error)`
- `fun datagrams(): Flow<ReadBuffer>` — parity with `streams()`
- `fun maxDatagramSize(): MaxDatagramSize` → `Bytes(n)` | `Unavailable`
- Enabled via `QuicOptions.datagrams: DatagramOptions?` (null = off, the default — fully backward compatible)

### Internals
- `QuicheApi` gains `configEnableDgram` / `connDgramSend` / `connDgramRecv` / `hasReadableDgram` / `connDgramMaxWritableLen`, implemented across **JNI** (`quiche_jni.c` + `JniQuicheApi`), **FFM**, and **K/N cinterop**; enabled through the shared `QuicConfigApplicator`.
- `DgramSend`/`DgramRecv` driver commands; `QuicheDriver` caches `MaxDatagramSize` and tickles conflated readiness/writable signals each `afterCommand`.
- `DriverDatagramAdapter` reuses `DriverStreamAdapter`'s buffer-ownership + `NonCancellable` in-flight-join lifetime guard, so any `BufferFactory` (including pools) works transparently — receive transfers ownership to the caller; send is caller-owned/read-only.

### Tests
- **Deterministic** adapter tests (`QuicDatagramAdapterTests`, `StubQuicheApi`) — control flow, backpressure parking, close handling, buffer-ownership leak check. Run on every platform, no native lib.
- **Real encrypted loopback round-trip** suite (`QuicDatagramTestSuite`) with JVM, Linux, and Android subclasses.

Validated locally: 7 adapter + 3 JVM-FFM round-trip tests green; existing driver/leak/options suites green; JNI C compiles; `macosArm64` + Android instrumented test compile clean; ktlint clean.

### CI coverage of native paths
- **Linux-native**: `LinuxQuicDatagramTests` runs under `:socket-quic:linuxX64Test` (already in `build-linux.yaml`).
- **Android**: `AndroidQuicDatagramTests` (in-process loopback) runs under `:socket-quic:connectedAndroidTest` (`android_integration.yaml`), exercising the cargo-ndk JNI datagram bindings.
- **JVM**: JNI shim rebuilds automatically (cache key hashes `quiche_jni.c`); FFM validated locally.

### Apple — deferred to #109
Network.framework models datagrams as a dedicated single *datagram flow* (`nw_quic_set_stream_is_datagram`, macOS 13 / iOS 16) requiring an `nw_connection_group` restructure of the single-`nw_connection_t` Apple impl; its `withQuicServer` is also still `TODO()`, so there's no in-process round-trip to validate. Apple inherits the throwing/`Unavailable` `QuicScope` defaults (compiles clean).

### dev-container
`.devcontainer/` (Dockerfile + devcontainer.json + README) reproduces the `build-linux.yaml` toolchain (JDK 17+21, Rust + cross targets, cargo-ndk, Android SDK/NDK, build deps, liburing) as a single source of truth. Runs via Apple `container` (native arm64) or Docker/Codespaces. **CI workflows unchanged.** Caveat documented: Android NDK host tools are x86_64-only, so Android JNI needs an amd64 image.