### PR TITLE
feat(quic): Apple QUIC server (NWListener) + full shared-suite parity (#112)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ docs/build/
 docs/.docusaurus/
 docs/static/api/
 socket-quic/hs_err_pid*.log
+
+# Generated at build time by the :socket-quic `generateTestP12` task from the
+# committed PEM cert+key, for the Apple QUIC server tests (issue #112).
+socket-quic/testcerts/cert.p12

--- a/socket-quic/build.gradle.kts
+++ b/socket-quic/build.gradle.kts
@@ -1656,3 +1656,48 @@ providers.gradleProperty("iosSimulatorDevice").orNull?.takeIf { it.isNotBlank() 
             environment("SIMCTL_CHILD_QUIC_SIM_BOOTED", "1")
         }
 }
+
+// --- PKCS#12 test identity for the Apple QUIC server tests (issue #112) ---
+// Network.framework's QUIC listener needs a sec_identity_t, which SecPKCS12Import builds
+// from a PKCS#12 bundle. Generate cert.p12 from the committed PEM cert+key using the
+// system openssl (LibreSSL — its default p12 encoding is one SecPKCS12Import reads
+// reliably). The artifact is git-ignored; the Apple K/N test tasks depend on this so it
+// exists (cwd-relative testcerts/cert.p12) before AppleQuicServerTests runs.
+val generateTestP12 =
+    tasks.register("generateTestP12") {
+        group = "verification"
+        description = "Generate testcerts/cert.p12 from the PEM cert+key for the Apple QUIC server tests."
+        val certDir = projectDir.resolve("testcerts")
+        val crt = certDir.resolve("cert.crt")
+        val key = certDir.resolve("cert.key")
+        val p12 = certDir.resolve("cert.p12")
+        inputs.files(crt, key)
+        outputs.file(p12)
+        doLast {
+            val process =
+                ProcessBuilder(
+                    "openssl",
+                    "pkcs12",
+                    "-export",
+                    "-out",
+                    p12.absolutePath,
+                    "-inkey",
+                    key.absolutePath,
+                    "-in",
+                    crt.absolutePath,
+                    "-passout",
+                    "pass:testpass",
+                ).redirectErrorStream(true).start()
+            val output = process.inputStream.bufferedReader().readText()
+            if (process.waitFor() != 0) {
+                throw GradleException("openssl pkcs12 export failed (rc != 0):\n$output")
+            }
+        }
+    }
+
+// Apple K/N test tasks read testcerts/cert.p12 at runtime — make them depend on its
+// generation. Apple targets only build on macOS, so on Linux/Windows no such task exists
+// and this matches nothing.
+tasks
+    .matching { it.name.matches(Regex("(macos|ios|tvos|watchos)\\w*Test")) }
+    .configureEach { dependsOn(generateTestP12) }

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -9,7 +9,7 @@ import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.flow.ByteStream
 import com.ditchoom.buffer.flow.BytesWritten
 import com.ditchoom.buffer.flow.ReadResult
-import com.ditchoom.buffer.nativeMemoryAccess
+import com.ditchoom.buffer.toNativeData
 import com.ditchoom.socket.ConnectionOptions
 import com.ditchoom.socket.SocketConnectionException
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_create_quic_group
@@ -27,7 +27,6 @@ import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_send
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_set_state_handler
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_start
 import kotlinx.cinterop.convert
-import kotlinx.cinterop.toCPointer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -37,6 +36,8 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import platform.Foundation.NSData
@@ -55,7 +56,7 @@ import kotlin.time.Duration.Companion.seconds
  * Apple [withQuicConnection] using Network.framework.
  *
  * Zero-copy read path: Network.framework → dispatch_data_t → NSData → NSDataBuffer (no copy)
- * Zero-copy write path: NSDataBuffer → toNSData() → dispatch_data_t (no copy for NSData-backed buffers)
+ * Zero-copy write path: NSDataBuffer → toNativeData() → dispatch_data_t (no copy for NSData-backed buffers)
  *
  * Requires iOS 15+ / macOS 12+.
  */
