### PR TITLE
feat(quic): Apple QUIC datagrams via Network.framework multiplex group

### DIFF
--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -538,6 +538,14 @@ tasks.register<Copy>("stageQuicheNativeResources") {
         }
     }
 
+    // Single-arch (default) path: this Copy reads each JNI shim's output dir
+    // (libs/quiche/<platform>/lib), so it must declare a dependency on the
+    // host-arch shim build — `prepareQuicheNativeLib` builds exactly that.
+    // Without it, Gradle flags an undeclared task-output dependency and fails
+    // validation on local non-allArches runs (CI always sets quicEchoAllArches,
+    // whose branch below already declares the deps, so CI never hit this).
+    dependsOn("prepareQuicheNativeLib")
+
     // Multi-arch path: depend on both x64 + arm64 JNI shim builds so the
     // staged dir has natives for both arches by the time `Copy` runs. We
     // attach to `stageQuicheNativeResources` rather than `quicEchoJar`

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -13,8 +13,15 @@ import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.ConnectionOptions
 import com.ditchoom.socket.SocketClosedException
 import com.ditchoom.socket.SocketConnectionException
-import com.ditchoom.socket.quic.nwhelpers.nw_helper_create_quic_connection
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_create_quic_group
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_cancel
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_datagram_send
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_cancel
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_extract_datagram_flow
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_extract_stream
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_set_state_handler
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_start
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_max_datagram_size
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_receive
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_send
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_set_state_handler
@@ -27,6 +34,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
@@ -34,6 +43,7 @@ import platform.Foundation.NSData
 import platform.Foundation.NSDataBase64DecodingIgnoreUnknownCharacters
 import platform.Foundation.NSNumber
 import platform.Foundation.create
+import platform.Network.nw_connection_group_t
 import platform.Network.nw_connection_t
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.resume
@@ -58,80 +68,156 @@ actual suspend fun <R> withQuicConnection(
     block: suspend QuicScope.() -> R,
 ): R =
     withTimeout(timeout) {
-        // Build ALPN array — pass as List which K/N bridges to NSArray
-        val alpnList: List<Any?> = quicOptions.alpnProtocols
-
-        // Pinned-CA trust anchors (issue #81): PEM → DER NSData, bridged to
-        // NSArray<NSData *>. Empty → null so the native helper keeps NW's default
-        // system trust. See nw_quic_helpers.h for the verify_block.
-        val caDerList: List<NSData>? =
-            quicOptions.trustedCaCertificatesPem
-                .flatMap { pemToDerCertificates(it) }
-                .ifEmpty { null }
-
-        val nwConn =
-            nw_helper_create_quic_connection(
-                hostname,
-                port.toUShort(),
-                alpnList,
-                NSNumber(bool = quicOptions.verifyPeer),
-                caDerList,
-                quicOptions.idleTimeout.inWholeSeconds.toInt(),
-                timeout.inWholeSeconds.toInt(),
-            ) ?: throw SocketConnectionException.Refused(hostname, port, platformError = "Failed to create QUIC connection")
-
-        // Wait for handshake completion
-        suspendCancellableCoroutine { cont ->
-            nw_helper_quic_set_state_handler(nwConn) { state, _, errorCode, errorDesc ->
-                when (state) {
-                    3 -> { // ready
-                        if (cont.isActive) cont.resume(Unit)
-                    }
-                    4 -> { // failed
-                        if (cont.isActive) {
-                            cont.resumeWithException(
-                                SocketConnectionException.Refused(
-                                    hostname,
-                                    port,
-                                    platformError = "QUIC handshake failed: code=$errorCode ${errorDesc ?: ""}",
-                                ),
-                            )
-                        }
-                    }
-                    5 -> { // cancelled
-                        if (cont.isActive) {
-                            cont.resumeWithException(
-                                SocketClosedException.General("QUIC connection cancelled"),
-                            )
-                        }
-                    }
-                    else -> {} // waiting=1, preparing=2 — in progress
-                }
-            }
-
-            nw_helper_quic_start(nwConn)
-
-            cont.invokeOnCancellation {
-                nw_helper_quic_cancel(nwConn)
-            }
-        }
-
-        val quicConn = AppleQuicConnection(nwConn, connectionOptions.bufferFactory)
-        try {
-            quicConn.block()
-        } finally {
-            quicConn.close()
-        }
+        connectQuicGroup(hostname, port, quicOptions, connectionOptions, timeout, block)
     }
 
 /**
- * Apple QUIC connection wrapping an NWConnection.
+ * The single Apple QUIC connect path, over a multiplex [nw_connection_group_t].
  *
- * Network.framework handles QUIC multiplexing internally — the same
- * NWConnection API used for TCP works identically for QUIC.
+ * Issue #109 migrated the former single-[nw_connection_t] path onto the group so one
+ * QUIC connection can carry real per-stream flows AND — when [QuicOptions.datagrams] is
+ * set — a dedicated datagram flow (RFC 9221), which Network.framework models as a
+ * separate flow rather than on the byte-stream path.
+ *
+ *  1. Create the group (advertising `max_datagram_frame_size` only when datagrams are
+ *     enabled) and await group `ready` — the QUIC handshake, including the #81
+ *     CA-pinning verify_block.
+ *  2. When datagrams are enabled, extract the one datagram flow (macOS 13 / iOS 16) and
+ *     await its `ready` so [nw_helper_quic_max_datagram_size] reflects the negotiated
+ *     path MTU before the user's block runs. Otherwise no datagram flow is extracted and
+ *     the connection reports datagrams as [MaxDatagramSize.Unavailable].
+ *  3. Hand a [AppleQuicGroupConnection] to [block]; streams are extracted lazily.
  */
