### PR TITLE
ci: weekly Claude dependency-update agent + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot keeps GitHub Actions and the independently-versioned Gradle
+# libraries current. The pieces it CANNOT handle are deliberately left to the
+# weekly Claude agent (.github/workflows/weekly-dependency-update.yaml):
+#   - the tightly-coupled toolchain (Kotlin, KSP, kotlin-wrappers, AGP) that
+#     must move in lockstep and needs a real build to validate;
+#   - the Gradle wrapper, which Dependabot cannot update;
+#   - the native deps built from source (quiche/BoringSSL, liburing), which are
+#     plain version strings in gradle/libs.versions.toml, not Maven modules, so
+#     Dependabot never sees them at all.
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    # Coordinated, build-validated toolchain bumps are owned by the weekly
+    # Claude agent. Kotlin / KSP / kotlin-wrappers must move in lock step (a
+    # lone Kotlin bump breaks KSP), and AGP majors need a build to verify.
+    ignore:
+      - dependency-name: "org.jetbrains.kotlin:*"
+      - dependency-name: "org.jetbrains.kotlin.*"
+      - dependency-name: "com.google.devtools.ksp*"
+      - dependency-name: "org.jetbrains.kotlin-wrappers:*"
+      - dependency-name: "com.android.*"
+    groups:
+      gradle-minor-patch:
+        # One PR for all non-major bumps to keep noise down; majors stay separate.
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/workflows/weekly-dependency-update.yaml
+++ b/.github/workflows/weekly-dependency-update.yaml
@@ -1,0 +1,150 @@
+name: "Weekly Dependency Update (Claude)"
+
+# Complements Dependabot. Dependabot (.github/dependabot.yml) handles GitHub
+# Actions and the independently-versioned Gradle libraries. This job owns the
+# pieces Dependabot cannot:
+#   - the Gradle wrapper;
+#   - the tightly-coupled toolchain (Kotlin / KSP / kotlin-wrappers / AGP) that
+#     must move in lockstep and needs a real build to validate;
+#   - the native deps built from source — quiche (which vendors BoringSSL as a
+#     git submodule, so SSL moves with it) and liburing — declared as version
+#     strings in gradle/libs.versions.toml that Dependabot cannot see.
+# Claude applies a coordinated bump, validates it with a real host build, and
+# only then opens a PR. Full cross-target CI (Apple/Windows/Android/K-N Linux)
+# runs on the PR itself via the normal review workflows.
+#
+# Requires repository secret CLAUDE_CODE_OAUTH_TOKEN (generate with
+# `claude setup-token`, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`).
+
+on:
+  schedule:
+    # Saturday 22:15 America/Chicago (CDT, UTC-5) == Sunday 03:15 UTC.
+    # Cron is fixed UTC, so during standard time (CST) this fires at 21:15 local.
+    - cron: "15 3 * * 0"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: weekly-dependency-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Native build toolchain for quiche + BoringSSL + liburing (mirrors
+      # build-linux.yaml). Without these a quiche/liburing bump cannot be
+      # validated and the agent would open an unverified PR.
+      - name: Install native build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential perl pkg-config cmake nasm
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "21"
+          cache: gradle
+
+      - name: Set up Rust (for quiche/BoringSSL cargo build)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Konan
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: cargo-${{ runner.os }}-
+
+      - name: Claude — coordinated toolchain + native dep update
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowedTools Bash,Edit,Write,Read,Glob,Grep --max-turns 80"
+          prompt: |
+            You are maintaining the `com.ditchoom:socket` Kotlin Multiplatform library. Check for
+            and apply updates to ONLY the parts of the build that Dependabot does not manage,
+            validate them with a real host build, and open a pull request only if at least one
+            update applies cleanly and the build passes. JAVA_HOME points at JDK 21 (do not change
+            the build toolchain). Rust/cargo, cmake, nasm and the C toolchain are installed.
+
+            ## Scope you OWN (everything else is Dependabot's — do not touch it)
+            In gradle/libs.versions.toml:
+              - Coupled toolchain: `kotlin`, `ksp`, `kotlinWrappers`, `androidGradlePlugin`.
+              - Native deps built from source: `quiche` (+ `quicheSha256`) and `liburing`
+                (+ `liburingSha256`).
+            Plus the Gradle wrapper version in gradle/wrapper/gradle-wrapper.properties.
+            Do NOT change kotlinxCoroutines, buffer, ktlint, mavenPublish, dokka, androidxCore,
+            or any GitHub Action versions — those are Dependabot's.
+
+            ## Find latest STABLE versions (ignore alpha/beta/rc/dev/preview/Snapshot)
+            - Gradle:   curl -s https://services.gradle.org/versions/current
+            - Kotlin:   https://api.github.com/repos/JetBrains/kotlin/releases (stable tags only)
+            - KSP:      https://api.github.com/repos/google/ksp/releases
+            - AGP:      https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/maven-metadata.xml
+            - wrappers: https://repo1.maven.org/maven2/org/jetbrains/kotlin-wrappers/kotlin-web/maven-metadata.xml
+            - quiche:   https://api.github.com/repos/cloudflare/quiche/releases (tags like 0.28.0)
+            - liburing: https://api.github.com/repos/axboe/liburing/releases (tags like liburing-2.x)
+
+            ## Hard compatibility rules (a wrong bump breaks the build)
+            - KSP's version tracks Kotlin's MINOR: KSP 2.3.x ⇒ Kotlin 2.3.x. NEVER bump `kotlin` to a
+              minor that has no matching `ksp` stable release — the buffer-codec processor needs KSP.
+            - `kotlinWrappers` must target the chosen Kotlin version. Verify against its POM
+              (kotlin-web-<v>.pom on Maven Central) before bumping.
+            - Move `kotlin`, `ksp`, `kotlinWrappers` together as one coordinated change.
+            - AGP majors can require build-script migration; apply only if you can make the build pass.
+
+            ## Native-dep specifics (socket-quic)
+            - `quiche` is cloned by git TAG (--branch <version>) with its BoringSSL submodule, so a
+              quiche bump moves BoringSSL/SSL too. Its `quicheSha256` is currently NOT verified by the
+              build (it is an unused parameter), so bumping `quiche` is just the version string — but
+              if a real release-asset SHA is published you may update `quicheSha256` for documentation.
+              Read the cloudflare/quiche CHANGELOG/release notes for breaking C-API changes before bumping,
+              and note them in the PR body.
+            - `liburing` IS SHA256-verified at build time and WILL fail on a stale hash. After bumping
+              `liburing`, recompute `liburingSha256` exactly as the build does — over the GitHub tarball:
+                curl -sL https://github.com/axboe/liburing/archive/refs/tags/liburing-<version>.tar.gz | sha256sum
+              and write the new hash into `liburingSha256`.
+
+            ## Apply + validate (host Linux build — fix any migration breakage you reasonably can)
+            1. Edit only the files in scope.
+            2. If you changed the Kotlin/JS toolchain, run `./gradlew kotlinUpgradeYarnLock` and stage
+               the updated kotlin-js-store/yarn.lock if it changed.
+            3. Run, in order, and ensure each passes:
+                 ./gradlew help
+                 ./gradlew ktlintCheck
+                 ./gradlew jvmTest
+               If you bumped `quiche` and/or `liburing`, ALSO build the native libs from source and run
+               the QUIC host tests (this is the real validation that quiche/BoringSSL/liburing compile):
+                 ./gradlew :socket-quic:jvmTest
+               Apple, Windows, Android and Kotlin/Native-Linux targets cannot be fully validated on this
+               runner — that is expected; the PR's normal CI covers them. Do not treat their absence here
+               as a failure.
+
+            ## Open a PR — only on success
+            - If you applied >= 1 update AND every command you ran above passed: open a PR against `main`
+              titled "build: weekly toolchain / native-dep update", body listing each old -> new version,
+              any breaking-change notes you found (especially for quiche), and the exact validation
+              commands you ran. Add the label "dependencies".
+            - If nothing is out of date, OR you cannot make the build pass: do NOT open a PR. State why
+              and stop.
+            - Never open a PR with a failing or unvalidated build.


### PR DESCRIPTION
Sets up automated dependency maintenance, mirroring the **DitchOoM/buffer** hybrid pattern and adapted for socket's from-source native deps.

## What this adds

**1. `.github/dependabot.yml`** — owns the routine stuff:
- GitHub Actions (grouped into one PR)
- Independently-versioned Gradle libs — minor/patch grouped, majors separate
- Ignores the coupled toolchain (kotlin / ksp / kotlin-wrappers / AGP), which Dependabot can't bump safely in lockstep

**2. `.github/workflows/weekly-dependency-update.yaml`** — a `claude-code-action` cron job owning what Dependabot can't:
- The Gradle wrapper
- The lockstep toolchain: `kotlin` / `ksp` / `kotlinWrappers` / `androidGradlePlugin`
- The from-source native deps: **`quiche`** (vendors **BoringSSL** as a git submodule, so SSL moves with it) and **`liburing`** — these are plain version strings in `libs.versions.toml`, invisible to Dependabot
- Validates on a Linux host (`help`, `ktlintCheck`, `jvmTest`, and `:socket-quic:jvmTest` for any quiche/liburing bump — the real BoringSSL/quiche compile) and **only opens a PR if the build passes**. Recomputes `liburingSha256` on bump (quiche is git-tag fetched; its SHA is unused).

## Schedule
`15 3 * * 0` = Saturday 10:15 PM America/Chicago (CDT) → Sunday 03:15 UTC. Also `workflow_dispatch` for manual runs. Full cross-target CI (Apple/Windows/Android/K-N Linux) runs on the resulting PR via the normal review workflows.

## ⚠️ Required before it runs
Add the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (socket doesn't have it yet; buffer does — same token works):
```
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN -R DitchOoM/socket
```

Test it without waiting for Saturday via the **Run workflow** button (workflow_dispatch) once the secret is set.