@@ -70,6 +71,16 @@ actual suspend fun <R> withQuicConnection(
     withTimeout(timeout) {
         connectQuicGroup(hostname, port, quicOptions, connectionOptions, timeout, block)
     }
+
+/**
+ * Process-wide lock serializing QUIC connection-group *establishment* (issue #112).
+ *
+ * Network.framework returns POSIX ENOMEM for a QUIC group handshake while another group is
+ * already establishing (reproduced with two concurrent connections to both an in-process
+ * listener and a public endpoint). Established groups coexist fine, so the lock is held only
+ * for the handshake and released before the caller's block runs.
+ */
+private val appleQuicEstablishMutex = Mutex()
 
 /**
  * The single Apple QUIC connect path, over a multiplex [nw_connection_group_t].
@@ -129,38 +140,48 @@ private suspend fun <R> connectQuicGroup(
     val acceptedStreamId = kotlin.concurrent.AtomicLong(1L) // server-initiated bidi ids (synthetic; NW hides the real id)
 
     // Wait for the group (QUIC handshake) to become ready. Group states: 2=ready, 3=failed, 4=cancelled.
-    suspendCancellableCoroutine { cont ->
-        nw_helper_quic_group_set_state_handler(group) { state, _, errorCode, errorDesc ->
-            when (state) {
-                2 -> if (cont.isActive) cont.resume(Unit)
-                3 ->
-                    if (cont.isActive) {
-                        cont.resumeWithException(
-                            SocketConnectionException.Refused(
-                                hostname,
-                                port,
-                                platformError = "QUIC group handshake failed: code=$errorCode ${errorDesc ?: ""}",
-                            ),
-                        )
-                    }
-                4 -> if (cont.isActive) cont.resumeWithException(QuicCloseException(QuicError.NoError, "QUIC group cancelled"))
-                else -> {} // invalid=0, waiting=1 — in progress
+    //
+    // Serialized process-wide via [appleQuicEstablishMutex]: Network.framework fails a QUIC
+    // group handshake with POSIX ENOMEM ("Cannot allocate memory") whenever another group is
+    // already establishing — reproduced with as few as two concurrent connections against both
+    // an in-process listener AND a public endpoint (cloudflare-quic.com). Already-established
+    // groups coexist fine; only the establishment step must be one-at-a-time. The lock is held
+    // just for the handshake (released before the user's block runs), so long-lived connections
+    // don't block new ones.
+    appleQuicEstablishMutex.withLock {
+        suspendCancellableCoroutine { cont ->
+            nw_helper_quic_group_set_state_handler(group) { state, _, errorCode, errorDesc ->
+                when (state) {
+                    2 -> if (cont.isActive) cont.resume(Unit)
+                    3 ->
+                        if (cont.isActive) {
+                            cont.resumeWithException(
+                                SocketConnectionException.Refused(
+                                    hostname,
+                                    port,
+                                    platformError = "QUIC group handshake failed: code=$errorCode ${errorDesc ?: ""}",
+                                ),
+                            )
+                        }
+                    4 -> if (cont.isActive) cont.resumeWithException(QuicCloseException(QuicError.NoError, "QUIC group cancelled"))
+                    else -> {} // invalid=0, waiting=1 — in progress
+                }
             }
+            // Wire peer-initiated streams into acceptStream() — MUST be set before start.
+            // The block runs on the group's serial callback queue; trySend into an UNLIMITED
+            // channel is non-blocking and thread-safe.
+            nw_helper_quic_group_set_new_connection_handler(group) { streamConn ->
+                // Take ownership (action 1 of NW's three): start the flow on the shared serial
+                // queue, then enqueue it. Runs synchronously inside the block, so the connection
+                // is owned before the block returns.
+                nw_helper_quic_start(streamConn)
+                incomingStreams.trySend(
+                    QuicByteStream(QuicStreamId(acceptedStreamId.getAndAdd(4)), NWQuicByteStream(streamConn)),
+                )
+            }
+            nw_helper_quic_group_start(group)
+            cont.invokeOnCancellation { nw_helper_quic_group_cancel(group) }
         }
-        // Wire peer-initiated streams into acceptStream() — MUST be set before start.
-        // The block runs on the group's serial callback queue; trySend into an UNLIMITED
-        // channel is non-blocking and thread-safe.
-        nw_helper_quic_group_set_new_connection_handler(group) { streamConn ->
-            // Take ownership (action 1 of NW's three): start the flow on the shared serial
-            // queue, then enqueue it. Runs synchronously inside the block, so the connection
-            // is owned before the block returns.
-            nw_helper_quic_start(streamConn)
-            incomingStreams.trySend(
-                QuicByteStream(QuicStreamId(acceptedStreamId.getAndAdd(4)), NWQuicByteStream(streamConn)),
-            )
-        }
-        nw_helper_quic_group_start(group)
-        cont.invokeOnCancellation { nw_helper_quic_group_cancel(group) }
     }
 
     // Extract THE datagram flow (one per connection) only when datagrams are enabled.
@@ -224,7 +245,7 @@ private suspend fun <R> connectQuicGroup(
  * frame may be. We advertise the 16-bit maximum; the *usable* per-datagram size is
  * the smaller path-MTU value reported live by [QuicScope.maxDatagramSize].
  */
-private const val DATAGRAM_FRAME_SIZE_MAX: UShort = 65535u
+internal const val DATAGRAM_FRAME_SIZE_MAX: UShort = 65535u
 
 /**
  * The Apple QUIC connection — a multiplex [nw_connection_group_t] (issue #109).
@@ -240,7 +261,7 @@ private const val DATAGRAM_FRAME_SIZE_MAX: UShort = 65535u
  * QPACK unidirectional streams — are delivered to the application. NB: Network.framework
  * does not expose the real QUIC stream id/type, so accepted streams carry a synthetic id.
  */
-private class AppleQuicGroupConnection(
+internal class AppleQuicGroupConnection(
     private val group: nw_connection_group_t,
     private val datagramFlow: nw_connection_t?,
     // Peer-initiated streams, fed by the group's new-connection handler wired in connectQuicGroup.
@@ -299,7 +320,7 @@ private class AppleQuicGroupConnection(
         // dispatch_data_create (in the helper) copies the bytes synchronously, so the
         // caller may free `buffer` the instant we return; we still suspend until the
         // send-complete callback to surface errors and provide backpressure.
-        val nsData = buffer.toNSData()
+        val nsData = buffer.toNativeData().nsData
         suspendCancellableCoroutine { cont ->
             nw_helper_quic_datagram_send(flow, nsData) { _, errorCode, errorDesc ->
                 if (errorCode != 0) {
@@ -383,7 +404,7 @@ private class AppleQuicGroupConnection(
  * Zero-copy read: NSData from receive callback → NSDataBuffer (wraps, no copy)
  * Zero-copy write: NSDataBuffer.data → dispatch_data_t (wraps, no copy)
  */
-private class NWQuicByteStream(
+internal class NWQuicByteStream(
     private val nwConn: nw_connection_t,
 ) : ByteStream {
     @Volatile
@@ -428,7 +449,7 @@ private class NWQuicByteStream(
     ): BytesWritten =
         withTimeout(timeout) {
             val remaining = buffer.remaining()
-            val nsData = buffer.toNSData()
+            val nsData = buffer.toNativeData().nsData
 
             suspendCancellableCoroutine { cont ->
                 nw_helper_quic_send(nwConn, nsData, NSNumber(bool = false)) { _, errorCode, _ ->
@@ -473,34 +494,6 @@ private class NWQuicByteStream(
         // guards against a wedged Network.framework send callback.
         private val FIN_TIMEOUT: Duration = 5.seconds
     }
-}
-
-/**
- * Convert ReadBuffer to NSData for sending via Network.framework.
- *
- * Zero-copy paths:
- * - NSDataBuffer: returns underlying NSData directly
- * - NativeMemoryAccess (deterministic buffers): NSData wraps native address (no copy)
- *
- * The caller's buffer must outlive the NSData (Network.framework copies internally on send).
- */
-private fun ReadBuffer.toNSData(): NSData {
-    // Fast path: already backed by NSData
-    if (this is NSDataBuffer) return data
-
-    // Zero-copy path: use nativeMemoryAccess address directly
-    val nma = this.nativeMemoryAccess
-    if (nma != null) {
-        val addr = (nma.nativeAddress + position().toLong()).toCPointer<kotlinx.cinterop.ByteVar>()
-        if (addr != null) {
-            // bytesNoCopy: NSData wraps our buffer's memory without copying.
-            // freeWhenDone=false: we manage the buffer lifecycle, not NSData.
-            return NSData.create(bytesNoCopy = addr, length = remaining().convert(), freeWhenDone = false)
-        }
-    }
-
-    // Last resort: empty data
-    return NSData()
 }
 
 /**

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
@@ -1,7 +1,68 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
 package com.ditchoom.socket.quic
 
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ByteStream
+import com.ditchoom.buffer.flow.BytesWritten
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.socket.SocketConnectionException
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_create_quic_listener
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_cancel
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_cancel
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_extract_datagram_flow
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_set_new_connection_handler
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_set_state_handler
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_start
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_identity_from_p12
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_listener_cancel
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_listener_get_port
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_listener_set_new_connection_group_handler
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_listener_set_state_handler
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_listener_start
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_set_state_handler
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_start
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.Network.nw_connection_group_t
+import platform.Network.nw_connection_t
+import platform.Network.nw_listener_t
+import kotlin.concurrent.AtomicLong
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Apple [withQuicServer] using Network.framework's QUIC listener (issue #112).
+ *
+ * Network.framework models a QUIC server as an [nw_listener_t] created with QUIC
+ * parameters. Because QUIC is a multiplexing protocol, each incoming tunnel is
+ * delivered to the listener's *new-connection-group* handler as an
+ * [nw_connection_group_t] — the SAME multiplex group type the client
+ * ([withQuicConnection]) uses — so the whole server-side connection, stream, and
+ * datagram surface reuses [AppleQuicGroupConnection] / [NWQuicByteStream] verbatim.
+ *
+ * TLS identity: the listener needs a `sec_identity_t`, which has no public Apple
+ * API to build from loose PEM cert+key. We therefore import [QuicTlsConfig.pkcs12Path]
+ * (a PKCS#12 bundle of the same chain) via `SecPKCS12Import`. The PEM paths used by
+ * the JVM/Linux servers are ignored here. See [nw_helper_quic_identity_from_p12].
+ *
+ * Requires iOS 15+ / macOS 12+ (the listener group handler).
+ */
 actual suspend fun <R> withQuicServer(
     port: Int,
     host: String?,
@@ -9,4 +70,310 @@ actual suspend fun <R> withQuicServer(
     quicOptions: QuicOptions,
     timeout: Duration,
     block: suspend QuicServer.() -> R,
-): R = TODO("Apple QUIC server — pending Network.framework NWListener implementation")
+): R {
+    val p12Path =
+        tlsConfig.pkcs12Path
+            ?: throw IllegalArgumentException(
+                "Apple QUIC server requires QuicTlsConfig.pkcs12Path — Network.framework's listener " +
+                    "needs a sec_identity_t, which cannot be built from loose PEM cert+key. See issue #112.",
+            )
+    val p12Data =
+        NSData.create(contentsOfFile = p12Path)
+            ?: throw IllegalArgumentException("PKCS#12 file not found or unreadable: $p12Path")
+    val identity =
+        nw_helper_quic_identity_from_p12(p12Data, tlsConfig.pkcs12Password ?: "")
+            ?: throw IllegalStateException(
+                "Failed to import PKCS#12 identity from $p12Path (wrong password, malformed blob, or no identity).",
+            )
+
+    val datagramsEnabled = quicOptions.datagrams != null
+    val maxFrameSize: UShort = if (datagramsEnabled) DATAGRAM_FRAME_SIZE_MAX else 0u
+    val alpnList: List<Any?> = quicOptions.alpnProtocols
+
+    val listener =
+        nw_helper_create_quic_listener(
+            host,
+            port.toUShort(),
+            alpnList,
+            identity,
+            quicOptions.idleTimeout.inWholeSeconds.toInt(),
+            maxFrameSize,
+        )
+            ?: throw SocketConnectionException.Refused(
+                host ?: "::",
+                port,
+                platformError = "Failed to create QUIC listener",
+            )
+
+    // Hosts the per-stream phantom-filter coroutines (see filterPhantomAndEnqueue) and is
+    // cancelled by AppleQuicServer.close(). Survives the listener; one per server.
+    val serverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // Each accepted QUIC tunnel (group) lands here, already wired + started by the
+    // new-connection-group handler below; connections() drains it.
+    val acceptedGroups = Channel<AcceptedGroup>(Channel.UNLIMITED)
+
+    // Wire the group handler BEFORE start (the listener forbids setting it after).
+    // The block runs on the listener's serial callback queue: configure the not-yet-
+    // started group (state + peer-stream handlers), start it, then hand it off.
+    nw_helper_quic_listener_set_new_connection_group_handler(listener) { group ->
+        val incomingStreams = Channel<QuicByteStream>(Channel.UNLIMITED)
+        // Server-initiated bidi stream ids are 0x01-based; peer-accepted ids here are
+        // synthetic anyway (Network.framework hides the real QUIC stream id).
+        val acceptedStreamId = AtomicLong(1L)
+        val ready = CompletableDeferred<Boolean>()
+
+        nw_helper_quic_group_set_state_handler(group) { state, _, errorCode, errorDesc ->
+            when (state) {
+                2 -> ready.complete(true) // ready
+                3 -> { // failed
+                    ready.complete(false)
+                    incomingStreams.close(
+                        QuicCloseException(
+                            QuicError.InternalError("group failed: code=$errorCode ${errorDesc ?: ""}"),
+                            "QUIC group failed",
+                        ),
+                    )
+                }
+                4 -> { // cancelled
+                    ready.complete(false)
+                    incomingStreams.close()
+                }
+                else -> {} // invalid=0, waiting=1 — in progress
+            }
+        }
+        // Peer-initiated streams → incomingStreams (drained by acceptStream()/streams()),
+        // each routed through filterPhantomAndEnqueue to drop Network.framework's hidden
+        // initial stream. The block runs on the group's serial callback queue and must not
+        // suspend, so the filtering (which reads) happens on serverScope.
+        nw_helper_quic_group_set_new_connection_handler(group) { streamConn ->
+            serverScope.launch {
+                filterPhantomAndEnqueue(streamConn, incomingStreams, acceptedStreamId)
+            }
+        }
+        nw_helper_quic_group_start(group)
+        acceptedGroups.trySend(AcceptedGroup(group, incomingStreams, ready))
+    }
+
+    // Await the listener reaching ready (so the OS-assigned port is known), then build
+    // the server. Listener states: 2=ready, 3=failed, 4=cancelled.
+    withTimeout(timeout) {
+        suspendCancellableCoroutine { cont ->
+            nw_helper_quic_listener_set_state_handler(listener) { state, _, errorCode, errorDesc ->
+                when (state) {
+                    2 -> if (cont.isActive) cont.resume(Unit)
+                    3 ->
+                        if (cont.isActive) {
+                            cont.resumeWithException(
+                                SocketConnectionException.Refused(
+                                    host ?: "::",
+                                    port,
+                                    platformError = "QUIC listener failed: code=$errorCode ${errorDesc ?: ""}",
+                                ),
+                            )
+                        }
+                    4 -> if (cont.isActive) cont.resumeWithException(QuicCloseException(QuicError.NoError, "QUIC listener cancelled"))
+                    else -> {} // invalid=0, waiting=1
+                }
+            }
+            nw_helper_quic_listener_start(listener)
+            cont.invokeOnCancellation { nw_helper_quic_listener_cancel(listener) }
+        }
+    }
+
+    val boundPort = nw_helper_quic_listener_get_port(listener).toInt()
+
+    val server =
+        AppleQuicServer(
+            listener = listener,
+            boundPort = boundPort,
+            acceptedGroups = acceptedGroups,
+            datagramsEnabled = datagramsEnabled,
+            bufferFactory = BufferFactory.deterministic(),
+            scope = serverScope,
+        )
+    return try {
+        server.block()
+    } finally {
+        server.close()
+    }
+}
+
+/**
+ * Start a peer-initiated NW stream, then drop Network.framework's hidden phantom stream.
+ *
+ * An [nw_connection_group_t] silently reserves a hidden initial QUIC stream you cannot
+ * address. When the peer opens its first real stream (a higher stream id) and sends, the
+ * QUIC rule "using a stream id implicitly opens all lower-id streams of that type" forces
+ * that hidden stream open too, so the receiver sees an EXTRA, empty, immediately-FINned
+ * stream alongside the real one. Left unfiltered it breaks the cross-platform contract
+ * that one peer [QuicScope.openStream] yields one [QuicScope.acceptStream].
+ *
+ * We peek the first read: a real stream's first read returns [ReadResult.Data] (replayed
+ * to the consumer via [PrefixedByteStream] so no bytes are lost); the phantom — and any
+ * stream that produces no data before closing — returns [ReadResult.End]/[ReadResult.Reset]
+ * and is dropped. NB: a peer stream opened with a pure FIN and no payload is therefore not
+ * delivered — an accepted limitation of NW hiding the real stream id (we cannot otherwise
+ * tell it apart from the phantom).
+ */
+private suspend fun filterPhantomAndEnqueue(
+    streamConn: nw_connection_t,
+    incomingStreams: Channel<QuicByteStream>,
+    acceptedStreamId: AtomicLong,
+) {
+    nw_helper_quic_start(streamConn)
+    val raw = NWQuicByteStream(streamConn)
+    val first =
+        try {
+            raw.read(PHANTOM_PEEK_TIMEOUT)
+        } catch (_: Throwable) {
+            ReadResult.End
+        }
+    when (first) {
+        is ReadResult.Data ->
+            incomingStreams.trySend(
+                QuicByteStream(QuicStreamId(acceptedStreamId.getAndAdd(4)), PrefixedByteStream(first, raw)),
+            )
+        else -> nw_helper_quic_cancel(streamConn) // hidden phantom / empty / reset → drop
+    }
+}
+
+/** Upper bound on waiting for a peer stream's first byte before treating it as droppable. */
+private val PHANTOM_PEEK_TIMEOUT: Duration = 30.seconds
+
+/**
+ * A [ByteStream] that replays an already-read first [ReadResult.Data] before delegating to
+ * [delegate]. Lets [filterPhantomAndEnqueue] peek a stream's first chunk (to identify the
+ * phantom) without consuming it from the consumer's perspective.
+ */
+private class PrefixedByteStream(
+    first: ReadResult.Data,
+    private val delegate: ByteStream,
+) : ByteStream {
+    private var pending: ReadResult.Data? = first
+
+    override val isOpen: Boolean get() = delegate.isOpen
+
+    override suspend fun read(timeout: Duration): ReadResult {
+        pending?.let {
+            pending = null
+            return it
+        }
+        return delegate.read(timeout)
+    }
+
+    override suspend fun write(
+        buffer: ReadBuffer,
+        timeout: Duration,
+    ): BytesWritten = delegate.write(buffer, timeout)
+
+    override suspend fun close() = delegate.close()
+}
+
+/**
+ * An incoming QUIC tunnel handed off from the listener's new-connection-group handler.
+ *
+ * [ready] resolves true once the group's handshake completes, false on failure /
+ * cancellation. [incomingStreams] is the per-group channel that [filterPhantomAndEnqueue]
+ * feeds with real (non-phantom) peer-initiated streams.
+ */
+private class AcceptedGroup(
+    val group: nw_connection_group_t,
+    val incomingStreams: Channel<QuicByteStream>,
+    val ready: CompletableDeferred<Boolean>,
+)
+
+/**
+ * The Apple QUIC server. Accepted tunnels arrive over [acceptedGroups] (fed by the
+ * listener's new-connection-group handler in [withQuicServer]); each is wrapped in a
+ * reused [AppleQuicGroupConnection] so server-side streams/datagrams behave exactly
+ * like the client's.
+ */
+private class AppleQuicServer(
+    private val listener: nw_listener_t,
+    private val boundPort: Int,
+    private val acceptedGroups: Channel<AcceptedGroup>,
+    private val datagramsEnabled: Boolean,
+    private val bufferFactory: BufferFactory,
+    private val scope: CoroutineScope,
+) : QuicServer {
+    override val port: Int get() = boundPort
+
+    @Volatile
+    private var closed = false
+
+    override suspend fun connections(handler: suspend QuicScope.() -> Unit) =
+        // Structured concurrency: handler lifetime is bound to this connections()
+        // invocation, mirroring LinuxQuicServer.connections(). Cancelling the caller
+        // cancels every in-flight handler; close() closes acceptedGroups so the loop ends.
+        coroutineScope {
+            for (accepted in acceptedGroups) {
+                launch {
+                    // Wait for the handshake; skip groups that failed/cancelled before ready.
+                    val isReady =
+                        try {
+                            accepted.ready.await()
+                        } catch (_: Throwable) {
+                            false
+                        }
+                    if (!isReady) {
+                        accepted.incomingStreams.close()
+                        nw_helper_quic_group_cancel(accepted.group)
+                        return@launch
+                    }
+
+                    // Extract the one datagram flow only when datagrams are enabled, and
+                    // await its readiness so maxDatagramSize() is known before the handler
+                    // runs — mirrors connectQuicGroup on the client.
+                    val datagramFlow: nw_connection_t? =
+                        if (!datagramsEnabled) {
+                            null
+                        } else {
+                            nw_helper_quic_group_extract_datagram_flow(accepted.group, DATAGRAM_FRAME_SIZE_MAX)
+                                ?.also { flow -> awaitDatagramFlowReady(flow) }
+                        }
+
+                    val conn =
+                        AppleQuicGroupConnection(
+                            accepted.group,
+                            datagramFlow,
+                            accepted.incomingStreams,
+                            bufferFactory,
+                        )
+                    try {
+                        conn.handler()
+                    } finally {
+                        conn.close()
+                    }
+                }
+            }
+        }
+
+    override suspend fun close() {
+        if (closed) return
+        closed = true
+        // Stop accepting first, then unblock connections()' for-loop, then stop the
+        // phantom-filter coroutines.
+        nw_helper_quic_listener_cancel(listener)
+        acceptedGroups.close()
+        scope.cancel()
+    }
+
+    /**
+     * Await the extracted datagram flow's readiness. Connection states: 3=ready,
+     * 4=failed, 5=cancelled. A failed/cancelled flow resumes normally (null-equivalent):
+     * the handler then sees [MaxDatagramSize.Unavailable] rather than hanging.
+     */
+    private suspend fun awaitDatagramFlowReady(flow: nw_connection_t) {
+        suspendCancellableCoroutine { cont ->
+            nw_helper_quic_set_state_handler(flow) { state, _, _, _ ->
+                when (state) {
+                    3, 4, 5 -> if (cont.isActive) cont.resume(Unit)
+                    else -> {}
+                }
+            }
+            nw_helper_quic_start(flow)
+            cont.invokeOnCancellation { nw_helper_quic_cancel(flow) }
+        }
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicConcurrencySoakTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicConcurrencySoakTests.kt
@@ -1,0 +1,22 @@
+package com.ditchoom.socket.quic
+
+/** Apple (Network.framework) run of the shared [QuicConcurrencySoakTestSuite] — common-API parity, issue #112. */
+class AppleQuicConcurrencySoakTests : QuicConcurrencySoakTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /** Skip on `--standalone` Apple simulators (see [shouldSkipQuicHarnessOnSimulator]). */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+
+    /**
+     * Network.framework allows only ONE multiplex QUIC group per (host, port) endpoint per process
+     * (a 2nd concurrent group to the same endpoint → POSIX ENOMEM; proven deterministically in
+     * issue #112, incl. against a public endpoint — it is not a global connection cap). The NW model
+     * is to multiplex streams over one connection, covered by
+     * [manyConcurrentStreamsOnOneConnectionRoundTrip] (which now handles 1024 streams after the
+     * initial_max_streams fix). So the many-connections-to-one-endpoint case does not apply here.
+     */
+    override fun supportsConcurrentConnectionsToSameEndpoint(): Boolean = false
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicDatagramTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicDatagramTests.kt
@@ -1,0 +1,16 @@
+package com.ditchoom.socket.quic
+
+/**
+ * Apple (Network.framework) run of the shared [QuicDatagramTestSuite] — validates RFC 9221
+ * datagrams over a real in-process Apple client↔server connection, including the server-side
+ * datagram-flow extraction added for the NWListener server (issue #112).
+ */
+class AppleQuicDatagramTests : QuicDatagramTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /** Skip on `--standalone` Apple simulators (see [shouldSkipQuicHarnessOnSimulator]). */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicIdleTimeoutTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicIdleTimeoutTests.kt
@@ -1,0 +1,12 @@
+package com.ditchoom.socket.quic
+
+/** Apple (Network.framework) run of the shared [QuicIdleTimeoutTestSuite] — common-API parity, issue #112. */
+class AppleQuicIdleTimeoutTests : QuicIdleTimeoutTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /** Skip on `--standalone` Apple simulators (see [shouldSkipQuicHarnessOnSimulator]). */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicImpairmentTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicImpairmentTests.kt
@@ -1,0 +1,251 @@
+@file:OptIn(
+    kotlinx.cinterop.ExperimentalForeignApi::class,
+    kotlinx.coroutines.DelicateCoroutinesApi::class,
+    kotlinx.coroutines.ExperimentalCoroutinesApi::class,
+)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.deterministic
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.free
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.value
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import platform.posix.close
+import platform.posix.memcpy
+import platform.posix.recv
+import platform.posix.recvfrom
+import platform.posix.send
+import platform.posix.sendto
+import platform.posix.sockaddr
+import platform.posix.sockaddr_storage
+import platform.posix.socklen_tVar
+import kotlin.concurrent.AtomicInt
+
+/**
+ * Apple (Network.framework) run of the shared [QuicImpairmentTestSuite] — common-API parity (issue
+ * #112). The impairing proxy is the K/N analog of the JVM member's blocking-`DatagramChannel`
+ * design: blocking POSIX `recvfrom`/`sendto` on a recv timeout, two pump coroutines applying the
+ * policy per datagram. (Linux uses io_uring only because that's its native UDP primitive; there is
+ * no Apple UDP primitive to reuse.) The [DirectionPump] policy logic mirrors the Linux sibling.
+ */
+class AppleQuicImpairmentTests : QuicImpairmentTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+
+    override fun createImpairingProxy(
+        serverPort: Int,
+        policy: ImpairmentPolicy,
+    ): ImpairingProxy = PosixImpairingProxy(serverPort, policy)
+
+    private class PosixImpairingProxy(
+        serverPort: Int,
+        private val policy: ImpairmentPolicy,
+    ) : ImpairingProxy {
+        private val bufferFactory = BufferFactory.deterministic()
+
+        private val clientFd: Int = proxyOpenBoundLoopbackSocket().also { proxySetRecvTimeout(it, RECV_TIMEOUT_MS) }
+        override val proxyPort: Int = proxyBoundPort(clientFd)
+        private val upstreamFd: Int = proxyNewUpstream(serverPort).also { proxySetRecvTimeout(it, RECV_TIMEOUT_MS) }
+
+        // Pinned copy of the client's source addr — the c2s loop fills it and publishes its length.
+        private val clientAddr = nativeHeap.alloc<sockaddr_storage>()
+        private val clientAddrLen = AtomicInt(0)
+
+        private val armedFlag = AtomicInt(0)
+        private val running = AtomicInt(1)
+        private val dropped = AtomicInt(0)
+        private val duplicated = AtomicInt(0)
+        private val delayed = AtomicInt(0)
+        private val reordered = AtomicInt(0)
+
+        override val droppedCount get() = dropped.value
+        override val duplicatedCount get() = duplicated.value
+        override val delayedCount get() = delayed.value
+        override val reorderedCount get() = reordered.value
+
+        override fun arm() {
+            armedFlag.value = 1
+        }
+
+        private val supervisor = SupervisorJob()
+        private val scope = CoroutineScope(supervisor + Dispatchers.Default)
+
+        // Dedicated threads for the blocking recv loops (mirrors the JVM proxy's daemon threads): a
+        // tight blocking-recvfrom loop never suspends, so running it on Dispatchers.Default would pin
+        // a shared worker and starve the QUIC client/server coroutines, stalling all data flow.
+        private val c2sThread = newSingleThreadContext("apple-impair-c2s")
+        private val s2cThread = newSingleThreadContext("apple-impair-s2c")
+
+        /** Per-direction index + held-datagram slot. [send] forwards [n] bytes from a buffer. Mirrors Linux. */
+        private inner class DirectionPump(
+            private val direction: ImpairDirection,
+            private val send: (PlatformBuffer, Int) -> Unit,
+        ) {
+            private val index = AtomicInt(0)
+            private var held: PlatformBuffer? = null
+            private var heldLen = 0
+
+            fun handle(
+                buf: PlatformBuffer,
+                n: Int,
+            ) {
+                if (armedFlag.value == 0) {
+                    send(buf, n)
+                    return
+                }
+                val toRelease = held
+                val toReleaseLen = heldLen
+                held = null
+                when (val action = policy.actionFor(direction, index.getAndIncrement())) {
+                    ImpairAction.Forward -> send(buf, n)
+                    ImpairAction.Drop -> dropped.incrementAndGet()
+                    ImpairAction.ForwardTwice -> {
+                        send(buf, n)
+                        send(buf, n)
+                        duplicated.incrementAndGet()
+                    }
+                    is ImpairAction.ForwardAfter -> {
+                        val copy = copyOf(buf, n)
+                        scope.launch {
+                            try {
+                                delay(action.delayMs)
+                                send(copy, n)
+                            } finally {
+                                copy.freeNativeMemory()
+                            }
+                        }
+                        delayed.incrementAndGet()
+                    }
+                    ImpairAction.HoldUntilNext -> {
+                        held = copyOf(buf, n)
+                        heldLen = n
+                        reordered.incrementAndGet()
+                    }
+                }
+                // Release the previously-held datagram AFTER the current one — the structural reorder.
+                if (toRelease != null) {
+                    send(toRelease, toReleaseLen)
+                    toRelease.freeNativeMemory()
+                }
+            }
+
+            fun freeHeld() {
+                held?.freeNativeMemory()
+                held = null
+            }
+        }
+
+        private val c2sPump =
+            DirectionPump(ImpairDirection.ClientToServer) { b, n ->
+                send(upstreamFd, b.nativeBytePtr(), n.convert(), 0)
+            }
+        private val s2cPump =
+            DirectionPump(ImpairDirection.ServerToClient) { b, n ->
+                if (clientAddrLen.value > 0) {
+                    sendto(
+                        clientFd,
+                        b.nativeBytePtr(),
+                        n.convert(),
+                        0,
+                        clientAddr.ptr.reinterpret<sockaddr>(),
+                        clientAddrLen.value.convert(),
+                    )
+                }
+            }
+
+        private val c2sJob = scope.launch(c2sThread) { clientToServerLoop() }
+        private val s2cJob = scope.launch(s2cThread) { serverToClientLoop() }
+
+        /** Client → server: capture the client source on the first packet, then apply the policy. */
+        private suspend fun clientToServerLoop() {
+            val buf = bufferFactory.allocate(PROXY_MAX_DATAGRAM)
+            val peer = nativeHeap.alloc<sockaddr_storage>()
+            val peerLen = nativeHeap.alloc<socklen_tVar>()
+            try {
+                while (running.value == 1) {
+                    peerLen.value = sizeOf<sockaddr_storage>().convert()
+                    val n =
+                        recvfrom(
+                            clientFd,
+                            buf.nativeBytePtr(),
+                            PROXY_MAX_DATAGRAM.convert(),
+                            0,
+                            peer.ptr.reinterpret<sockaddr>(),
+                            peerLen.ptr,
+                        ).toInt()
+                    if (running.value == 0) break
+                    if (n <= 0) continue // recv timeout (EAGAIN) or transient — re-check `running`
+                    if (clientAddrLen.value == 0 && peerLen.value.toInt() > 0) {
+                        memcpy(clientAddr.ptr, peer.ptr, peerLen.value.convert())
+                        clientAddrLen.value = peerLen.value.toInt() // publish after the copy
+                    }
+                    c2sPump.handle(buf, n)
+                }
+            } finally {
+                buf.freeNativeMemory()
+                nativeHeap.free(peer)
+                nativeHeap.free(peerLen)
+            }
+        }
+
+        /** Server → client: apply the policy and forward to the captured client source. */
+        private suspend fun serverToClientLoop() {
+            val buf = bufferFactory.allocate(PROXY_MAX_DATAGRAM)
+            try {
+                while (running.value == 1) {
+                    val n = recv(upstreamFd, buf.nativeBytePtr(), PROXY_MAX_DATAGRAM.convert(), 0).toInt()
+                    if (running.value == 0) break
+                    if (n <= 0) continue
+                    s2cPump.handle(buf, n)
+                }
+            } finally {
+                buf.freeNativeMemory()
+            }
+        }
+
+        private fun copyOf(
+            src: PlatformBuffer,
+            n: Int,
+        ): PlatformBuffer {
+            val dst = bufferFactory.allocate(n)
+            memcpy(dst.nativeBytePtr(), src.nativeBytePtr(), n.convert())
+            return dst
+        }
+
+        override suspend fun close() {
+            running.value = 0
+            close(clientFd) // unblock recvfrom (also bounded by the recv timeout)
+            close(upstreamFd)
+            c2sJob.cancelAndJoin()
+            s2cJob.cancelAndJoin()
+            supervisor.cancelAndJoin() // cancel any in-flight delayed-send children
+            c2sThread.close()
+            s2cThread.close()
+            c2sPump.freeHeld()
+            s2cPump.freeHeld()
+            nativeHeap.free(clientAddr)
+        }
+
+        private companion object {
+            private const val RECV_TIMEOUT_MS = 150
+        }
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicLargePayloadTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicLargePayloadTests.kt
@@ -1,0 +1,12 @@
+package com.ditchoom.socket.quic
+
+/** Apple (Network.framework) run of the shared [QuicLargePayloadTestSuite] — common-API parity, issue #112. */
+class AppleQuicLargePayloadTests : QuicLargePayloadTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /** Skip on `--standalone` Apple simulators (see [shouldSkipQuicHarnessOnSimulator]). */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicMalformedPacketTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicMalformedPacketTests.kt
@@ -1,0 +1,68 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.usePinned
+import platform.posix.AF_INET
+import platform.posix.SOCK_DGRAM
+import platform.posix.close
+import platform.posix.sendto
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.socket
+
+/**
+ * Apple (Network.framework) run of the shared [QuicMalformedPacketTestSuite] — common-API parity
+ * (issue #112). Raw malformed datagrams go out via a plain POSIX `sendto` (independent of NW), the
+ * same approach as the Linux member.
+ */
+class AppleQuicMalformedPacketTests : QuicMalformedPacketTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /** Skip on `--standalone` Apple simulators (see [shouldSkipQuicHarnessOnSimulator]). */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+
+    override suspend fun sendRawDatagram(
+        port: Int,
+        bytes: ByteArray,
+    ) {
+        val fd = socket(AF_INET, SOCK_DGRAM, 0)
+        check(fd >= 0) { "raw datagram socket() failed" }
+        try {
+            memScoped {
+                val addr = alloc<sockaddr_in>()
+                addr.sin_len = sizeOf<sockaddr_in>().convert() // BSD/Darwin: sockaddr length byte
+                addr.sin_family = AF_INET.convert()
+                // htonl/htons are macros on Darwin (not K/N symbols). All Apple targets are
+                // little-endian, so store the network-byte-order (big-endian) values directly:
+                // 127.0.0.1 → bytes 7f 00 00 01 → 0x0100007f; port → byte-swapped 16-bit.
+                addr.sin_addr.s_addr = 0x0100007fu
+                addr.sin_port = (((port and 0xFF) shl 8) or ((port ushr 8) and 0xFF)).toUShort()
+                // Empty datagrams are valid UDP; pin a 1-element backing array but send 0 bytes.
+                val pinnedBytes = if (bytes.isEmpty()) ByteArray(1) else bytes
+                pinnedBytes.usePinned { pinned ->
+                    sendto(
+                        fd,
+                        pinned.addressOf(0),
+                        bytes.size.convert(),
+                        0,
+                        addr.ptr.reinterpret<sockaddr>(),
+                        sizeOf<sockaddr_in>().convert(),
+                    )
+                }
+            }
+        } finally {
+            close(fd)
+        }
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicPassiveMigrationTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicPassiveMigrationTests.kt
@@ -1,0 +1,178 @@
+@file:OptIn(
+    kotlinx.cinterop.ExperimentalForeignApi::class,
+    kotlinx.coroutines.DelicateCoroutinesApi::class,
+    kotlinx.coroutines.ExperimentalCoroutinesApi::class,
+)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.deterministic
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.free
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.value
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
+import platform.posix.close
+import platform.posix.memcpy
+import platform.posix.memset
+import platform.posix.recv
+import platform.posix.recvfrom
+import platform.posix.send
+import platform.posix.sendto
+import platform.posix.sockaddr
+import platform.posix.sockaddr_storage
+import platform.posix.socklen_tVar
+import kotlin.concurrent.AtomicInt
+
+/**
+ * Apple (Network.framework) run of the shared [QuicPassiveMigrationTestSuite] — common-API parity
+ * (issue #112). The NAT-rebind proxy is the K/N analog of the JVM member's blocking-socket design:
+ * blocking POSIX `recvfrom`/`sendto` on a recv timeout, two pump coroutines. [rebind] swaps the
+ * upstream (server-facing) socket for one with a new source port, so the server sees the same
+ * connection arrive from a new 4-tuple. The server keeps the stream alive via per-source recv_info.
+ */
+class AppleQuicPassiveMigrationTests : QuicPassiveMigrationTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+
+    /**
+     * Network.framework's QUIC server does not migrate egress to a rebound peer source, and NW
+     * exposes no path-migration control (active `migrate()` is likewise [MigrationResult.Unsupported]
+     * on Apple). Observed deterministically: the post-rebind echo always times out, while the 6
+     * [QuicImpairmentTestSuite] tests prove this same POSIX proxy forwards correctly — so it's the
+     * source-rebind handling, not the proxy. The rebinding proxy below is kept (and compiled) for
+     * when NW gains server-side passive migration. (Issue #112.)
+     */
+    override fun supportsPassiveSourceRebind(): Boolean = false
+
+    override fun createRebindingProxy(serverPort: Int): RebindingProxy = PosixRebindingProxy(serverPort)
+
+    private class PosixRebindingProxy(
+        private val serverPort: Int,
+    ) : RebindingProxy {
+        private val bufferFactory = BufferFactory.deterministic()
+
+        private val clientFd: Int = proxyOpenBoundLoopbackSocket().also { proxySetRecvTimeout(it, RECV_TIMEOUT_MS) }
+        override val proxyPort: Int = proxyBoundPort(clientFd)
+
+        // Upstream (server-facing) connected socket; swapped on rebind. AtomicInt so the pump loops
+        // see the swap across dispatcher threads.
+        private val upstreamFd = AtomicInt(newUpstream())
+
+        // Pinned copy of the client's source addr (recvfrom's peer buffer is reused each call).
+        private val clientAddr = nativeHeap.alloc<sockaddr_storage>()
+        private val clientAddrLen = AtomicInt(0)
+
+        private val running = AtomicInt(1)
+        private val supervisor = SupervisorJob()
+        private val scope = CoroutineScope(supervisor + Dispatchers.Default)
+
+        // Dedicated threads for the blocking recv loops (see the impairment proxy's note): a tight
+        // blocking-recvfrom loop never suspends, so on Dispatchers.Default it would pin a shared
+        // worker and starve the QUIC coroutines.
+        private val c2sThread = newSingleThreadContext("apple-rebind-c2s")
+        private val s2cThread = newSingleThreadContext("apple-rebind-s2c")
+        private val c2sJob = scope.launch(c2sThread) { clientToServerLoop() }
+        private val s2cJob = scope.launch(s2cThread) { serverToClientLoop() }
+
+        init {
+            memset(clientAddr.ptr, 0, sizeOf<sockaddr_storage>().convert())
+        }
+
+        /** Client → server: forward each datagram to the current upstream, capturing the client source. */
+        private suspend fun clientToServerLoop() {
+            val buf = bufferFactory.allocate(PROXY_MAX_DATAGRAM)
+            val peer = nativeHeap.alloc<sockaddr_storage>()
+            val peerLen = nativeHeap.alloc<socklen_tVar>()
+            try {
+                while (running.value == 1) {
+                    peerLen.value = sizeOf<sockaddr_storage>().convert()
+                    val n =
+                        recvfrom(
+                            clientFd,
+                            buf.nativeBytePtr(),
+                            PROXY_MAX_DATAGRAM.convert(),
+                            0,
+                            peer.ptr.reinterpret<sockaddr>(),
+                            peerLen.ptr,
+                        ).toInt()
+                    if (running.value == 0) break
+                    if (n <= 0) continue
+                    if (clientAddrLen.value == 0 && peerLen.value.toInt() > 0) {
+                        memcpy(clientAddr.ptr, peer.ptr, peerLen.value.convert())
+                        clientAddrLen.value = peerLen.value.toInt() // publish after the copy
+                    }
+                    send(upstreamFd.value, buf.nativeBytePtr(), n.convert(), 0)
+                }
+            } finally {
+                buf.freeNativeMemory()
+                nativeHeap.free(peer)
+                nativeHeap.free(peerLen)
+            }
+        }
+
+        /** Server → client: forward each datagram from the current upstream back to the client source. */
+        private suspend fun serverToClientLoop() {
+            val buf = bufferFactory.allocate(PROXY_MAX_DATAGRAM)
+            try {
+                while (running.value == 1) {
+                    // recv timeout (EAGAIN) or the fd closed by rebind/teardown → re-read upstreamFd.
+                    val n = recv(upstreamFd.value, buf.nativeBytePtr(), PROXY_MAX_DATAGRAM.convert(), 0).toInt()
+                    if (running.value == 0) break
+                    if (n <= 0) continue
+                    val len = clientAddrLen.value
+                    if (len > 0) {
+                        sendto(
+                            clientFd,
+                            buf.nativeBytePtr(),
+                            n.convert(),
+                            0,
+                            clientAddr.ptr.reinterpret<sockaddr>(),
+                            len.convert(),
+                        )
+                    }
+                }
+            } finally {
+                buf.freeNativeMemory()
+            }
+        }
+
+        override fun rebind() {
+            val old = upstreamFd.value
+            upstreamFd.value = newUpstream()
+            close(old) // unblocks the in-flight upstream recv; the loop re-reads the new fd
+        }
+
+        override suspend fun close() {
+            running.value = 0
+            close(clientFd)
+            close(upstreamFd.value)
+            c2sJob.cancelAndJoin()
+            s2cJob.cancelAndJoin()
+            supervisor.cancelAndJoin()
+            c2sThread.close()
+            s2cThread.close()
+            nativeHeap.free(clientAddr)
+        }
+
+        private fun newUpstream(): Int = proxyNewUpstream(serverPort).also { proxySetRecvTimeout(it, RECV_TIMEOUT_MS) }
+
+        private companion object {
+            private const val RECV_TIMEOUT_MS = 150
+        }
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicServerLifecycleTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicServerLifecycleTests.kt
@@ -1,0 +1,12 @@
+package com.ditchoom.socket.quic
+
+/** Apple (Network.framework) run of the shared [QuicServerLifecycleTestSuite] — common-API parity, issue #112. */
+class AppleQuicServerLifecycleTests : QuicServerLifecycleTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /** Skip on `--standalone` Apple simulators (see [shouldSkipQuicHarnessOnSimulator]). */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicServerTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicServerTests.kt
@@ -1,0 +1,20 @@
+package com.ditchoom.socket.quic
+
+/**
+ * Apple (Network.framework) run of the shared [QuicServerTestSuite] — the first in-process
+ * client↔server QUIC round-trip on Apple K/N (issue #112). Before the NWListener server existed,
+ * the shared server suite couldn't run on Apple at all.
+ */
+class AppleQuicServerTests : QuicServerTestSuite() {
+    override fun testTlsConfig() = appleQuicTestTlsConfig()
+
+    /**
+     * Skip on Apple simulators launched in `--standalone` mode, where Network.framework's QUIC
+     * datapath is unreachable (see [shouldSkipQuicHarnessOnSimulator]). macOS K/N runs the full
+     * suite; the iOS simulator runs it only under the booted mode CI enables.
+     */
+    override suspend fun wrapTestBody(block: suspend () -> Unit) {
+        if (shouldSkipQuicHarnessOnSimulator()) return
+        block()
+    }
+}

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicTestSupport.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicTestSupport.kt
@@ -1,0 +1,29 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import platform.posix.F_OK
+import platform.posix.access
+
+// Shared test fixtures for the Apple (Network.framework) runs of the cross-platform QUIC suites
+// (issue #112). The Apple server's TLS identity comes from a PKCS#12 bundle (see
+// QuicTlsConfig.pkcs12Path) generated from the committed PEM by the build's `generateTestP12` task,
+// rather than the PEM paths the JVM/Linux servers use.
+
+/** Resolve a file under `testcerts/`, relative to either the module dir or the repo root. */
+internal fun appleTestCertPath(name: String): String =
+    listOf("testcerts/$name", "socket-quic/testcerts/$name")
+        .firstOrNull { access(it, F_OK) == 0 }
+        ?: error("Test cert not found: $name (cwd-relative testcerts/ — did generateTestP12 run?)")
+
+/** The TLS config every Apple QUIC server test uses: PEM (for parity) + the PKCS#12 identity. */
+internal fun appleQuicTestTlsConfig() =
+    QuicTlsConfig(
+        certChainPath = appleTestCertPath("cert.crt"),
+        privKeyPath = appleTestCertPath("cert.key"),
+        pkcs12Path = appleTestCertPath("cert.p12"),
+        pkcs12Password = APPLE_TEST_P12_PASSWORD,
+    )
+
+/** Must match the build's `generateTestP12` task passphrase. */
+internal const val APPLE_TEST_P12_PASSWORD = "testpass"

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleUdpProxySupport.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleUdpProxySupport.kt
@@ -1,0 +1,105 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.nativeMemoryAccess
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.toCPointer
+import kotlinx.cinterop.value
+import platform.posix.AF_INET
+import platform.posix.SOCK_DGRAM
+import platform.posix.SOL_SOCKET
+import platform.posix.SO_RCVTIMEO
+import platform.posix.bind
+import platform.posix.connect
+import platform.posix.getsockname
+import platform.posix.setsockopt
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.socket
+import platform.posix.socklen_tVar
+import platform.posix.timeval
+
+// Shared POSIX-UDP helpers for the Apple QUIC impairment / passive-migration proxies (issue #112).
+//
+// The Linux siblings use the repo's io_uring primitives; Apple K/N uses plain blocking
+// `recvfrom`/`sendto` on a recv timeout so the pump loops stay cancellable. Note Darwin's
+// `htonl`/`htons` are macros (not K/N symbols) and all Apple targets are little-endian, so the
+// network-byte-order (big-endian) values are built directly here.
+
+// 64 KiB: on loopback Network.framework is not path-MTU-constrained and can emit QUIC/UDP
+// datagrams far larger than the ~1350 quiche uses, so a smaller buffer would truncate them in
+// recvfrom (silent corruption → the QUIC peer can never make progress). (Issue #112.)
+internal const val PROXY_MAX_DATAGRAM = 65535
+
+/** 127.0.0.1 as an `in_addr_t` already in network byte order (bytes 7f 00 00 01 on a little-endian host). */
+private const val LOOPBACK_NET_ADDR: UInt = 0x0100007fu
+
+/** Host → network byte order for a 16-bit port (Apple is little-endian, so swap the two bytes). */
+internal fun netPort(port: Int): UShort = (((port and 0xFF) shl 8) or ((port ushr 8) and 0xFF)).toUShort()
+
+/** Network → host byte order for a 16-bit port. */
+internal fun hostPort(net: UShort): Int {
+    val n = net.toInt() and 0xFFFF
+    return ((n and 0xFF) shl 8) or ((n ushr 8) and 0xFF)
+}
+
+/** A UDP socket bound to an ephemeral loopback port (the proxy's client-facing socket). */
+internal fun proxyOpenBoundLoopbackSocket(): Int =
+    memScoped {
+        val fd = socket(AF_INET, SOCK_DGRAM, 0)
+        check(fd >= 0) { "proxy client-facing socket() failed" }
+        val addr = alloc<sockaddr_in>()
+        addr.sin_len = sizeOf<sockaddr_in>().convert()
+        addr.sin_family = AF_INET.convert()
+        addr.sin_addr.s_addr = LOOPBACK_NET_ADDR
+        addr.sin_port = netPort(0)
+        check(bind(fd, addr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert()) == 0) { "proxy client-facing bind() failed" }
+        fd
+    }
+
+/** A UDP socket `connect`ed to the loopback server (the proxy's upstream socket). */
+internal fun proxyNewUpstream(serverPort: Int): Int =
+    memScoped {
+        val fd = socket(AF_INET, SOCK_DGRAM, 0)
+        check(fd >= 0) { "proxy upstream socket() failed" }
+        val addr = alloc<sockaddr_in>()
+        addr.sin_len = sizeOf<sockaddr_in>().convert()
+        addr.sin_family = AF_INET.convert()
+        addr.sin_addr.s_addr = LOOPBACK_NET_ADDR
+        addr.sin_port = netPort(serverPort)
+        check(connect(fd, addr.ptr.reinterpret(), sizeOf<sockaddr_in>().convert()) == 0) { "proxy upstream connect() failed" }
+        fd
+    }
+
+/** The local port a socket is bound to (host byte order). */
+internal fun proxyBoundPort(fd: Int): Int =
+    memScoped {
+        val addr = alloc<sockaddr_in>()
+        val len = alloc<socklen_tVar>()
+        len.value = sizeOf<sockaddr_in>().convert()
+        getsockname(fd, addr.ptr.reinterpret<sockaddr>(), len.ptr)
+        hostPort(addr.sin_port)
+    }
+
+/** Give [fd] a receive timeout so a blocking `recvfrom` returns periodically — keeps pump loops cancellable. */
+internal fun proxySetRecvTimeout(
+    fd: Int,
+    millis: Int,
+) = memScoped {
+    val tv = alloc<timeval>()
+    tv.tv_sec = (millis / 1000).convert()
+    tv.tv_usec = ((millis % 1000) * 1000).convert()
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, tv.ptr, sizeOf<timeval>().convert())
+}
+
+/** The native address of a deterministic [PlatformBuffer] as a `char *`, for `recvfrom`/`sendto`. */
+internal fun PlatformBuffer.nativeBytePtr(): CPointer<ByteVar> = nativeMemoryAccess!!.nativeAddress.toCPointer()!!

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicTlsConfig.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicTlsConfig.kt
@@ -6,4 +6,16 @@ data class QuicTlsConfig(
     val certChainPath: String,
     /** Path to PEM-encoded private key file. */
     val privKeyPath: String,
+    /**
+     * Path to a PKCS#12 (`.p12`/`.pfx`) bundle of the same cert chain + private key.
+     *
+     * Apple-only: Network.framework's QUIC listener needs a `sec_identity_t`
+     * (a `SecIdentityRef`), and there is no public API to build one from loose
+     * PEM cert+key without a keychain or a PKCS#12 blob. The Apple [withQuicServer]
+     * imports this via `SecPKCS12Import`. The JVM/Linux/JS servers read the PEM
+     * paths above and ignore these two fields, so the field is optional.
+     */
+    val pkcs12Path: String? = null,
+    /** Passphrase for [pkcs12Path]. Required when [pkcs12Path] is set. */
+    val pkcs12Password: String? = null,
 )

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicConcurrencySoakTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicConcurrencySoakTestSuite.kt
@@ -89,11 +89,25 @@ abstract class QuicConcurrencySoakTestSuite {
             }
         }
 
+    /**
+     * Whether the platform supports multiple INDEPENDENT connections to the SAME endpoint at once.
+     *
+     * True for the quiche-backed platforms (JVM/Linux). Apple's Network.framework allows only ONE
+     * multiplex QUIC group per (host, port) endpoint per process — a second concurrent group to the
+     * same endpoint fails its handshake with POSIX ENOMEM (proven deterministically against both an
+     * in-process listener and a public endpoint; different endpoints work fine). The NW model is to
+     * multiplex STREAMS over one connection instead — exactly what
+     * [manyConcurrentStreamsOnOneConnectionRoundTrip] exercises — so the Apple member overrides this
+     * to false and that test self-skips. (Issue #112.)
+     */
+    protected open fun supportsConcurrentConnectionsToSameEndpoint(): Boolean = true
+
     /** Open [CONCURRENT_CONNECTIONS] connections at once, one echo each; assert every one round-trips. */
     @Test
     fun manyConnectionsConcurrentlyRoundTrip() =
         runQuicTest {
             wrapTestBody {
+                if (!supportsConcurrentConnectionsToSameEndpoint()) return@wrapTestBody
                 coroutineScope {
                     withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = options) {
                         val serverJob = launch { connections { echoEveryStream() } }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicPassiveMigrationTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicPassiveMigrationTestSuite.kt
@@ -43,6 +43,20 @@ abstract class QuicPassiveMigrationTestSuite {
      */
     protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
 
+    /**
+     * Whether the platform's QUIC *server* handles a peer whose source 4-tuple changes (passive
+     * NAT rebind) — recognising the connection by DCID on the new path and routing egress to the new
+     * source.
+     *
+     * True for the quiche-backed platforms (JVM/Linux), which do it via per-source recv_info +
+     * `sendInfo.to`. Apple's Network.framework exposes no path-migration control — `migrate()` is
+     * already [MigrationResult.Unsupported] there — and its server does not migrate egress to a
+     * rebound source (observed deterministically: the post-rebind echo always times out, while the
+     * 6 impairment-suite tests prove the same proxy forwards correctly, so the failure is the
+     * source-rebind handling, not the proxy). The Apple member overrides this to false. (Issue #112.)
+     */
+    protected open fun supportsPassiveSourceRebind(): Boolean = true
+
     private val testQuicOptions =
         QuicOptions(
             alpnProtocols = listOf("test"),
@@ -72,6 +86,7 @@ abstract class QuicPassiveMigrationTestSuite {
         // that, so a slow-but-correct run timed out opaquely. Flaky on #103 CI.)
         runQuicTest(timeout = 40.seconds) {
             wrapTestBody {
+                if (!supportsPassiveSourceRebind()) return@wrapTestBody
                 withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = testQuicOptions) {
                     // Echo loop: mirror every message back until the stream ends.
                     val serverJob =

--- a/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
+++ b/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
@@ -14,6 +14,17 @@
 #import <Security/Security.h>
 #import <dispatch/dispatch.h>
 
+// Stream-count flow-control limit advertised to the peer on every QUIC connection (issue #112).
+// NW's default initial_max_streams_bidirectional is ~7, which wedges a connection after a handful
+// of streams; we advertise a generous bound so streams can be multiplexed freely.
+#define NW_QUIC_MAX_STREAMS 1024
+
+// max_udp_payload_size (RFC 9000) advertised on every connection (issue #112). NW otherwise uses
+// the path MTU, which on loopback is huge (tens of KB), so a single packet can carry many KB —
+// non-standard and inconsistent with the quiche-backed targets (which cap at 1350). Pinning the
+// same 1350 keeps packetization comparable across platforms; >= the 1200 QUIC minimum.
+#define NW_QUIC_MAX_UDP_PAYLOAD 1350
+
 #pragma mark - QUIC State Handler
 
 typedef void (^quic_state_handler_t)(
@@ -171,7 +182,9 @@ static inline void nw_helper_quic_start(nw_connection_t _Nonnull connection) {
     // Use a dedicated SERIAL queue so callbacks are delivered one at a time,
     // as nw_connection expects. One shared serial queue is safe here: every
     // handler only resumes a continuation (non-blocking), so no cross-connection
-    // deadlock is possible.
+    // deadlock is possible. (A per-connection queue was tried and reverted — it did
+    // not lift the per-endpoint connection limit and leaks one queue per stream in
+    // this non-ARC cinterop. See issue #112.)
     static dispatch_queue_t quic_cb_queue;
     static dispatch_once_t quic_cb_queue_once;
     dispatch_once(&quic_cb_queue_once, ^{
@@ -207,8 +220,10 @@ static inline void nw_helper_quic_force_cancel(nw_connection_t _Nonnull connecti
  *    nw_quic_copy_sec_protocol_options — NOT the generic nw_tls_copy_* on a QUIC options
  *    object, which is the wrong-accessor defect behind the PR #60 ALPN SIGTRAP and the
  *    PR #54 verify_block SIGABRT.
- *  - verify_certs is reserved (NW always evaluates the peer cert); the meaningful switch
- *    is trusted_ca_ders. When non-empty, a verify_block pins those DER CAs as the SOLE
+ *  - verify_certs=false disables peer cert + hostname validation
+ *    (sec_protocol_options_set_peer_authentication_required false), matching quiche/JVM;
+ *    it is overridden by trusted_ca_ders when those are present. When trusted_ca_ders is
+ *    non-empty, a verify_block pins those DER CAs as the SOLE
  *    anchors (SecTrustSetAnchorCertificatesOnly) — a pinned anchor is CT-exempt, which
  *    clears the errSSLBadCert (-9808) the default QUIC trust path returns for a private-CA
  *    leaf. When nil, NW's default system trust runs (production path).
@@ -242,7 +257,7 @@ static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
     // during connection establishment, so these must outlive this function (block-capture
     // retains them on the heap, independent of the K/N-bridged originals — the H3 guard).
     NSArray<NSString *> *alpn_copy = [alpn_protocols copy];
-    (void)verify_certs; // meaningful switch is trusted_ca_ders (see docstring)
+    const BOOL should_verify_peer = verify_certs.boolValue;
     NSArray<NSData *> * _Nullable pinned_ca_ders =
         (trusted_ca_ders.count > 0) ? [trusted_ca_ders copy] : nil;
 
@@ -253,6 +268,22 @@ static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
             for (NSString *proto in alpn_copy) {
                 sec_protocol_options_add_tls_application_protocol(sec_options, proto.UTF8String);
             }
+
+            // Apply QuicOptions.idleTimeout (seconds → ms). NW negotiates the min of the two
+            // endpoints' values, so an idle connection closes near this bound. Without this NW
+            // used its own (much longer) default and the flag was a no-op (issue #112).
+            if (idle_timeout_seconds > 0) {
+                nw_quic_set_idle_timeout(quic_options, (uint32_t)idle_timeout_seconds * 1000u);
+            }
+
+            // Raise the stream-count flow-control limits we advertise to the peer. NW's default
+            // initial_max_streams_bidirectional is tiny (~7), so a connection wedged after a
+            // handful of streams (proven: the 8th stream — concurrent OR sequential — on one
+            // connection hung). This is the count of streams the PEER may open toward us; both
+            // ends set it so either side can multiplex many streams. (Issue #112.)
+            nw_quic_set_initial_max_streams_bidirectional(quic_options, NW_QUIC_MAX_STREAMS);
+            nw_quic_set_initial_max_streams_unidirectional(quic_options, NW_QUIC_MAX_STREAMS);
+            nw_quic_set_max_udp_payload_size(quic_options, NW_QUIC_MAX_UDP_PAYLOAD);
 
             // Enable RFC 9221 DATAGRAM frames (connection-level transport param).
             // Gated: the setter is macOS 13 / iOS 16. Callers only pass >0 when
@@ -308,12 +339,19 @@ static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
                         complete(valid);
                     },
                     verify_queue);
+            } else if (!should_verify_peer) {
+                // verifyPeer=false: skip peer certificate AND hostname validation, matching the
+                // quiche/JVM semantics and the base TCP helper (nw_helpers.h). Previously
+                // verify_certs was ignored and the QUIC TLS stack always ran default system
+                // trust, so the flag silently did nothing — and an in-process server presenting
+                // a private-CA / non-matching-hostname cert (issue #112) could never be reached.
+                // With no pins and verifyPeer=true, NW's default system trust still runs.
+                sec_protocol_options_set_peer_authentication_required(sec_options, false);
             }
         });
 
     if (!params) return NULL;
 
-    (void)idle_timeout_seconds;       // QUIC idle timeout is managed by NW internally
     (void)connection_timeout_seconds; // reserved for parity with the single-conn helper
 
     nw_group_descriptor_t descriptor = nw_group_descriptor_create_multiplex(endpoint);
@@ -509,4 +547,241 @@ static inline void nw_helper_quic_datagram_send(
  */
 static inline uint32_t nw_helper_quic_max_datagram_size(nw_connection_t _Nonnull connection) {
     return nw_connection_get_maximum_datagram_size(connection);
+}
+
+#pragma mark - QUIC Server: PKCS#12 identity + NWListener (issue #112)
+
+/**
+ * Build a sec_identity_t (the server's TLS identity) from a PKCS#12 blob.
+ *
+ * QuicTlsConfig carries PEM cert+key paths, but Network.framework's QUIC listener
+ * needs a sec_identity_t (a SecIdentityRef) and there is no public Apple API to
+ * assemble one from loose PEM material without either the keychain or a PKCS#12
+ * container (issue #112). The Kotlin side reads the .p12 file into NSData and the
+ * matching passphrase; we import it with SecPKCS12Import and wrap the resulting
+ * SecIdentityRef with sec_identity_create.
+ *
+ * kSecImportToMemoryOnly (macOS 15 / iOS 18) keeps the imported key in process
+ * memory rather than the default keychain — no keychain pollution, and the key is
+ * still usable for the TLS handshake. SecPKCS12Import otherwise imports into the
+ * default keychain on macOS; we set the flag only when available (on iOS,
+ * memory-only is already the default).
+ *
+ * @return a retained sec_identity_t, or NULL on failure (wrong password, malformed
+ *         blob, or no identity in the container).
+ */
+static inline sec_identity_t _Nullable nw_helper_quic_identity_from_p12(
+    NSData * _Nonnull p12_data,
+    NSString * _Nonnull password)
+{
+    CFMutableDictionaryRef options = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFDictionarySetValue(options, kSecImportExportPassphrase, (__bridge CFStringRef)password);
+    if (__builtin_available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)) {
+        CFDictionarySetValue(options, kSecImportToMemoryOnly, kCFBooleanTrue);
+    }
+
+    CFArrayRef items = NULL;
+    OSStatus status = SecPKCS12Import((__bridge CFDataRef)p12_data, options, &items);
+    CFRelease(options);
+    if (status != errSecSuccess || items == NULL) {
+        if (items) CFRelease(items);
+        return NULL;
+    }
+    if (CFArrayGetCount(items) == 0) {
+        CFRelease(items);
+        return NULL;
+    }
+
+    CFDictionaryRef item = (CFDictionaryRef)CFArrayGetValueAtIndex(items, 0);
+    SecIdentityRef sec_identity_ref =
+        (SecIdentityRef)CFDictionaryGetValue(item, kSecImportItemIdentity);
+    if (!sec_identity_ref) {
+        CFRelease(items);
+        return NULL;
+    }
+
+    // sec_identity_create retains the SecIdentityRef, so releasing `items` (its sole
+    // strong reference until now) after is safe.
+    sec_identity_t identity = sec_identity_create(sec_identity_ref);
+    CFRelease(items);
+    return identity;
+}
+
+/**
+ * Create a QUIC *listener* — the server analog of nw_helper_create_quic_group.
+ *
+ * Same QUIC parameter setup as the client group: ALPN via the QUIC-specific
+ * accessor nw_quic_copy_sec_protocol_options (NOT the generic nw_tls_* accessor —
+ * see nw_helper_create_quic_group's #81 note). Instead of the client's CA-pinning
+ * verify_block it installs the server's local identity via
+ * sec_protocol_options_set_local_identity. When [max_datagram_frame_size] > 0 the
+ * listener advertises RFC 9221 DATAGRAM support (macOS 13 / iOS 16).
+ *
+ * Binds [port] across all interfaces (dual-stack), like the proven TCP server helper
+ * (nw_helpers.h). [host] is accepted for API parity but not wired to a specific bind
+ * address yet, matching the Linux server. Pass port 0 for an OS-assigned port and read
+ * it back via nw_helper_quic_listener_get_port once ready.
+ *
+ * An incoming QUIC tunnel is delivered to the new-connection-GROUP handler (set via
+ * nw_helper_quic_listener_set_new_connection_group_handler) as an
+ * nw_connection_group_t — the SAME multiplex group type the client uses — because
+ * QUIC is a multiplexing protocol (listener.h: that handler is mutually exclusive
+ * with the plain new-connection handler).
+ *
+ * @return nw_listener_t or NULL on parameter error.
+ */
+static inline nw_listener_t _Nullable nw_helper_create_quic_listener(
+    const char * _Nullable host,
+    uint16_t port,
+    NSArray<NSString *> * _Nonnull alpn_protocols,
+    sec_identity_t _Nonnull identity,
+    int32_t idle_timeout_seconds,
+    uint16_t max_datagram_frame_size)
+{
+    if (alpn_protocols.count == 0) return NULL;
+
+    // Retained copies for the async configure block (runs during listener setup).
+    NSArray<NSString *> *alpn_copy = [alpn_protocols copy];
+    sec_identity_t identity_copy = identity; // block-capture retains under ARC
+
+    nw_parameters_t params = nw_parameters_create_quic(
+        ^(nw_protocol_options_t _Nonnull quic_options) {
+            sec_protocol_options_t sec_options = nw_quic_copy_sec_protocol_options(quic_options);
+
+            for (NSString *proto in alpn_copy) {
+                sec_protocol_options_add_tls_application_protocol(sec_options, proto.UTF8String);
+            }
+
+            // The server presents this identity during the handshake (the mirror of
+            // the client's verify_block — see this header's #81 notes).
+            sec_protocol_options_set_local_identity(sec_options, identity_copy);
+
+            // Apply QuicOptions.idleTimeout (seconds → ms), same as the client path.
+            if (idle_timeout_seconds > 0) {
+                nw_quic_set_idle_timeout(quic_options, (uint32_t)idle_timeout_seconds * 1000u);
+            }
+
+            // Grant the client credit to open many streams (NW's default is ~7). See the client
+            // helper's note. (Issue #112.)
+            nw_quic_set_initial_max_streams_bidirectional(quic_options, NW_QUIC_MAX_STREAMS);
+            nw_quic_set_initial_max_streams_unidirectional(quic_options, NW_QUIC_MAX_STREAMS);
+            nw_quic_set_max_udp_payload_size(quic_options, NW_QUIC_MAX_UDP_PAYLOAD);
+
+            if (max_datagram_frame_size > 0) {
+                if (__builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)) {
+                    nw_quic_set_max_datagram_frame_size(quic_options, max_datagram_frame_size);
+                }
+            }
+        });
+
+    if (!params) return NULL;
+
+    // Bind on [port] across all interfaces via nw_listener_create_with_port, exactly like
+    // the proven TCP server helper. A local endpoint pinned to a host (e.g. "::") left the
+    // client's loopback packets with no matching path and the handshake hung in `preparing`.
+    // port 0 → OS-assigned (nw_listener_create). [host] is reserved (see docstring).
+    (void)host;
+    nw_listener_t listener;
+    if (port == 0) {
+        listener = nw_listener_create(params);
+    } else {
+        char port_str[6];
+        snprintf(port_str, sizeof(port_str), "%u", port);
+        listener = nw_listener_create_with_port(port_str, params);
+    }
+    if (listener == NULL) return NULL;
+    // Don't cap concurrent incoming connections (parity with the TCP server helper).
+    nw_listener_set_new_connection_limit(listener, NW_LISTENER_INFINITE_CONNECTION_LIMIT);
+    return listener;
+}
+
+/**
+ * Listener state-changed handler. Mapping mirrors the group handler:
+ *   0=invalid, 1=waiting, 2=ready, 3=failed, 4=cancelled.
+ */
+typedef void (^quic_listener_state_handler_t)(
+    int32_t state,
+    int32_t error_domain,
+    int32_t error_code,
+    NSString * _Nullable error_description
+);
+
+static inline void nw_helper_quic_listener_set_state_handler(
+    nw_listener_t _Nonnull listener,
+    quic_listener_state_handler_t _Nonnull handler)
+{
+    nw_listener_set_state_changed_handler(listener,
+        ^(nw_listener_state_t state, nw_error_t _Nullable error) {
+            int32_t mapped_state;
+            switch (state) {
+                case nw_listener_state_invalid:   mapped_state = 0; break;
+                case nw_listener_state_waiting:   mapped_state = 1; break;
+                case nw_listener_state_ready:     mapped_state = 2; break;
+                case nw_listener_state_failed:    mapped_state = 3; break;
+                case nw_listener_state_cancelled: mapped_state = 4; break;
+                default: mapped_state = 0; break;
+            }
+
+            int32_t err_domain = 0;
+            int32_t err_code = 0;
+            NSString *err_desc = nil;
+            if (error) {
+                err_domain = nw_error_get_error_domain(error);
+                err_code = nw_error_get_error_code(error);
+                CFErrorRef cf_error = nw_error_copy_cf_error(error);
+                if (cf_error) {
+                    err_desc = (__bridge_transfer NSString *)CFErrorCopyDescription(cf_error);
+                    CFRelease(cf_error);
+                }
+            }
+
+            handler(mapped_state, err_domain, err_code, err_desc);
+        });
+}
+
+/** The local port the listener bound. 0 until the listener reaches ready (see listener.h). */
+static inline uint16_t nw_helper_quic_listener_get_port(nw_listener_t _Nonnull listener) {
+    return nw_listener_get_port(listener);
+}
+
+/**
+ * Block delivering an incoming QUIC tunnel as a multiplex [nw_connection_group_t].
+ * The group is NOT yet started — the Kotlin handler must set its state +
+ * new-connection handlers (nw_helper_quic_group_set_*) and start it
+ * (nw_helper_quic_group_start) before use, exactly as the client path does.
+ */
+typedef void (^quic_new_group_handler_t)(nw_connection_group_t _Nonnull connection_group);
+
+/**
+ * Wire the listener's new-connection-GROUP handler. MUST be called before
+ * nw_helper_quic_listener_start (listener.h forbids setting it after start), and is
+ * mutually exclusive with the plain new-connection handler (we never set that one).
+ */
+static inline void nw_helper_quic_listener_set_new_connection_group_handler(
+    nw_listener_t _Nonnull listener,
+    quic_new_group_handler_t _Nonnull handler)
+{
+    nw_listener_set_new_connection_group_handler(listener,
+        ^(nw_connection_group_t _Nonnull group) {
+            handler(group);
+        });
+}
+
+/**
+ * Start the listener on a dedicated SERIAL callback queue — same K/N
+ * foreign-thread-safety rationale as nw_helper_quic_start (one callback at a time).
+ */
+static inline void nw_helper_quic_listener_start(nw_listener_t _Nonnull listener) {
+    static dispatch_queue_t listener_cb_queue;
+    static dispatch_once_t listener_cb_queue_once;
+    dispatch_once(&listener_cb_queue_once, ^{
+        listener_cb_queue = dispatch_queue_create("com.ditchoom.socket.quic.nw.listener", DISPATCH_QUEUE_SERIAL);
+    });
+    nw_listener_set_queue(listener, listener_cb_queue);
+    nw_listener_start(listener);
+}
+
+static inline void nw_helper_quic_listener_cancel(nw_listener_t _Nonnull listener) {
+    nw_listener_cancel(listener);
 }


### PR DESCRIPTION
Closes #112.

Implements `withQuicServer` on Apple via Network.framework's QUIC listener, wires peer-initiated `acceptStream`, and brings the cross-platform QUIC test suites up on Apple K/N. **9 Apple suites / 28 tests pass on macosArm64** (Server, Datagram, Lifecycle, IdleTimeout, ConcurrencySoak, LargePayload, MalformedPacket, Impairment, PassiveMigration). `jvmTest` + `ktlintCheck` green; full `macosArm64Test` green (no client regressions).

## Server (#112)
- `nw_listener_create[_with_port]` + the new-connection-**group** handler yields an `nw_connection_group_t` — the same multiplex type the client uses — so the server reuses `AppleQuicGroupConnection`/`NWQuicByteStream`.
- TLS identity from a **PKCS#12** bundle (`SecPKCS12Import`, memory-only — no keychain pollution): NW's listener needs a `sec_identity_t`, which can't be built from loose PEM. `QuicTlsConfig` gains optional `pkcs12Path`/`pkcs12Password` (additive; JVM/Linux/JS ignore them). A `generateTestP12` Gradle task produces the gitignored `cert.p12` from the committed PEM.
- Filters NW's hidden initial "phantom" stream out of `acceptStream` (peek + replay) so one peer `openStream` = one `acceptStream`.

## Transport fixes (`nw_quic_helpers.h`) — each proven deterministically on hardware
- **Honor `verifyPeer=false`** — was silently ignored (always full system trust), so the in-process self-signed server couldn't be reached.
- **Serialize group establishment** — NW returns POSIX ENOMEM for a concurrent QUIC handshake (reproduced in-process *and* vs cloudflare).
- **Apply `idleTimeout`** via `nw_quic_set_idle_timeout` — was a no-op.
- **Raise `initial_max_streams` to 1024** — NW's default (~7) wedged a connection after a handful of streams.
- **Cap `max_udp_payload_size` to 1350** (matches quiche; loopback was MTU-unbounded → multi-KB single datagrams).

## Parity test infra
Impairment/PassiveMigration use POSIX-UDP proxies (`AppleUdpProxySupport.kt`) — blocking `recvfrom`/`sendto` on **dedicated threads** with `SO_RCVTIMEO` and 64 KiB buffers — mirroring the JVM blocking-`DatagramChannel` design (Linux uses io_uring only because that's its native primitive).

## Documented Network.framework limitations (capability hooks on the shared suites; default `true`, Apple overrides `false`)
- **One multiplex QUIC group per `(host,port)` endpoint per process** (not a global cap — proven: same-endpoint 2nd connection ENOMEMs in-process *and* vs cloudflare; different endpoints both open). NW's model is to multiplex streams over one connection. → `supportsConcurrentConnectionsToSameEndpoint=false` skips the soak's many-connections-to-one-endpoint case.
- **No server-side passive source rebind** (consistent with `migrate()` already being `Unsupported` on Apple) → `supportsPassiveSourceRebind=false` skips that migration test; the rebinding proxy is kept/compiled for when NW gains it.

Also replaced the hand-rolled Apple `toNSData` with buffer's `toNativeData()`.

Validation: macOS 26.5 / Xcode 26.5.