-private class AppleQuicConnection(
-    private val nwConn: nw_connection_t,
+private suspend fun <R> connectQuicGroup(
+    hostname: String,
+    port: Int,
+    quicOptions: QuicOptions,
+    connectionOptions: ConnectionOptions,
+    timeout: Duration,
+    block: suspend QuicScope.() -> R,
+): R {
+    // Build ALPN array — pass as List which K/N bridges to NSArray.
+    val alpnList: List<Any?> = quicOptions.alpnProtocols
+
+    // Pinned-CA trust anchors (issue #81): PEM → DER NSData, bridged to NSArray<NSData *>.
+    // Empty → null so the native helper keeps NW's default system trust. See
+    // nw_quic_helpers.h for the verify_block.
+    val caDerList: List<NSData>? =
+        quicOptions.trustedCaCertificatesPem
+            .flatMap { pemToDerCertificates(it) }
+            .ifEmpty { null }
+
+    val datagramsEnabled = quicOptions.datagrams != null
+    val maxFrameSize: UShort = if (datagramsEnabled) DATAGRAM_FRAME_SIZE_MAX else 0u
+
+    val group =
+        nw_helper_create_quic_group(
+            hostname,
+            port.toUShort(),
+            alpnList,
+            NSNumber(bool = quicOptions.verifyPeer),
+            caDerList,
+            quicOptions.idleTimeout.inWholeSeconds.toInt(),
+            timeout.inWholeSeconds.toInt(),
+            maxFrameSize,
+        ) ?: throw SocketConnectionException.Refused(hostname, port, platformError = "Failed to create QUIC connection group")
+
+    // Wait for the group (QUIC handshake) to become ready. Group states: 2=ready, 3=failed, 4=cancelled.
+    suspendCancellableCoroutine { cont ->
+        nw_helper_quic_group_set_state_handler(group) { state, _, errorCode, errorDesc ->
+            when (state) {
+                2 -> if (cont.isActive) cont.resume(Unit)
+                3 ->
+                    if (cont.isActive) {
+                        cont.resumeWithException(
+                            SocketConnectionException.Refused(
+                                hostname,
+                                port,
+                                platformError = "QUIC group handshake failed: code=$errorCode ${errorDesc ?: ""}",
+                            ),
+                        )
+                    }
+                4 -> if (cont.isActive) cont.resumeWithException(SocketClosedException.General("QUIC group cancelled"))
+                else -> {} // invalid=0, waiting=1 — in progress
+            }
+        }
+        nw_helper_quic_group_start(group)
+        cont.invokeOnCancellation { nw_helper_quic_group_cancel(group) }
+    }
+
+    // Extract THE datagram flow (one per connection) only when datagrams are enabled.
+    val datagramFlow: nw_connection_t? =
+        if (!datagramsEnabled) {
+            null
+        } else {
+            // NULL below macOS 13 / iOS 16 — the only place the datagram feature is gated.
+            val flow =
+                nw_helper_quic_group_extract_datagram_flow(group, DATAGRAM_FRAME_SIZE_MAX)
+                    ?: run {
+                        nw_helper_quic_group_cancel(group)
+                        throw SocketConnectionException.Refused(
+                            hostname,
+                            port,
+                            platformError = "QUIC datagrams require macOS 13 / iOS 16",
+                        )
+                    }
+
+            // Await the flow's readiness so its maximum datagram size is known before the
+            // block runs. Connection states: 3=ready, 4=failed, 5=cancelled.
+            suspendCancellableCoroutine { cont ->
+                nw_helper_quic_set_state_handler(flow) { state, _, errorCode, errorDesc ->
+                    when (state) {
+                        3 -> if (cont.isActive) cont.resume(Unit)
+                        4 ->
+                            if (cont.isActive) {
+                                cont.resumeWithException(
+                                    SocketConnectionException.Refused(
+                                        hostname,
+                                        port,
+                                        platformError = "QUIC datagram flow failed: code=$errorCode ${errorDesc ?: ""}",
+                                    ),
+                                )
+                            }
+                        5 -> if (cont.isActive) cont.resumeWithException(SocketClosedException.General("QUIC datagram flow cancelled"))
+                        else -> {}
+                    }
+                }
+                nw_helper_quic_start(flow)
+                cont.invokeOnCancellation { nw_helper_quic_cancel(flow) }
+            }
+            flow
+        }
+
+    val quicConn = AppleQuicGroupConnection(group, datagramFlow, connectionOptions.bufferFactory)
+    return try {
+        quicConn.block()
+    } finally {
+        quicConn.close()
+    }
+}
+
+/**
+ * Advertised `max_datagram_frame_size` (RFC 9221) — the largest a single DATAGRAM
+ * frame may be. We advertise the 16-bit maximum; the *usable* per-datagram size is
+ * the smaller path-MTU value reported live by [QuicScope.maxDatagramSize].
+ */
+private const val DATAGRAM_FRAME_SIZE_MAX: UShort = 65535u
+
+/**
+ * The Apple QUIC connection — a multiplex [nw_connection_group_t] (issue #109).
+ *
+ * Each [openStream] extracts a REAL distinct QUIC stream from the group. [datagramFlow]
+ * is the dedicated RFC 9221 datagram flow extracted at establish, or null when
+ * [QuicOptions.datagrams] was not set — in which case the datagram surface reports
+ * [MaxDatagramSize.Unavailable] and the send/receive methods throw, matching the
+ * [QuicScope] defaults a non-datagram connection should present.
+ *
+ * Remaining seam (follow-up): wire `acceptStream`/peer-initiated streams via the group's
+ * new-connection handler — today [acceptStream] just suspends until the connection closes.
+ */
+private class AppleQuicGroupConnection(
+    private val group: nw_connection_group_t,
+    private val datagramFlow: nw_connection_t?,
     private val bufferFactory: BufferFactory,
     private val scope: CoroutineScope = CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default),
 ) : QuicConnection,
