### PR TITLE
feat(quic): wire Apple acceptStream via the group new-connection handler

### DIFF
--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -19,6 +19,7 @@ import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_datagram_send
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_cancel
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_extract_datagram_flow
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_extract_stream
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_set_new_connection_handler
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_set_state_handler
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_start
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_max_datagram_size
@@ -122,6 +123,12 @@ private suspend fun <R> connectQuicGroup(
             maxFrameSize,
         ) ?: throw SocketConnectionException.Refused(hostname, port, platformError = "Failed to create QUIC connection group")
 
+    // Peer-initiated streams land here via the group's new-connection handler (wired below,
+    // before start) and are drained by acceptStream()/streams(). Declared here so the handler
+    // — which the API requires to be set before nw_helper_quic_group_start — can target it.
+    val incomingStreams = Channel<QuicByteStream>(Channel.UNLIMITED)
+    val acceptedStreamId = kotlin.concurrent.AtomicLong(1L) // server-initiated bidi ids (synthetic; NW hides the real id)
+
     // Wait for the group (QUIC handshake) to become ready. Group states: 2=ready, 3=failed, 4=cancelled.
     suspendCancellableCoroutine { cont ->
         nw_helper_quic_group_set_state_handler(group) { state, _, errorCode, errorDesc ->
@@ -140,6 +147,18 @@ private suspend fun <R> connectQuicGroup(
                 4 -> if (cont.isActive) cont.resumeWithException(SocketClosedException.General("QUIC group cancelled"))
                 else -> {} // invalid=0, waiting=1 — in progress
             }
+        }
+        // Wire peer-initiated streams into acceptStream() — MUST be set before start.
+        // The block runs on the group's serial callback queue; trySend into an UNLIMITED
+        // channel is non-blocking and thread-safe.
+        nw_helper_quic_group_set_new_connection_handler(group) { streamConn ->
+            // Take ownership (action 1 of NW's three): start the flow on the shared serial
+            // queue, then enqueue it. Runs synchronously inside the block, so the connection
+            // is owned before the block returns.
+            nw_helper_quic_start(streamConn)
+            incomingStreams.trySend(
+                QuicByteStream(QuicStreamId(acceptedStreamId.getAndAdd(4)), NWQuicByteStream(streamConn)),
+            )
         }
         nw_helper_quic_group_start(group)
         cont.invokeOnCancellation { nw_helper_quic_group_cancel(group) }
@@ -188,7 +207,7 @@ private suspend fun <R> connectQuicGroup(
             flow
         }
 
-    val quicConn = AppleQuicGroupConnection(group, datagramFlow, connectionOptions.bufferFactory)
+    val quicConn = AppleQuicGroupConnection(group, datagramFlow, incomingStreams, connectionOptions.bufferFactory)
     return try {
         quicConn.block()
     } finally {
@@ -212,12 +231,16 @@ private const val DATAGRAM_FRAME_SIZE_MAX: UShort = 65535u
  * [MaxDatagramSize.Unavailable] and the send/receive methods throw, matching the
  * [QuicScope] defaults a non-datagram connection should present.
  *
- * Remaining seam (follow-up): wire `acceptStream`/peer-initiated streams via the group's
- * new-connection handler — today [acceptStream] just suspends until the connection closes.
+ * [acceptStream]/[streams] are fed by the group's new-connection handler (wired in
+ * connectQuicGroup), so peer-initiated streams — e.g. an HTTP/3 server's control and
+ * QPACK unidirectional streams — are delivered to the application. NB: Network.framework
+ * does not expose the real QUIC stream id/type, so accepted streams carry a synthetic id.
  */
 private class AppleQuicGroupConnection(
     private val group: nw_connection_group_t,
     private val datagramFlow: nw_connection_t?,
+    // Peer-initiated streams, fed by the group's new-connection handler wired in connectQuicGroup.
+    private val incomingStreams: Channel<QuicByteStream>,
     private val bufferFactory: BufferFactory,
     private val scope: CoroutineScope = CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default),
 ) : QuicConnection,
@@ -225,7 +248,6 @@ private class AppleQuicGroupConnection(
     private val _state = MutableStateFlow<QuicConnectionState>(QuicConnectionState.Established("h3"))
     override val state: StateFlow<QuicConnectionState> = _state
 
-    private val incomingStreams = Channel<QuicByteStream>(Channel.UNLIMITED)
     private val nextClientStreamId = kotlin.concurrent.AtomicLong(0L)
 
     @Volatile
@@ -246,8 +268,8 @@ private class AppleQuicGroupConnection(
 
     override suspend fun acceptStream(): QuicByteStream {
         check(!closed) { "AppleQuicGroupConnection is closed" }
-        // Peer-initiated streams (group new-connection handler) are not wired yet; see
-        // the class docstring. Suspends until the connection closes.
+        // Suspends until the group's new-connection handler delivers a peer-initiated
+        // stream, or throws when the channel closes (connection gone).
         return incomingStreams.receive()
     }
 

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicHarnessIntegrationTests.kt
@@ -286,4 +286,29 @@ class QuicHarnessIntegrationTests {
                 }
             }
         }
