### PR TITLE
test(socket): make SimpleSocketTests socket-closed check deterministic

### DIFF
--- a/src/appleTest/kotlin/com/ditchoom/socket/ReadStats.kt
+++ b/src/appleTest/kotlin/com/ditchoom/socket/ReadStats.kt
@@ -34,18 +34,6 @@ internal actual fun runTestNoTimeSkipping(
         }
     }
 
-actual suspend fun readStats(
-    port: Int,
-    contains: String,
-): List<String> {
-//    delay(100)
-//    yield()
-//    if (!PortHelper().isPortOpenWithActualPort(port.convert())) {
-//        return listOf("$port is still open")
-//    }
-    return emptyList()
-}
-
 actual fun supportsIPv6(): Boolean = true // Apple platforms support IPv6
 
 private val startMark = TimeSource.Monotonic.markNow()

--- a/src/commonJvmTest/kotlin/com/ditchoom/socket/ReadStats.kt
+++ b/src/commonJvmTest/kotlin/com/ditchoom/socket/ReadStats.kt
@@ -34,31 +34,6 @@ internal actual fun runTestNoTimeSkipping(
         }
     }
 
-actual suspend fun readStats(
-    port: Int,
-    contains: String,
-): List<String> {
-    try {
-        val process =
-            ProcessBuilder()
-                .command("lsof", "-iTCP:$port", "-sTCP:$contains", "-l", "-n")
-                .redirectErrorStream(true)
-                .start()
-        try {
-            process.inputStream.use { stream ->
-                return String(stream.readBytes())
-                    .split("\n")
-                    .filter { it.isNotBlank() }
-                    .filter { it.contains(contains) }
-            }
-        } finally {
-            process.destroy()
-        }
-    } catch (t: Throwable) {
-        return emptyList()
-    }
-}
-
 actual fun supportsIPv6(): Boolean =
     try {
         NetworkInterface.getNetworkInterfaces()?.asSequence()?.any { iface ->

--- a/src/commonTest/kotlin/com/ditchoom/socket/SimpleSocketTests.kt
+++ b/src/commonTest/kotlin/com/ditchoom/socket/SimpleSocketTests.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
@@ -154,10 +155,12 @@ class SimpleSocketTests {
             val server = ServerSocket.allocate()
             val text = "yolo swag lyfestyle"
             var serverToClientPort = 0
+            var acceptedSocket: ClientSocket? = null
             val serverToClientMutex = Mutex(locked = true)
             val flow = server.bind()
             launch(Dispatchers.Default) {
                 flow.collect { serverToClient ->
+                    acceptedSocket = serverToClient
                     val buffer = serverToClient.read(1.seconds)
                     val dataReceivedFromClient = buffer.readString(buffer.remaining(), Charset.UTF8)
                     assertEquals(text, dataReceivedFromClient)
@@ -177,9 +180,7 @@ class SimpleSocketTests {
             assertTrue(clientToServerPort > 0, "Invalid clientToServerPort local port.")
             clientToServer.close()
             server.close()
-            checkPort(serverToClientPort)
-            checkPort(clientToServerPort)
-            checkPort(serverPort)
+            assertSocketsClosed(clientToServer, acceptedSocket, server)
         }
 
     @Test
@@ -188,10 +189,12 @@ class SimpleSocketTests {
             val text = "yolo swag lyfestyle"
             val server = ServerSocket.allocate()
             var serverToClientPort = 0
+            var acceptedSocket: ClientSocket? = null
             val serverToClientMutex = Mutex(locked = true)
             val acceptedClientFlow = server.bind()
             launch(Dispatchers.Default) {
                 acceptedClientFlow.collect { serverToClient ->
+                    acceptedSocket = serverToClient
                     serverToClientPort = serverToClient.localPort()
                     assertTrue { serverToClientPort > 0 }
                     serverToClient.writeString(text, Charset.UTF8, 5.seconds)
@@ -212,9 +215,7 @@ class SimpleSocketTests {
             assertTrue(clientToServerPort > 0, "No port number: clientToServerPort")
             clientToServer.close()
             server.close()
-            checkPort(clientToServerPort)
-            checkPort(serverToClientPort)
-            checkPort(serverPort)
+            assertSocketsClosed(clientToServer, acceptedSocket, server)
         }
 
     @Test
@@ -228,10 +229,12 @@ class SimpleSocketTests {
         val text = "yolo swag lyfestyle"
         val text2 = "old mac donald had a farm"
         var serverToClientPort = 0
+        var acceptedSocket: ClientSocket? = null
         val serverToClientMutex = Mutex(locked = true)
         val acceptedClientFlow = server.bind()
         launch(Dispatchers.Default) {
             acceptedClientFlow.collect { serverToClient ->
+                acceptedSocket = serverToClient
                 serverToClientPort = serverToClient.localPort()
                 assertTrue(serverToClientPort > 0, "No port number: serverToClientPort")
                 serverToClient.writeString(text, Charset.UTF8, 1.seconds)
@@ -258,36 +261,30 @@ class SimpleSocketTests {
         assertEquals(utf8v2, text2)
         clientToServer.close()
         server.close()
-        checkPort(clientToServerPort)
-        checkPort(serverPort)
-        checkPort(serverToClientPort)
+        assertSocketsClosed(clientToServer, acceptedSocket, server)
     }
 
-    private suspend fun checkPort(port: Int) {
-        if (getNetworkCapabilities() != NetworkCapabilities.FULL_SOCKET_ACCESS) return
-        // TCP teardown is asynchronous: after close() a socket can sit briefly in
-        // CLOSE_WAIT before the kernel reaps it. Poll until it drains instead of
-        // asserting once — a socket that drains quickly is normal, one that never
-        // drains is a real leak and trips the watchdog below. 10 s is generous
-        // for WSL2-under-load (Phase-2 harness compose + concurrent tests can
-        // push reap latency past 5 s); a real leak hangs indefinitely either way.
-        try {
-            withTimeout(10.seconds) {
-                while (readStats(port, "CLOSE_WAIT").isNotEmpty()) {
-                    delay(50)
-                }
-            }
-        } catch (_: TimeoutCancellationException) {
-            val stats = readStats(port, "CLOSE_WAIT")
-            fail("Socket still in CLOSE_WAIT after 10s (count=${stats.count()}): $stats")
+    /**
+     * Deterministic replacement for the old `lsof`-by-port CLOSE_WAIT poll, which was flaky:
+     * `lsof -iTCP:<port>` matches a bare port number as *either* endpoint, and ephemeral ports get
+     * reused, so under parallel test load an unrelated/reused-port connection in CLOSE_WAIT produced
+     * a false failure. Instead we assert directly on the socket objects we just closed — their
+     * `isOpen()`/`isListening()` delegate to the underlying channel/FD state (e.g. NIO
+     * `SocketChannel.isOpen`), so this proves the library actually released the FD, with no port-number
+     * race and no dependence on OS tooling. `close()` is synchronous, so these hold immediately.
+     */
+    private fun assertSocketsClosed(
+        client: ClientSocket,
+        accepted: ClientSocket?,
+        server: ServerSocket,
+    ) {
+        assertFalse(client.isOpen(), "client socket reports open after close() — FD not released")
+        assertNotNull(accepted, "server never accepted the client connection").let {
+            assertFalse(it.isOpen(), "accepted server-side socket reports open after close() — FD not released")
         }
+        assertFalse(server.isListening(), "server reports listening after close() — listener FD not released")
     }
 }
-
-expect suspend fun readStats(
-    port: Int,
-    contains: String,
-): List<String>
 
 expect fun supportsIPv6(): Boolean
 

--- a/src/jsTest/kotlin/com/ditchoom/socket/ReadStats.kt
+++ b/src/jsTest/kotlin/com/ditchoom/socket/ReadStats.kt
@@ -5,11 +5,9 @@ import com.ditchoom.socket.NetworkCapabilities.WEBSOCKETS_ONLY
 import com.ditchoom.socket.harness.HarnessConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.asDeferred
 import kotlinx.coroutines.promise
 import kotlinx.coroutines.withTimeout
 import kotlin.js.Date
-import kotlin.js.Promise
 import kotlin.time.Duration
 
 actual typealias TestRunResult = Any
@@ -32,27 +30,6 @@ internal actual fun runTestNoTimeSkipping(
             }
         }
     }
-
-actual suspend fun readStats(
-    port: Int,
-    contains: String,
-): List<String> {
-    if (TcpPortUsed.check(port.toInt(), "127.0.0.1").asDeferred().await()) {
-        return listOf("TCP CHECK FAIL PORT: $port")
-    }
-    return emptyList()
-}
-
-@JsModule("tcp-port-used")
-@JsNonModule
-external class TcpPortUsed {
-    companion object {
-        fun check(
-            port: Int,
-            address: String,
-        ): Promise<Boolean>
-    }
-}
 
 actual fun supportsIPv6(): Boolean = false // JS/browser doesn't have direct socket access
 

--- a/src/linuxTest/kotlin/com/ditchoom/socket/ReadStats.kt
+++ b/src/linuxTest/kotlin/com/ditchoom/socket/ReadStats.kt
@@ -33,15 +33,6 @@ internal actual fun runTestNoTimeSkipping(
         }
     }
 
-actual suspend fun readStats(
-    port: Int,
-    contains: String,
-): List<String> {
-    // Linux implementation using ss or netstat could be added here
-    // For now, return empty list
-    return emptyList()
-}
-
 actual fun supportsIPv6(): Boolean = true // Linux supports IPv6
 
 private val startMark = TimeSource.Monotonic.markNow()

--- a/src/wasmJsTest/kotlin/com/ditchoom/socket/TestActuals.kt
+++ b/src/wasmJsTest/kotlin/com/ditchoom/socket/TestActuals.kt
@@ -23,11 +23,6 @@ internal actual fun runTestNoTimeSkipping(
     return TestRunResult()
 }
 
-actual suspend fun readStats(
-    port: Int,
-    contains: String,
-): List<String> = emptyList()
-
 actual fun supportsIPv6(): Boolean = false
 
 @JsFun("() => Date.now()")


### PR DESCRIPTION
## Problem
`SimpleSocketTests` (`clientEcho`/`serverEcho`/`suspendingInputStream`) verified "no FD leak after close" via `checkPort()` → `lsof -iTCP:<port> -sTCP:CLOSE_WAIT`, polling 10s. That's **flaky**: `lsof -iTCP:<port>` matches a bare port number as **either** endpoint, and ephemeral ports get **reused**, so under parallel CI load an unrelated/reused-port connection sitting in CLOSE_WAIT produces a false positive.

Observed on an unrelated PR's CI: `AssertionError: Socket still in CLOSE_WAIT after 10s … 42739->46134` — a connection where the **checked port was the peer**, not even the test's local socket.

## Fix
Replace `checkPort` with `assertSocketsClosed()`, which asserts directly on the socket objects the test just closed:
- `client.isOpen()` / `accepted.isOpen()` / `server.isListening()` delegate to the underlying channel/FD state (e.g. NIO `SocketChannel.isOpen`), so this **deterministically proves the library released the FD** — no port-number race, no `lsof`, no OS tooling.
- `close()` is synchronous (`aClose` → `blockingClose` → `channel.close()`), so the assertions hold immediately.

Removes the now-unused `readStats` expect/actuals across all targets.

Validated: `SimpleSocketTests` pass on JVM, JS (Node), and macOS; `ktlintCheck` clean.