@@ -146,29 +232,123 @@ private class AppleQuicConnection(
     private var closed = false
 
     override suspend fun openStream(): QuicByteStream {
-        check(!closed) { "AppleQuicConnection is closed" }
+        check(!closed) { "AppleQuicGroupConnection is closed" }
         check(_state.value is QuicConnectionState.Established) {
             "Cannot open stream in state ${_state.value}"
         }
+        val streamConn =
+            nw_helper_quic_group_extract_stream(group)
+                ?: throw SocketClosedException.General("Failed to open QUIC stream")
+        nw_helper_quic_start(streamConn)
         val streamId = QuicStreamId(nextClientStreamId.getAndAdd(4))
-        return QuicByteStream(streamId, NWQuicByteStream(nwConn))
+        return QuicByteStream(streamId, NWQuicByteStream(streamConn))
     }
 
     override suspend fun acceptStream(): QuicByteStream {
-        check(!closed) { "AppleQuicConnection is closed" }
+        check(!closed) { "AppleQuicGroupConnection is closed" }
+        // Peer-initiated streams (group new-connection handler) are not wired yet; see
+        // the class docstring. Suspends until the connection closes.
         return incomingStreams.receive()
     }
 
     override fun streams(): Flow<QuicByteStream> = incomingStreams.consumeAsFlow()
 
+    // --- Unreliable datagrams (RFC 9221) ---
+    // Mirrors the quiche-backed DriverDatagramAdapter contract: size-check against the
+    // live max, caller retains ownership on send, ownership transfers to caller on receive.
+
+    override suspend fun sendDatagram(buffer: ReadBuffer) {
+        if (closed) throw QuicCloseException(closeReason(), "connection closed")
+        val flow =
+            datagramFlow
+                ?: throw IllegalStateException("QUIC datagrams are not enabled, or the peer did not advertise support")
+        val remaining = buffer.remaining()
+        when (val max = maxDatagramSize()) {
+            is MaxDatagramSize.Unavailable ->
+                throw IllegalStateException("QUIC datagrams are not enabled, or the peer did not advertise support")
+            is MaxDatagramSize.Bytes ->
+                require(remaining <= max.bytes) { "datagram too large: $remaining > ${max.bytes} bytes" }
+        }
+
+        // dispatch_data_create (in the helper) copies the bytes synchronously, so the
+        // caller may free `buffer` the instant we return; we still suspend until the
+        // send-complete callback to surface errors and provide backpressure.
+        val nsData = buffer.toNSData()
+        suspendCancellableCoroutine { cont ->
+            nw_helper_quic_datagram_send(flow, nsData) { _, errorCode, errorDesc ->
+                if (errorCode != 0) {
+                    if (cont.isActive) {
+                        cont.resumeWithException(
+                            QuicCloseException(
+                                closeReason(QuicError.InternalError("datagram send error: $errorCode")),
+                                "QUIC datagram send error: $errorCode ${errorDesc ?: ""}",
+                            ),
+                        )
+                    }
+                } else {
+                    if (cont.isActive) cont.resume(Unit)
+                }
+            }
+        }
+    }
+
+    override suspend fun receiveDatagram(): DatagramReceiveResult {
+        val flow =
+            datagramFlow
+                ?: throw UnsupportedOperationException("QUIC datagrams are not enabled on this connection")
+        if (closed) return DatagramReceiveResult.ConnectionClosed(closeReason())
+        return suspendCancellableCoroutine { cont ->
+            // One datagram per receive — the datagram flow delivers each as a complete
+            // message (is_complete=true). Zero-copy: wrap the NSData, flip to read mode.
+            nw_helper_quic_receive(flow, 1u, DATAGRAM_FRAME_SIZE_MAX.convert()) { data, _, _, errorCode, _ ->
+                when {
+                    data != null && data.length.toInt() > 0 -> {
+                        val buf = NSDataBuffer(data, ByteOrder.BIG_ENDIAN)
+                        buf.position(data.length.toInt())
+                        buf.resetForRead()
+                        if (cont.isActive) cont.resume(DatagramReceiveResult.Received(buf))
+                    }
+                    // No data (flow ended / min_length unmet) or an error → the flow is gone.
+                    // NB: a zero-length datagram (valid per RFC 9221) lands here too — an
+                    // accepted limitation of the NW datagram-flow receive boundary.
+                    else -> if (cont.isActive) cont.resume(DatagramReceiveResult.ConnectionClosed(closeReason()))
+                }
+            }
+        }
+    }
+
+    override fun datagrams(): Flow<ReadBuffer> {
+        if (datagramFlow == null) return emptyFlow()
+        return flow {
+            while (true) {
+                when (val result = receiveDatagram()) {
+                    is DatagramReceiveResult.Received -> emit(result.buffer)
+                    is DatagramReceiveResult.ConnectionClosed -> return@flow
+                }
+            }
+        }
+    }
+
+    override fun maxDatagramSize(): MaxDatagramSize {
+        if (closed) return MaxDatagramSize.Unavailable
+        val flow = datagramFlow ?: return MaxDatagramSize.Unavailable
+        val bytes = nw_helper_quic_max_datagram_size(flow).toInt()
+        return if (bytes > 0) MaxDatagramSize.Bytes(bytes) else MaxDatagramSize.Unavailable
+    }
+
     override suspend fun close(error: QuicError) {
         if (closed) return
         closed = true
         _state.value = QuicConnectionState.Draining
-        nw_helper_quic_cancel(nwConn)
+        datagramFlow?.let { nw_helper_quic_cancel(it) }
+        nw_helper_quic_group_cancel(group)
         incomingStreams.close()
         _state.value = QuicConnectionState.Closed(error)
     }
+
+    /** The structured close reason if known, else [fallback]. */
+    private fun closeReason(fallback: QuicError = QuicError.NoError): QuicError =
+        (_state.value as? QuicConnectionState.Closed)?.error ?: fallback
 }
 
 /**

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -221,6 +222,67 @@ class QuicHarnessIntegrationTests {
                         result.buffer.freeIfNeeded()
                     }
                     stream.close()
+                }
+            }
+        }
+
+    // --- Unreliable datagrams (RFC 9221, issue #109) ---
+
+    /**
+     * Same connect-or-skip contract as [withHarness], but with datagrams enabled
+     * (`DatagramOptions`), which routes Apple onto the multiplex-group + datagram-flow
+     * path. The harness peer ([QuicEchoTestServer]) echoes datagrams, so this is the
+     * real round-trip that validates the Apple datagram surface end-to-end on the
+     * macOS host (and, in CI's booted mode, the iOS simulator).
+     */
+    private suspend fun withHarnessDatagrams(block: suspend QuicScope.() -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) {
+            println("[QuicHarnessIntegrationTests] harness SKIP: Apple simulator under --standalone (issue #81)")
+            return
+        }
+        try {
+            withQuicConnection(
+                harnessHost,
+                QuicHarnessConfig.quicEchoPort,
+                quicOptions.copy(datagrams = DatagramOptions()),
+                connOptions,
+                connectTimeout,
+                block,
+            )
+            println("[QuicHarnessIntegrationTests] harness OK")
+        } catch (t: Throwable) {
+            println("[QuicHarnessIntegrationTests] harness SKIP: ${t::class.simpleName}: ${t.message}")
+        }
+    }
+
+    /**
+     * Round-trips one unreliable datagram through the echo peer. Loopback with no
+     * impairment doesn't drop a single datagram, so the echo assertion is
+     * deterministic (same rationale as [QuicDatagramTestSuite]).
+     */
+    @Test
+    fun harness_datagram_roundTrip() =
+        runTest(timeout = 60.seconds) {
+            withContext(Dispatchers.Default) {
+                withHarnessDatagrams {
+                    assertIs<MaxDatagramSize.Bytes>(maxDatagramSize(), "datagrams should be sendable")
+
+                    val payload = "hello dgram"
+                    bufferFactory.allocate(payload.length).use { buf ->
+                        buf.writeString(payload, Charset.UTF8)
+                        buf.resetForRead()
+                        sendDatagram(buf)
+                    }
+
+                    when (val r = withTimeoutOrNull(opTimeout) { receiveDatagram() }) {
+                        is DatagramReceiveResult.Received -> {
+                            assertEquals(payload, r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+                            r.buffer.freeIfNeeded()
+                        }
+                        is DatagramReceiveResult.ConnectionClosed ->
+                            throw AssertionError("connection closed before datagram echo")
+                        null -> throw AssertionError("datagram echo timed out")
+                    }
                 }
             }
         }

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicEchoTestServer.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicEchoTestServer.kt
@@ -1,7 +1,9 @@
 package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
@@ -34,6 +36,10 @@ fun main(args: Array<String>) {
             alpnProtocols = listOf("test"),
             verifyPeer = false,
             idleTimeout = 30.seconds,
+            // Advertise RFC 9221 DATAGRAM support so datagram-enabled clients (incl.
+            // the Apple group path, issue #109) can round-trip. Stream-only clients
+            // are unaffected — this only advertises the transport parameter.
+            datagrams = DatagramOptions(),
         )
     val tlsConfig = QuicTlsConfig(certChainPath = certPath, privKeyPath = keyPath)
 
@@ -45,26 +51,53 @@ fun main(args: Array<String>) {
 
             // Accept connections — each runs in its own coroutine scope
             connections {
-                try {
-                    // acceptStream has a timeout so health-check connections
-                    // (that connect but never open a stream) don't block the server
-                    val stream = withTimeout(3.seconds) { acceptStream() }
-                    try {
-                        while (true) {
-                            val data = stream.read(30.seconds)
-                            if (data is ReadResult.Data) {
-                                stream.write(data.buffer, 10.seconds)
-                            } else {
-                                break
+                // Streams and datagrams are echoed by independent child jobs: a
+                // datagram-only client (e.g. the Apple group path, issue #109) never
+                // opens a stream, and a stream client never sends datagrams. The
+                // connection is held open until the PEER goes away (the datagram loop
+                // observes ConnectionClosed), so a datagram client isn't cut off by the
+                // stream-accept timeout — and per-connection scopes mean one lingering
+                // connection never blocks the server's accept loop.
+                val datagramJob =
+                    launch {
+                        try {
+                            while (true) {
+                                when (val r = receiveDatagram()) {
+                                    is DatagramReceiveResult.Received -> {
+                                        sendDatagram(r.buffer) // reads zero-copy; we still own it
+                                        r.buffer.freeIfNeeded()
+                                    }
+                                    is DatagramReceiveResult.ConnectionClosed -> break
+                                }
                             }
+                        } catch (_: Exception) {
                         }
-                    } catch (_: Exception) {
-                    } finally {
-                        stream.close()
                     }
-                } catch (_: Exception) {
-                    // Health-check connection with no stream — just let it close
-                }
+                val streamJob =
+                    launch {
+                        try {
+                            // acceptStream has a timeout so a datagram-only / health-check
+                            // connection doesn't keep this job parked forever.
+                            val stream = withTimeout(3.seconds) { acceptStream() }
+                            try {
+                                while (true) {
+                                    val data = stream.read(30.seconds)
+                                    if (data is ReadResult.Data) {
+                                        stream.write(data.buffer, 10.seconds)
+                                    } else {
+                                        break
+                                    }
+                                }
+                            } catch (_: Exception) {
+                            } finally {
+                                stream.close()
+                            }
+                        } catch (_: Exception) {
+                            // No stream opened (datagram-only or health-check) — fine.
+                        }
+                    }
+                datagramJob.join()
+                streamJob.cancel()
             }
         }
     }

--- a/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
+++ b/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
@@ -14,167 +14,6 @@
 #import <Security/Security.h>
 #import <dispatch/dispatch.h>
 
-#pragma mark - QUIC Connection Creation
-
-/**
- * Create a QUIC connection.
- * Uses nw_parameters_create_quic() with TLS 1.3 (mandatory for QUIC).
- *
- * The QUIC options block above takes the QUIC protocol options object;
- * ALPN must be set via nw_quic_copy_sec_protocol_options (NOT the generic
- * nw_tls_copy_*, which on a QUIC options object produced the handshake-start
- * SIGTRAP fixed in PR #60).
- *
- * Certificate verification (issue #81):
- *   - **trusted_ca_ders non-empty** → install a verify_block that evaluates the
- *     peer chain against the supplied DER-encoded CAs as the SOLE trust anchors
- *     (`SecTrustSetAnchorCertificatesOnly`), via `SecTrustEvaluateWithError`.
- *     Network.framework's own SSL policy (hostname + serverAuth EKU) is kept,
- *     so the hostname must still match a SAN. Pinning to custom anchors is
- *     CT-exempt, so a private-CA / non-CT-logged harness leaf is accepted
- *     without the errSSLBadCert (-9808) the default QUIC trust path returns.
- *     This is real chain validation — NOT an always-accept bypass — and it is
- *     what lets `QuicHarnessIntegrationTests` run (not skip) on Apple K/N.
- *   - **trusted_ca_ders nil/empty** → no verify_block; Network.framework's
- *     default system trust evaluation runs (keychain anchors, hostname check).
- *     This is the production path for real, CT-logged server certs.
- *
- * The verify_block MUST be attached to the QUIC sec_protocol_options obtained
- * via nw_quic_copy_sec_protocol_options (NOT the generic nw_tls_copy_*). PR #54
- * attached its verify_block to nw_tls_copy_sec_protocol_options applied to a
- * QUIC options object — the same wrong-accessor defect PR #60 fixed for ALPN —
- * which is what actually SIGABRT'd, not "macOS TLS hardening" as first believed.
- *
- * @param host Hostname to connect to
- * @param port Port number
- * @param alpn_protocols NSArray of NSString ALPN identifiers (mandatory for QUIC)
- * @param verify_certs Reserved for parity with the quiche path; when
- *                     trusted_ca_ders is empty, NW default trust always runs.
- * @param trusted_ca_ders NSArray of DER-encoded CA certs (NSData) to pin as the
- *                        sole anchors, or nil/empty to use NW's default trust.
- * @param idle_timeout_seconds QUIC idle timeout (0 = no timeout)
- * @param connection_timeout_seconds TCP-level connection timeout
- * @return nw_connection_t or NULL on parameter error
- */
-static inline nw_connection_t _Nullable nw_helper_create_quic_connection(
-    const char * _Nonnull host,
-    uint16_t port,
-    NSArray<NSString *> * _Nonnull alpn_protocols,
-    NSNumber * _Nonnull verify_certs,
-    NSArray<NSData *> * _Nullable trusted_ca_ders,
-    int32_t idle_timeout_seconds,
-    int32_t connection_timeout_seconds)
-{
-    if (alpn_protocols.count == 0) return NULL;
-
-    char port_str[6];
-    snprintf(port_str, sizeof(port_str), "%u", port);
-
-    nw_endpoint_t endpoint = nw_endpoint_create_host(host, port_str);
-    if (!endpoint) return NULL;
-
-    // Retain an independent copy of the ALPN list so the async configure block
-    // below (run during nw_connection_start) never iterates a K/N-bridged
-    // NSArray proxy that may have been released by then (H3).
-    NSArray<NSString *> *alpn_copy = [alpn_protocols copy];
-
-    (void)verify_certs; // see docstring — meaningful switch is trusted_ca_ders
-
-    // Block-captured retained copy: the verify_block runs asynchronously during
-    // the handshake, so the DER bytes must outlive this function. Block-capture
-    // retains the array (and its elements) when the block is copied to the heap,
-    // independent of the K/N-bridged original (same H3 guard as alpn_copy above).
-    NSArray<NSData *> * _Nullable pinned_ca_ders =
-        (trusted_ca_ders.count > 0) ? [trusted_ca_ders copy] : nil;
-
-    // Create QUIC parameters. The block configures the QUIC protocol options;
-    // ALPN and any verify_block come from the QUIC-specific sec_protocol_options
-    // accessor (nw_quic_copy_sec_protocol_options) — NOT the generic TLS one.
-    // Attaching to nw_tls_copy_sec_protocol_options on a QUIC options object is
-    // the wrong-accessor defect behind both the PR #60 ALPN SIGTRAP and the
-    // PR #54 verify_block SIGABRT (see docstring).
-    nw_parameters_t params = nw_parameters_create_quic(
-        ^(nw_protocol_options_t _Nonnull quic_options) {
-            sec_protocol_options_t sec_options = nw_quic_copy_sec_protocol_options(quic_options);
-
-            for (NSString *proto in alpn_copy) {
-                sec_protocol_options_add_tls_application_protocol(sec_options, proto.UTF8String);
-            }
-
-            // CA-pinning verify_block (issue #81). Only installed when CAs are
-            // supplied; the production default (nil) keeps NW's default system
-            // trust. The block does REAL chain validation against the pinned CAs
-            // as the sole anchors — pinning makes the chain CT-exempt, which is
-            // what clears the -9808 the default QUIC trust path returns for the
-            // private-CA harness leaf. Delivered on a dedicated serial queue;
-            // the block is pure C / Security-framework and captures no K/N state.
-            if (pinned_ca_ders != nil) {
-                static dispatch_queue_t verify_queue;
-                static dispatch_once_t verify_queue_once;
-                dispatch_once(&verify_queue_once, ^{
-                    verify_queue = dispatch_queue_create("com.ditchoom.socket.quic.verify", DISPATCH_QUEUE_SERIAL);
-                });
-                sec_protocol_options_set_verify_block(sec_options,
-                    ^(sec_protocol_metadata_t metadata, sec_trust_t sec_trust, sec_protocol_verify_complete_t complete) {
-                        (void)metadata;
-                        // sec_trust_t free-bridges to SecTrustRef (Network/Security
-                        // toll-free types, per WWDC 2018 "Network Framework").
-                        SecTrustRef trust_ref = sec_trust_copy_ref(sec_trust);
-                        if (!trust_ref) { complete(false); return; }
-
-                        // Build the anchor set from every supplied CA DER.
-                        CFMutableArrayRef anchors =
-                            CFArrayCreateMutable(kCFAllocatorDefault, pinned_ca_ders.count, &kCFTypeArrayCallBacks);
-                        for (NSData *der in pinned_ca_ders) {
-                            SecCertificateRef ca_cert = SecCertificateCreateWithData(
-                                kCFAllocatorDefault, (__bridge CFDataRef)der);
-                            if (ca_cert) {
-                                CFArrayAppendValue(anchors, ca_cert);
-                                CFRelease(ca_cert);
-                            }
-                        }
-                        if (CFArrayGetCount(anchors) == 0) {
-                            CFRelease(anchors);
-                            CFRelease(trust_ref);
-                            complete(false);
-                            return;
-                        }
-
-                        // Pin: our CAs are the SOLE acceptable anchors. We do NOT
-                        // replace NW's policies, so the hostname/serverAuth SSL
-                        // policy it configured still applies (the leaf SAN must
-                        // match the connect host).
-                        SecTrustSetAnchorCertificates(trust_ref, anchors);
-                        SecTrustSetAnchorCertificatesOnly(trust_ref, true);
-
-                        // Offline evaluation: a pinned private CA has no CT log,
-                        // OCSP/CRL responder, or intermediates to fetch, so disable
-                        // network fetch — the evaluation is fully local and
-                        // deterministic (and can't stall on trustd network I/O).
-                        SecTrustSetNetworkFetchAllowed(trust_ref, false);
-
-                        CFErrorRef error = NULL;
-                        bool valid = SecTrustEvaluateWithError(trust_ref, &error);
-                        if (error) CFRelease(error);
-
-                        CFRelease(anchors);
-                        CFRelease(trust_ref);
-
-                        complete(valid);
-                    },
-                    verify_queue);
-            }
-        });
-
-    if (!params) return NULL;
-
-    // Note: QUIC idle timeout is managed by Network.framework internally.
-    // The idle_timeout_seconds parameter is reserved for future use.
-
-    nw_connection_t connection = nw_connection_create(endpoint, params);
-    return connection;
-}
-
 #pragma mark - QUIC State Handler
 
 typedef void (^quic_state_handler_t)(
@@ -348,4 +187,302 @@ static inline void nw_helper_quic_cancel(nw_connection_t _Nonnull connection) {
 
 static inline void nw_helper_quic_force_cancel(nw_connection_t _Nonnull connection) {
     nw_connection_force_cancel(connection);
+}
+
+#pragma mark - QUIC Multiplex Group (streams + datagram flow) — RFC 9221 (issue #109)
+
+/**
+ * Create the *multiplex* QUIC connection group — THE Apple QUIC creator (issue #109
+ * migrated the former single-nw_connection path onto this).
+ *
+ * Network.framework models a single nw_connection created via nw_parameters_create_quic
+ * as ONE QUIC flow — a flow is EITHER a stream OR the datagram flow
+ * (nw_quic_set_stream_is_datagram), never both. To carry real multiple streams AND a
+ * datagram flow over ONE QUIC connection you must create a multiplex group and extract
+ * each flow from it (nw_helper_quic_group_extract_stream /
+ * nw_helper_quic_group_extract_datagram_flow).
+ *
+ * **#81 hardening baked in here** (the verify_block below):
+ *  - ALPN and the verify_block MUST be configured via the QUIC accessor
+ *    nw_quic_copy_sec_protocol_options — NOT the generic nw_tls_copy_* on a QUIC options
+ *    object, which is the wrong-accessor defect behind the PR #60 ALPN SIGTRAP and the
+ *    PR #54 verify_block SIGABRT.
+ *  - verify_certs is reserved (NW always evaluates the peer cert); the meaningful switch
+ *    is trusted_ca_ders. When non-empty, a verify_block pins those DER CAs as the SOLE
+ *    anchors (SecTrustSetAnchorCertificatesOnly) — a pinned anchor is CT-exempt, which
+ *    clears the errSSLBadCert (-9808) the default QUIC trust path returns for a private-CA
+ *    leaf. When nil, NW's default system trust runs (production path).
+ *
+ * When [max_datagram_frame_size] > 0 the connection advertises the RFC 9221
+ * `max_datagram_frame_size` transport parameter (macOS 13 / iOS 16). The datagram FLOW
+ * itself is extracted later via nw_helper_quic_group_extract_datagram_flow.
+ *
+ * @param max_datagram_frame_size 0 disables DATAGRAM frames; >0 advertises support.
+ * @return nw_connection_group_t or NULL on parameter error.
+ */
+static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
+    const char * _Nonnull host,
+    uint16_t port,
+    NSArray<NSString *> * _Nonnull alpn_protocols,
+    NSNumber * _Nonnull verify_certs,
+    NSArray<NSData *> * _Nullable trusted_ca_ders,
+    int32_t idle_timeout_seconds,
+    int32_t connection_timeout_seconds,
+    uint16_t max_datagram_frame_size)
+{
+    if (alpn_protocols.count == 0) return NULL;
+
+    char port_str[6];
+    snprintf(port_str, sizeof(port_str), "%u", port);
+
+    nw_endpoint_t endpoint = nw_endpoint_create_host(host, port_str);
+    if (!endpoint) return NULL;
+
+    // Retained copies for the async configure/verify blocks: the configure block runs
+    // during connection establishment, so these must outlive this function (block-capture
+    // retains them on the heap, independent of the K/N-bridged originals — the H3 guard).
+    NSArray<NSString *> *alpn_copy = [alpn_protocols copy];
+    (void)verify_certs; // meaningful switch is trusted_ca_ders (see docstring)
+    NSArray<NSData *> * _Nullable pinned_ca_ders =
+        (trusted_ca_ders.count > 0) ? [trusted_ca_ders copy] : nil;
+
+    nw_parameters_t params = nw_parameters_create_quic(
+        ^(nw_protocol_options_t _Nonnull quic_options) {
+            sec_protocol_options_t sec_options = nw_quic_copy_sec_protocol_options(quic_options);
+
+            for (NSString *proto in alpn_copy) {
+                sec_protocol_options_add_tls_application_protocol(sec_options, proto.UTF8String);
+            }
+
+            // Enable RFC 9221 DATAGRAM frames (connection-level transport param).
+            // Gated: the setter is macOS 13 / iOS 16. Callers only pass >0 when
+            // QuicOptions.datagrams was set, and the Kotlin side already requires
+            // that OS floor before taking the group path.
+            if (max_datagram_frame_size > 0) {
+                if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
+                    nw_quic_set_max_datagram_frame_size(quic_options, max_datagram_frame_size);
+                }
+            }
+
+            // CA-pinning verify_block (issue #81 — see this function's docstring).
+            if (pinned_ca_ders != nil) {
+                static dispatch_queue_t verify_queue;
+                static dispatch_once_t verify_queue_once;
+                dispatch_once(&verify_queue_once, ^{
+                    verify_queue = dispatch_queue_create("com.ditchoom.socket.quic.verify.group", DISPATCH_QUEUE_SERIAL);
+                });
+                sec_protocol_options_set_verify_block(sec_options,
+                    ^(sec_protocol_metadata_t metadata, sec_trust_t sec_trust, sec_protocol_verify_complete_t complete) {
+                        (void)metadata;
+                        SecTrustRef trust_ref = sec_trust_copy_ref(sec_trust);
+                        if (!trust_ref) { complete(false); return; }
+
+                        CFMutableArrayRef anchors =
+                            CFArrayCreateMutable(kCFAllocatorDefault, pinned_ca_ders.count, &kCFTypeArrayCallBacks);
+                        for (NSData *der in pinned_ca_ders) {
+                            SecCertificateRef ca_cert = SecCertificateCreateWithData(
+                                kCFAllocatorDefault, (__bridge CFDataRef)der);
+                            if (ca_cert) {
+                                CFArrayAppendValue(anchors, ca_cert);
+                                CFRelease(ca_cert);
+                            }
+                        }
+                        if (CFArrayGetCount(anchors) == 0) {
+                            CFRelease(anchors);
+                            CFRelease(trust_ref);
+                            complete(false);
+                            return;
+                        }
+
+                        SecTrustSetAnchorCertificates(trust_ref, anchors);
+                        SecTrustSetAnchorCertificatesOnly(trust_ref, true);
+                        SecTrustSetNetworkFetchAllowed(trust_ref, false);
+
+                        CFErrorRef error = NULL;
+                        bool valid = SecTrustEvaluateWithError(trust_ref, &error);
+                        if (error) CFRelease(error);
+
+                        CFRelease(anchors);
+                        CFRelease(trust_ref);
+
+                        complete(valid);
+                    },
+                    verify_queue);
+            }
+        });
+
+    if (!params) return NULL;
+
+    (void)idle_timeout_seconds;       // QUIC idle timeout is managed by NW internally
+    (void)connection_timeout_seconds; // reserved for parity with the single-conn helper
+
+    nw_group_descriptor_t descriptor = nw_group_descriptor_create_multiplex(endpoint);
+    if (!descriptor) return NULL;
+
+    nw_connection_group_t group = nw_connection_group_create(descriptor, params);
+    return group;
+}
+
+/**
+ * Group state-changed handler. Mapping (NB: group states differ from connection
+ * states — there is no `preparing`):
+ *   0=invalid, 1=waiting, 2=ready, 3=failed, 4=cancelled.
+ */
+typedef void (^quic_group_state_handler_t)(
+    int32_t state,
+    int32_t error_domain,
+    int32_t error_code,
+    NSString * _Nullable error_description
+);
+
+static inline void nw_helper_quic_group_set_state_handler(
+    nw_connection_group_t _Nonnull group,
+    quic_group_state_handler_t _Nonnull handler)
+{
+    nw_connection_group_set_state_changed_handler(group,
+        ^(nw_connection_group_state_t state, nw_error_t _Nullable error) {
+            int32_t mapped_state;
+            switch (state) {
+                case nw_connection_group_state_invalid:   mapped_state = 0; break;
+                case nw_connection_group_state_waiting:   mapped_state = 1; break;
+                case nw_connection_group_state_ready:     mapped_state = 2; break;
+                case nw_connection_group_state_failed:    mapped_state = 3; break;
+                case nw_connection_group_state_cancelled: mapped_state = 4; break;
+                default: mapped_state = 0; break;
+            }
+
+            int32_t err_domain = 0;
+            int32_t err_code = 0;
+            NSString *err_desc = nil;
+            if (error) {
+                err_domain = nw_error_get_error_domain(error);
+                err_code = nw_error_get_error_code(error);
+                CFErrorRef cf_error = nw_error_copy_cf_error(error);
+                if (cf_error) {
+                    err_desc = (__bridge_transfer NSString *)CFErrorCopyDescription(cf_error);
+                    CFRelease(cf_error);
+                }
+            }
+
+            handler(mapped_state, err_domain, err_code, err_desc);
+        });
+}
+
+/**
+ * Start the group. Uses a dedicated SERIAL callback queue for the same K/N
+ * foreign-thread-safety reason as nw_helper_quic_start (one callback at a time).
+ *
+ * nw_connection_group_start requires a receive handler to be set first. A multiplex
+ * QUIC group delivers peer-initiated streams via the new-connection handler and
+ * datagrams via the extracted datagram-flow connection — never as group-level
+ * messages — so the group receive handler is a required no-op.
+ */
+static inline void nw_helper_quic_group_start(nw_connection_group_t _Nonnull group) {
+    static dispatch_queue_t group_cb_queue;
+    static dispatch_once_t group_cb_queue_once;
+    dispatch_once(&group_cb_queue_once, ^{
+        group_cb_queue = dispatch_queue_create("com.ditchoom.socket.quic.nw.group", DISPATCH_QUEUE_SERIAL);
+    });
+    nw_connection_group_set_queue(group, group_cb_queue);
+    nw_connection_group_set_receive_handler(group, 65535, false,
+        ^(dispatch_data_t _Nullable content, nw_content_context_t _Nonnull context, bool is_complete) {
+            (void)content; (void)context; (void)is_complete; // no-op: see docstring
+        });
+    nw_connection_group_start(group);
+}
+
+static inline void nw_helper_quic_group_cancel(nw_connection_group_t _Nonnull group) {
+    nw_connection_group_cancel(group);
+}
+
+/**
+ * Extract a new locally-initiated bidirectional stream flow from the group. Each
+ * call opens a REAL distinct QUIC stream (unlike the single-connection path, where
+ * every "stream" aliased the one nw_connection). The returned connection must have
+ * its queue set and be started (nw_helper_quic_start) before use.
+ */
+static inline nw_connection_t _Nullable nw_helper_quic_group_extract_stream(
+    nw_connection_group_t _Nonnull group)
+{
+    // nil protocol options → default bidirectional stream.
+    return nw_connection_group_extract_connection(group, NULL, NULL);
+}
+
+/**
+ * Extract THE datagram flow from the group. Network.framework permits exactly one
+ * QUIC datagram flow per connection. macOS 13 / iOS 16 (nw_quic_set_stream_is_datagram);
+ * returns NULL below that floor. The returned connection must be started
+ * (nw_helper_quic_start) before use; send via nw_helper_quic_datagram_send and
+ * receive via nw_helper_quic_receive.
+ */
+static inline nw_connection_t _Nullable nw_helper_quic_group_extract_datagram_flow(
+    nw_connection_group_t _Nonnull group,
+    uint16_t max_datagram_frame_size)
+{
+    if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
+        // The extract options MUST be the connection's OWN QUIC options — copied from
+        // the group's established parameters and carrying the negotiated ALPN +
+        // max_datagram_frame_size — NOT a fresh nw_quic_create_options(). Passing fresh
+        // default options to extract_connection tears the flow down immediately with
+        // ENETDOWN ("Network is down"); a bidi stream extracted with NULL options is
+        // fine, so it is specifically the fresh/empty custom options that break the
+        // flow. We copy the group's transport (QUIC) protocol options and only flip
+        // is_datagram. (Issue #109.)
+        nw_parameters_t params = nw_connection_group_copy_parameters(group);
+        if (!params) return NULL;
+        nw_protocol_stack_t stack = nw_parameters_copy_default_protocol_stack(params);
+        if (!stack) return NULL;
+        nw_protocol_options_t quic_options = nw_protocol_stack_copy_transport_protocol(stack);
+        if (!quic_options || !nw_protocol_options_is_quic(quic_options)) return NULL;
+        nw_quic_set_stream_is_datagram(quic_options, true);
+        if (max_datagram_frame_size > 0) {
+            nw_quic_set_max_datagram_frame_size(quic_options, max_datagram_frame_size);
+        }
+        return nw_connection_group_extract_connection(group, NULL, quic_options);
+    }
+    return NULL;
+}
+
+/**
+ * Send one unreliable datagram on the datagram-flow connection.
+ *
+ * Unlike nw_helper_quic_send (stream path, where is_complete=true means a
+ * FINAL_MESSAGE FIN that half-closes the flow), a datagram is one COMPLETE message
+ * on a never-closing flow: DEFAULT_MESSAGE_CONTEXT with is_complete=true emits
+ * exactly one DATAGRAM frame and keeps the flow open for the next datagram.
+ */
+static inline void nw_helper_quic_datagram_send(
+    nw_connection_t _Nonnull connection,
+    NSData * _Nonnull data,
+    quic_send_complete_t _Nonnull handler)
+{
+    dispatch_data_t dispatch_data = dispatch_data_create(
+        data.bytes, data.length, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0),
+        DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+
+    nw_connection_send(connection, dispatch_data, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true,
+        ^(nw_error_t _Nullable error) {
+            int32_t err_domain = 0;
+            int32_t err_code = 0;
+            NSString *err_desc = nil;
+            if (error) {
+                err_domain = nw_error_get_error_domain(error);
+                err_code = nw_error_get_error_code(error);
+                CFErrorRef cf_error = nw_error_copy_cf_error(error);
+                if (cf_error) {
+                    err_desc = (__bridge_transfer NSString *)CFErrorCopyDescription(cf_error);
+                    CFRelease(cf_error);
+                }
+            }
+            handler(err_domain, err_code, err_desc);
+        });
+}
+
+/**
+ * Maximum datagram payload currently writable on [connection] (the datagram flow),
+ * derived from the path MTU minus protocol overhead. 0 until the flow is ready or
+ * if datagrams are unavailable. Maps to QuicScope.maxDatagramSize().
+ */
+static inline uint32_t nw_helper_quic_max_datagram_size(nw_connection_t _Nonnull connection) {
+    return nw_connection_get_maximum_datagram_size(connection);
 }


### PR DESCRIPTION
Closes #109.

Implements RFC 9221 unreliable datagrams on Apple (Network.framework) — the last platform inheriting the throwing/`Unavailable` `QuicScope` defaults — and migrates the whole Apple QUIC path onto an `nw_connection_group` so one QUIC connection carries real per-stream flows **and** a datagram flow.

## Why a connection group
Network.framework models datagrams as a dedicated *flow* (`nw_quic_set_stream_is_datagram`, macOS 13 / iOS 16), not on the byte-stream path. A single `nw_connection` is *either* a stream *or* the datagram flow — never both — so streams + datagrams on one connection require a multiplex connection group.

`connectQuicGroup` is now the **single** Apple QUIC connect path:
- The legacy single-`nw_connection` `AppleQuicConnection` class and the `nw_helper_create_quic_connection` C helper are **deleted**.
- `openStream()` extracts a real distinct stream (fixes the prior single-stream aliasing — every "stream" used to wrap the one connection).
- The datagram flow is extracted only when `QuicOptions.datagrams` is set; otherwise the surface reports `MaxDatagramSize.Unavailable` and the send/receive methods throw, matching the `QuicScope` defaults.

## The key bug (and fix)
Extracting the datagram flow with a fresh `nw_quic_create_options()` fails immediately with **ENETDOWN** ("Network is down"). A bidi stream extracted with `NULL` options establishes fine, so it's specifically the fresh/empty custom options. The flow must inherit the connection's **own** QUIC options: copy them via `nw_connection_group_copy_parameters` → `copy_default_protocol_stack` → `copy_transport_protocol`, then only flip `is_datagram` + `max_datagram_frame_size`.

Datagram-flow helpers are `@available`-gated to macOS 13 / iOS 16 (`__builtin_available`); the group + stream path stays at macOS 12 / iOS 15. The #81 CA-pinning verify_block and serial callback-queue hardening carry onto the group creator.

## Test infrastructure
- `QuicEchoTestServer` echoes datagrams (`DatagramOptions` + a datagram-echo child job that holds the connection open until the peer disconnects, so a datagram-only client isn't cut by the stream-accept timeout).
- `QuicHarnessIntegrationTests.harness_datagram_roundTrip` reuses the existing macOS-host quic-echo launch + CA pinning for a real encrypted round-trip.
- Build fix: `stageQuicheNativeResources` now `dependsOn("prepareQuicheNativeLib")` — the default (non-`quicEchoAllArches`) path had an undeclared task-output dependency that failed local-macOS `jvmTest`/`quicEchoJar` validation (CI always sets `quicEchoAllArches=true`, which hid it).

## Validation
Validated end-to-end on the **macosArm64 host** (real Network.framework ↔ JVM-quiche echo over loopback): all 6 `QuicHarnessIntegrationTests` pass through the group path — including handshake-only (no stream/datagram), stream write→echo→read via an extracted flow, and the datagram round-trip — all `harness OK`. iOS simulator + device targets compile; `ktlintFormat` clean.

## Out of scope (pre-existing, unchanged)
- `withQuicServer` on Apple is still `TODO()` (pending NWListener) — see follow-up.
- `acceptStream` / peer-initiated streams (the group's new-connection handler) remain to be wired; `acceptStream()` currently suspends until the connection closes.