+
+    /**
+     * Accepts a SERVER-initiated stream (issue #112). The echo peer opens one stream toward
+     * the client and writes a fixed greeting, exercising the path where peer-initiated
+     * streams reach [QuicScope.acceptStream] — what an HTTP/3 client needs for the server's
+     * control + QPACK unidirectional streams. On Apple this is the group new-connection
+     * handler; on quiche it's the driver's incoming-stream surface.
+     */
+    @Test
+    fun harness_acceptStream_receivesServerInitiatedStream() =
+        runTest(timeout = 60.seconds) {
+            withContext(Dispatchers.Default) {
+                withHarness {
+                    val stream =
+                        withTimeoutOrNull(opTimeout) { acceptStream() }
+                            ?: throw AssertionError("no server-initiated stream arrived")
+                    val result = withTimeoutOrNull(opTimeout) { stream.read(opTimeout) }
+                    if (result !is ReadResult.Data) throw AssertionError("expected data on the server-initiated stream, got $result")
+                    val text = result.buffer.readString(result.buffer.remaining(), Charset.UTF8)
+                    result.buffer.freeIfNeeded()
+                    assertEquals("HELLO\n", text)
+                    stream.close()
+                }
+            }
+        }
 }

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicEchoTestServer.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicEchoTestServer.kt
@@ -1,5 +1,8 @@
 package com.ditchoom.socket.quic
 
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.flow.ReadResult
 import com.ditchoom.buffer.freeIfNeeded
 import kotlinx.coroutines.Dispatchers
@@ -73,6 +76,24 @@ fun main(args: Array<String>) {
                         } catch (_: Exception) {
                         }
                     }
+                // Server-initiated stream (issue #112): open one stream TOWARD the client
+                // and write a fixed greeting, so clients can exercise acceptStream() against a
+                // real peer-initiated stream (e.g. an HTTP/3 server's control/QPACK streams).
+                // Independent of the echo path; clients that don't accept it simply ignore it.
+                val pushJob =
+                    launch {
+                        try {
+                            val s = openStream()
+                            val greeting = "HELLO\n"
+                            val buf = BufferFactory.deterministic().allocate(greeting.length)
+                            buf.writeString(greeting, Charset.UTF8)
+                            buf.resetForRead()
+                            s.write(buf, 10.seconds)
+                            buf.freeNativeMemory()
+                            s.close() // FIN, so the client sees the greeting then End
+                        } catch (_: Exception) {
+                        }
+                    }
                 val streamJob =
                     launch {
                         try {
@@ -98,6 +119,7 @@ fun main(args: Array<String>) {
                     }
                 datagramJob.join()
                 streamJob.cancel()
+                pushJob.cancel()
             }
         }
     }

--- a/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
+++ b/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
@@ -369,6 +369,30 @@ static inline void nw_helper_quic_group_set_state_handler(
 }
 
 /**
+ * Block delivering a peer-initiated stream flow (one [nw_connection_t] per stream the
+ * remote opened). The Kotlin handler takes ownership: it starts the connection
+ * (nw_helper_quic_start) and enqueues it for acceptStream()/streams().
+ */
+typedef void (^quic_new_stream_handler_t)(nw_connection_t _Nonnull connection);
+
+/**
+ * Wire the group's new-connection handler so peer-initiated streams reach acceptStream().
+ * MUST be called BEFORE nw_helper_quic_group_start (the API forbids setting it after
+ * start). Taking ownership of the delivered connection (action 1 of the three the API
+ * permits) is the Kotlin handler's job — it runs synchronously inside this block, so the
+ * connection is owned (queue set + started) before the block returns.
+ */
+static inline void nw_helper_quic_group_set_new_connection_handler(
+    nw_connection_group_t _Nonnull group,
+    quic_new_stream_handler_t _Nonnull handler)
+{
+    nw_connection_group_set_new_connection_handler(group,
+        ^(nw_connection_t _Nonnull connection) {
+            handler(connection);
+        });
+}
+
+/**
  * Start the group. Uses a dedicated SERIAL callback queue for the same K/N
  * foreign-thread-safety reason as nw_helper_quic_start (one callback at a time).
  *


### PR DESCRIPTION
Part of #112 (the `acceptStream` half; the `withQuicServer`/NWListener part stays open). Builds on #111.

Peer-initiated streams now reach `acceptStream()`/`streams()` on Apple. Previously the multiplex group's new-connection handler was unwired, so `acceptStream()` suspended forever — which would block an HTTP/3 client, since the server opens its control + QPACK unidirectional streams *to* the client.

## Change
- **C:** `nw_helper_quic_group_set_new_connection_handler` — wires `nw_connection_group_set_new_connection_handler`, set **before** group start (the API forbids setting it after). It hands each delivered peer-initiated stream flow to the Kotlin handler, which takes ownership.
- **Kotlin:** the `incomingStreams` channel + handler are created in `connectQuicGroup` (so they exist before start, as required) and handed to `AppleQuicGroupConnection`. The handler starts each delivered flow (`nw_helper_quic_start`) and `trySend`s it into the channel; `acceptStream()`/`streams()` drain it.
- NB: Network.framework does not expose the real QUIC stream id/type, so accepted streams carry a **synthetic id** for now (id/type fidelity is an HTTP/3 follow-up).

## Validation
- `QuicEchoTestServer` now opens one server-initiated stream per connection and writes a fixed greeting (independent of the echo path; clients that don't accept it simply ignore it).
- New `harness_acceptStream_receivesServerInitiatedStream` accepts that stream and asserts the greeting.
- **All 7 `QuicHarnessIntegrationTests` pass on both `macosArm64` (the new NW wiring) and `jvm` (quiche, unchanged)** — confirming the wiring works *and* the server-push doesn't disturb the existing stream/datagram tests. iOS simulator + device compile; ktlint clean.

## Why now
This is the QUIC-layer prerequisite for an HTTP/3 client on Apple (Phase 1). The remaining #112 item — `withQuicServer` (NWListener) — is **not** needed for the H3 *client* (which tests against external servers), so it's deferred.