### PR TITLE
feat(http3): production server role + rolling push window

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -162,6 +162,7 @@ jobs:
           ./gradlew :macosX64Test :macosArm64Test :iosSimulatorArm64Test
           :tvosSimulatorArm64Test :watchosSimulatorArm64Test :ktlintCheck
           :socket-quic:jvmProcessResources
+          :socket-http3:macosArm64Test :socket-http3:ktlintCheck
           --no-configuration-cache ${{ inputs.gradle-args }}
 
       # :socket-quic:jvmTest on macOS — re-enabled (issue #70). It was excluded

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -466,6 +466,10 @@ jobs:
       # trace that gradle's brief CI log otherwise truncates to
       # `AssertionError at Assert.java:89`. Indispensable for diagnosing the
       # next harness flake without having to push a re-run with debug prints.
+      # Also collect JVM fatal-error logs from a native crash (SIGABRT/SIGSEGV in quiche/JNI/FFM):
+      # the test process writes hs_err_pid*/replay_pid* to its cwd, which the JUnit XML never
+      # captures — without these a native abort is an invisible "exit 134". This is what lets us
+      # diagnose the intermittent :socket-quic:jvmTest SIGABRT instead of guessing.
       - name: Upload test reports (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -476,6 +480,8 @@ jobs:
             build/test-results/
             socket-quic/build/reports/tests/
             socket-quic/build/test-results/
+            **/hs_err_pid*.log
+            **/replay_pid*.log
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -379,7 +379,13 @@ jobs:
       # self-contained shim via Panama. This is the only CI run that exercises
       # FfmQuicheApi — including the FFM migration path (the in-repo FFM server +
       # client), which had a SIGSEGV that the old silent JNI fallback hid.
+      #
+      # `if: !cancelled()` so this runs even when the default (JNI) step above
+      # crashed: the two backends are independent and a native abort in one must
+      # not blind us to the other. Without it, an intermittent JNI SIGABRT skips
+      # the entire FFM run, so we never learn whether the crash is JNI-only.
       - name: Run socket-quic JVM tests (FFM backend)
+        if: ${{ !cancelled() }}
         timeout-minutes: 8
         env:
           QUIC_MIGRATION_REQUIRE_RUN: "1"
@@ -393,7 +399,11 @@ jobs:
       # The java21/FFM classes aren't on the JNI classpath, so there is no
       # UnsupportedClassVersionError. Proves connNewScid + sockaddr decode +
       # server routing on the JNI shim at runtime on JDK < 21.
+      #
+      # `if: !cancelled()` for the same reason as the FFM step: independent of an
+      # earlier backend's crash, so all three backend runs always report.
       - name: Run socket-quic JVM tests (JDK 17 / JNI)
+        if: ${{ !cancelled() }}
         timeout-minutes: 8
         env:
           QUIC_MIGRATION_REQUIRE_RUN: "1"

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -337,7 +337,7 @@ jobs:
           :socket-quic:jsNodeTest
           :socket-quic:jvmProcessResources :socket-quic:ktlintCheck
           :socket-http3:jvmTest :socket-http3:jsNodeTest :socket-http3:linuxX64Test
-          :socket-http3:ktlintCheck
+          :socket-http3:testDebugUnitTest :socket-http3:ktlintCheck
           -PquicEchoAllArches=true
           --no-configuration-cache ${{ inputs.gradle-args }}
 

--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -288,8 +288,14 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
   `Http3ServerExchange`. Dynamic QPACK both directions when `qpackCapacity > 0`. Modeled on the proven
   `Http3LoopbackServer` mechanics (hand-rolled codecs, per the user — no buffer-codec/declarative). E2E
   tests `productionServerRole_getAndPostRoundTrip` + `…_dynamicQpackRoundTrip` (jvm + linuxX64) drive
-  the real `withHttp3Connection` client against the production server. **Server-initiated push is NOT
-  implemented** — a follow-up (inverse of the client push API).
+  the real `withHttp3Connection` client against the production server.
+- **Server-initiated push (RFC 9114 §4.6) — DONE.** `Http3ServerExchange.push(path, …) { respond }`
+  allocates a Push ID within the client's MAX_PUSH_ID credit, sends a PUSH_PROMISE on the request
+  stream, opens a push stream (`0x01` + Push ID), and writes the pushed response via the `respond`
+  lambda (synchronously — call it before finishing the main response). Returns false when the client
+  granted no/insufficient credit. The server captures the client's MAX_PUSH_ID on the control stream.
+  E2E `productionServerInitiatedPush` (jvm + linuxX64): production server pushes, real client receives
+  it on `pushes` — push proven in BOTH roles. (Sent synchronously per push; concurrent push is a tune.)
 - **Push-window tune (RFC 9114 §7.2.7).** The client now re-issues MAX_PUSH_ID upward as it observes
   push ids (`currentMaxPushId`, `maybeExtendMaxPushId`, window = initial maxPushId+1), so `maxPushId`
   is a rolling-credit window rather than a hard lifetime cap. `validatePushId` checks the live max.
@@ -313,8 +319,9 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
    `Http3Connection`; verified by unit tests + a deterministic bidirectional loopback + the live
    interop GET decoding real servers' dynamic compression.
 4. ✅ **Server push (RFC 9114 §4.6) — DONE**, and ✅ **full server role — DONE** (`withHttp3Server`;
-   see "DONE — full server role" above). Remaining: **server-initiated push** (server side of §4.6),
-   the Apple `reset()` + server-observed close-code follow-ups, and the deferred QPACK-eviction tune.
+   see "DONE — full server role" above), including ✅ **server-initiated push** (§4.6, both roles now).
+   Remaining: the Apple `reset()` + server-observed close-code follow-ups, the deferred QPACK-eviction
+   tune, concurrent (non-blocking) server push, and WebTransport Phase 2.
    (Encoder strategy note: the client encoder is deliberately conservative — never evicts, references
    only acknowledged entries — correct but not maximally compressing; a smarter strategy is a future tune.)
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under

--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -276,6 +276,31 @@ Three gaps closed this session (all green locally; not yet a PR):
 Green: jvm + linuxX64 + jsNode test suites; wasmJs + android test sources compile. 180 linuxX64 / 179 jvm
 tests, 0 fail.
 
+## ✅ DONE — full server role + push-window tune + Apple/Android CI tests (branch `feat/http3-server-role`)
+
+Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) + android unit (173).
+
+- **Full HTTP/3 server role (production).** New `withHttp3Server(port, tlsConfig, …, onRequest, block)` +
+  `Http3ServerConnection` (per accepted QUIC connection: server control stream + SETTINGS, QPACK
+  streams, routes client uni/bidi streams) + `Http3ServerRequest` (streaming body via
+  `nextBodyChunk`/`readFullBody` + trailers) + `Http3ServerResponse` (`send()` one-shot, or streaming
+  `sendHeaders`/`writeBody`/`sendTrailers`; auto-FIN + minimal 500 if the handler sends nothing) +
+  `Http3ServerExchange`. Dynamic QPACK both directions when `qpackCapacity > 0`. Modeled on the proven
+  `Http3LoopbackServer` mechanics (hand-rolled codecs, per the user — no buffer-codec/declarative). E2E
+  tests `productionServerRole_getAndPostRoundTrip` + `…_dynamicQpackRoundTrip` (jvm + linuxX64) drive
+  the real `withHttp3Connection` client against the production server. **Server-initiated push is NOT
+  implemented** — a follow-up (inverse of the client push API).
+- **Push-window tune (RFC 9114 §7.2.7).** The client now re-issues MAX_PUSH_ID upward as it observes
+  push ids (`currentMaxPushId`, `maybeExtendMaxPushId`, window = initial maxPushId+1), so `maxPushId`
+  is a rolling-credit window rather than a hard lifetime cap. `validatePushId` checks the live max.
+  E2E `serverPushWindowRollsViaReIssuedMaxPushId` (maxPushId=0, server pushes >1 across requests).
+- **Apple/Android CI tests.** `:socket-http3:testDebugUnitTest` added to build-linux.yaml (Android unit
+  — codec/scripted + skip-guarded interop, validated locally) and `:socket-http3:macosArm64Test` to
+  build-apple.yaml.
+- **Deliberately deferred — smarter QPACK encoder eviction/blocking.** NOT minor: correctness-critical
+  vs. the current correct-and-interop-proven never-evict strategy. Do it as its own adversarially-tested
+  effort, not a tail-end bundle.
+
 ## NEXT (start here)
 
 1. ✅ **In-process H3 loopback test — DONE** (see "DONE — in-process H3 loopback" above). Green on
@@ -287,9 +312,9 @@ tests, 0 fail.
    dynamic table, encoder + decoder, instruction streams, blocked-stream waiting, wired into
    `Http3Connection`; verified by unit tests + a deterministic bidirectional loopback + the live
    interop GET decoding real servers' dynamic compression.
-4. ✅ **Server push (RFC 9114 §4.6) — DONE** (see "DONE — publishing + … + server push" above).
-   Remaining conformance: the **full server role** (promote `Http3LoopbackServer` to a production
-   `withHttp3Server`); plus the Apple `reset()` + server-observed close-code follow-ups noted above.
+4. ✅ **Server push (RFC 9114 §4.6) — DONE**, and ✅ **full server role — DONE** (`withHttp3Server`;
+   see "DONE — full server role" above). Remaining: **server-initiated push** (server side of §4.6),
+   the Apple `reset()` + server-observed close-code follow-ups, and the deferred QPACK-eviction tune.
    (Encoder strategy note: the client encoder is deliberately conservative — never evicts, references
    only acknowledged entries — correct but not maximally compressing; a smarter strategy is a future tune.)
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under

--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -295,7 +295,13 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
   lambda (synchronously — call it before finishing the main response). Returns false when the client
   granted no/insufficient credit. The server captures the client's MAX_PUSH_ID on the control stream.
   E2E `productionServerInitiatedPush` (jvm + linuxX64): production server pushes, real client receives
-  it on `pushes` — push proven in BOTH roles. (Sent synchronously per push; concurrent push is a tune.)
+  it on `pushes` — push proven in BOTH roles.
+- **Concurrent server push — DONE.** `push()` sends the PUSH_PROMISE synchronously (it rides the
+  request stream, before the FIN) but writes the push-stream **body concurrently** in a child of the
+  connection scope, so a handler can push several resources without blocking its main response.
+  Safe because `QpackEncoder.encodeSection` is internally mutex-guarded (concurrent push bodies + the
+  main response share the dynamic encoder). E2E `productionServerPushesMultipleConcurrently` (3 pushes
+  for one request, all arrive; jvm + linuxX64).
 - **Push-window tune (RFC 9114 §7.2.7).** The client now re-issues MAX_PUSH_ID upward as it observes
   push ids (`currentMaxPushId`, `maybeExtendMaxPushId`, window = initial maxPushId+1), so `maxPushId`
   is a rolling-credit window rather than a hard lifetime cap. `validatePushId` checks the live max.
@@ -320,8 +326,20 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
    interop GET decoding real servers' dynamic compression.
 4. ✅ **Server push (RFC 9114 §4.6) — DONE**, and ✅ **full server role — DONE** (`withHttp3Server`;
    see "DONE — full server role" above), including ✅ **server-initiated push** (§4.6, both roles now).
-   Remaining: the Apple `reset()` + server-observed close-code follow-ups, the deferred QPACK-eviction
-   tune, concurrent (non-blocking) server push, and WebTransport Phase 2.
+   Remaining: the deferred **QPACK-eviction tune** (NEXT — see below), the Apple `reset()` +
+   server-observed close-code follow-ups, and WebTransport Phase 2.
+
+## NEXT — smarter QPACK encoder eviction (start a FRESH session here)
+
+The client + server `QpackEncoder` is deliberately conservative: it **never evicts** and references only
+**acknowledged** dynamic entries, so it is always non-blocking and correct — interop-proven against
+Cloudflare/Google. The tune is to evict old entries when the table is full and reference newer ones
+(optionally allowing blocking), for better compression. This is **correctness-critical**, not minor:
+a subtle bug = decode failures / `QPACK_DECOMPRESSION_FAILED` against real peers. Do it as its own
+adversarially-tested effort — RIC/Known-Received-Count accounting, draining references before eviction,
+eviction-vs-blocked-stream interaction. Encoder is `QpackEncoder.kt` (internally `mutex`-guarded;
+`encodeSection`/`processDecoderInstruction`). Validate against the existing dynamic-QPACK loopback +
+the live interop GET, and add eviction-specific tests (table churn forcing eviction, then re-reference).
    (Encoder strategy note: the client encoder is deliberately conservative — never evicts, references
    only acknowledged entries — correct but not maximally compressing; a smarter strategy is a future tune.)
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under

--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -309,9 +309,28 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
 - **Apple/Android CI tests.** `:socket-http3:testDebugUnitTest` added to build-linux.yaml (Android unit
   — codec/scripted + skip-guarded interop, validated locally) and `:socket-http3:macosArm64Test` to
   build-apple.yaml.
-- **Deliberately deferred — smarter QPACK encoder eviction/blocking.** NOT minor: correctness-critical
-  vs. the current correct-and-interop-proven never-evict strategy. Do it as its own adversarially-tested
-  effort, not a tail-end bundle.
+- **QPACK encoder eviction tune — DONE (eviction, still non-blocking).** The encoder is no longer
+  never-evict: a full table now evicts its oldest entries to admit new ones, so it keeps churning as
+  headers evolve instead of freezing once full. Correctness via **reference counting** — `entryRefCount`
+  (absolute index → #outstanding sections referencing it, plus the section being built) and
+  `QpackDynamicTable.insertIfEvictable(predicate)`, which evicts oldest-first **only** when every victim
+  is unreferenced (RFC 9204 §2.1.3); the decoder evicts in lockstep, so a referenced entry is never
+  evicted out from under an in-flight section. Section Acknowledgment / Stream Cancellation release a
+  section's pins. The **non-blocking invariant is preserved** — still references only acknowledged
+  (`< knownReceivedCount`) live entries, so QPACK_BLOCKED_STREAMS stays 0 and there is no
+  eviction-vs-blocked-stream interaction. Adversarial tests: `QpackDynamicTableTests` (predicate-gated
+  eviction) + `QpackEncoderTests` (`tableChurnsViaEvictionAndReReferencesPostEvictionEntry`,
+  `inFlightSectionPreventsEvictionOfItsReferencedEntry`, `streamCancellationReleasesPinnedEntryForEviction`).
+  Green jvm + linuxX64; existing dynamic-QPACK loopback unchanged.
+  **Third-party interop validated.** `Http3DockerInteropTests` drives 64 evicting requests against a real
+  **aioquic/lsqpack** server (`socket-http3/docker-interop/`, `run-server.sh`) on `127.0.0.1` loopback —
+  a *foreign* QPACK decoder accepts our evicting encoder stream end-to-end (passed jvm + linuxX64, at both
+  the default 4096 and a thrash-the-table 256-octet capacity). Skip-on-unreachable like the public interop
+  test (never flaky-fails; fails only on a post-handshake QPACK regression). Not in CI by default — needs a
+  Docker sidecar; see `docker-interop/README.md`. (toxiproxy can't help — it's TCP-only, QUIC is UDP;
+  netem can layer reorder/loss on the container veth.)
+  *Still deferred:* reference-the-newest + **blocking** encoding (Duplicate of draining entries,
+  RIC > Known Received Count) — a further compression tune that would engage QPACK_BLOCKED_STREAMS.
 
 ## NEXT (start here)
 
@@ -329,19 +348,19 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
    Remaining: the deferred **QPACK-eviction tune** (NEXT — see below), the Apple `reset()` +
    server-observed close-code follow-ups, and WebTransport Phase 2.
 
-## NEXT — smarter QPACK encoder eviction (start a FRESH session here)
+## ✅ DONE — QPACK encoder eviction tune (see the bullet above)
 
-The client + server `QpackEncoder` is deliberately conservative: it **never evicts** and references only
-**acknowledged** dynamic entries, so it is always non-blocking and correct — interop-proven against
-Cloudflare/Google. The tune is to evict old entries when the table is full and reference newer ones
-(optionally allowing blocking), for better compression. This is **correctness-critical**, not minor:
-a subtle bug = decode failures / `QPACK_DECOMPRESSION_FAILED` against real peers. Do it as its own
-adversarially-tested effort — RIC/Known-Received-Count accounting, draining references before eviction,
-eviction-vs-blocked-stream interaction. Encoder is `QpackEncoder.kt` (internally `mutex`-guarded;
-`encodeSection`/`processDecoderInstruction`). Validate against the existing dynamic-QPACK loopback +
-the live interop GET, and add eviction-specific tests (table churn forcing eviction, then re-reference).
-   (Encoder strategy note: the client encoder is deliberately conservative — never evicts, references
-   only acknowledged entries — correct but not maximally compressing; a smarter strategy is a future tune.)
+The `QpackEncoder` now **evicts** (reference-counted, eviction-safe) while keeping the non-blocking
+invariant — `entryRefCount` + `QpackDynamicTable.insertIfEvictable`. Validated by the dynamic-QPACK
+loopback + new adversarial eviction tests (jvm + linuxX64). See the "QPACK encoder eviction tune — DONE"
+bullet under "full server role" above for the full description.
+
+**Still open — reference-the-newest + blocking encoder (a FRESH session).** The remaining compression
+tune: reference *unacknowledged* entries (RIC > Known Received Count) and Duplicate entries close to
+eviction (RFC 9204 §2.1.3 draining), which engages **QPACK_BLOCKED_STREAMS** (currently advertised 0).
+That is the part with eviction-vs-blocked-stream interaction; do it adversarially-tested, validating
+against the live interop GET. Encoder is `QpackEncoder.kt` (`mutex`-guarded;
+`encodeSection`/`processDecoderInstruction`).
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under
    `if (isMacOS)`); verify on a macOS runner / CI. Optionally run Apple/Android *tests* in their CI workflows.
 6. **WebTransport** (Phase 2): RFC 9220 Extended CONNECT (gate on `peerSettings().enableConnectProtocol`)

--- a/socket-http3/docker-interop/Dockerfile
+++ b/socket-http3/docker-interop/Dockerfile
@@ -1,0 +1,19 @@
+# Third-party HTTP/3 server (aioquic + lsqpack) for QPACK eviction interop testing.
+# See server.py for the rationale; run via run-server.sh.
+FROM python:3.12-slim
+
+# aioquic pulls in `cryptography` (used for the self-signed cert) and the lsqpack QPACK codec.
+RUN pip install --no-cache-dir "aioquic>=1.0.0"
+
+WORKDIR /app
+COPY server.py .
+
+# QUIC is UDP. Publish 4433/udp when running (see run-server.sh).
+EXPOSE 4433/udp
+
+ENV HTTP3_HOST=0.0.0.0 \
+    HTTP3_PORT=4433 \
+    QPACK_MAX_TABLE_CAPACITY=4096 \
+    QPACK_BLOCKED_STREAMS=16
+
+CMD ["python", "server.py"]

--- a/socket-http3/docker-interop/README.md
+++ b/socket-http3/docker-interop/README.md
@@ -1,0 +1,51 @@
+# HTTP/3 QPACK interop server (aioquic)
+
+A minimal third-party HTTP/3 server — [aioquic](https://github.com/aiortc/aioquic), which decodes QPACK
+with **lsqpack** — used to validate our client's QPACK encoder (including the **dynamic-table eviction
+tune**) against an *independent* implementation, deterministically and offline.
+
+## Why
+
+The in-process loopback suite round-trips our encoder through *our own* decoder, so a bug symmetric
+across both halves could hide. A foreign decoder can't be wrong the same way: if our evicting encoder
+ever references an entry the peer has evicted (RFC 9204 §2.1.3 violation), lsqpack raises a decompression
+/ decoder-stream error and the connection dies — failing the test. Running on `127.0.0.1` loopback also
+avoids the UDP/443 egress flakiness that makes the public-endpoint interop test skip on WSL2/CI.
+
+## Run it
+
+```bash
+./run-server.sh                              # build + run on udp/4433 (foreground)
+QPACK_MAX_TABLE_CAPACITY=256 ./run-server.sh # tiny table → eviction on nearly every request
+./run-server.sh stop                         # stop + remove the container
+```
+
+Then, in another shell:
+
+```bash
+./gradlew :socket-http3:jvmTest      --tests '*Http3DockerInteropTests*'
+./gradlew :socket-http3:linuxX64Test --tests '*Http3DockerInteropTests*'
+```
+
+`Http3DockerInteropTests` drives 64 requests on one connection, each with a distinct ~220-octet custom
+header, to push the encoder's dynamic table past capacity so it evicts, re-references, and re-inserts.
+The server echoes every `x-*` request header back as `echo-x-*`; the test asserts each echo matches —
+proving lsqpack decoded our evicting encoder stream the whole way through.
+
+**The test skips itself (never fails) when the server isn't reachable on `127.0.0.1:4433`,** so it is safe
+to leave in the suite. It only *fails* on a post-handshake error — i.e. a real QPACK regression.
+
+## Knobs (env vars)
+
+| Var | Default | Effect |
+|-----|---------|--------|
+| `QPACK_MAX_TABLE_CAPACITY` | `4096` | server-advertised QPACK table ceiling; our encoder is bounded by it, so a smaller value forces eviction sooner |
+| `QPACK_BLOCKED_STREAMS` | `16` | server-advertised QPACK_BLOCKED_STREAMS |
+| `HTTP3_PORT` | `4433` | UDP listen port |
+
+## CI
+
+Not wired into CI by default — it needs a Docker sidecar. To enable, run the container as a service step
+(publish `4433/udp`) before the Gradle test job; the test auto-skips if it's absent, so adding it is
+non-breaking. netem can be layered on the container's veth (`tc qdisc add dev … netem delay/loss/reorder`)
+to add packet reordering between the QPACK encoder stream and the request streams.

--- a/socket-http3/docker-interop/run-server.sh
+++ b/socket-http3/docker-interop/run-server.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build + run the aioquic HTTP/3 echo server for the gated Http3DockerInteropTests.
+#
+#   ./run-server.sh            # build (if needed) and run in the foreground on udp/4433
+#   ./run-server.sh stop       # stop + remove the container
+#   QPACK_MAX_TABLE_CAPACITY=256 ./run-server.sh   # force eviction with a smaller table
+#
+# Then, in another shell: ./gradlew :socket-http3:jvmTest --tests '*Http3DockerInteropTests*'
+# The test skips itself if the server is not reachable on 127.0.0.1:4433, so it never flaky-fails CI.
+set -euo pipefail
+
+IMAGE="socket-http3-interop"
+NAME="socket-http3-interop"
+PORT="${HTTP3_PORT:-4433}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${1:-}" == "stop" ]]; then
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  echo "stopped $NAME"
+  exit 0
+fi
+
+docker build -t "$IMAGE" "$DIR"
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+exec docker run --rm --name "$NAME" \
+  -p "${PORT}:4433/udp" \
+  -e "QPACK_MAX_TABLE_CAPACITY=${QPACK_MAX_TABLE_CAPACITY:-4096}" \
+  -e "QPACK_BLOCKED_STREAMS=${QPACK_BLOCKED_STREAMS:-16}" \
+  "$IMAGE"

--- a/socket-http3/docker-interop/server.py
+++ b/socket-http3/docker-interop/server.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Minimal third-party HTTP/3 server (aioquic / lsqpack) for QPACK interop testing.
+
+Why this exists: our Kotlin client's QPACK *encoder* (incl. the dynamic-table eviction tune) is only
+truly validated when an INDEPENDENT QPACK *decoder* accepts its output. aioquic decodes with lsqpack —
+a different implementation from ours — so if our eviction accounting drifts from the wire contract, this
+server's decoder raises QPACK_DECOMPRESSION_FAILED / a decoder-stream error and tears the connection
+down, failing the test. Running on localhost over loopback also sidesteps the UDP/443 egress flakiness
+that makes the public-endpoint interop test skip on WSL2/CI.
+
+Behaviour: every request gets a 200 whose response headers echo each request header named `x-*` back as
+`echo-<name>: <value>`, plus a tiny `ok` body. The client drives a churn of distinct large headers to
+force its encoder's dynamic table to fill, evict, and re-reference, then asserts every echo round-trips.
+
+The server advertises a QPACK dynamic table (default 4096; override with QPACK_MAX_TABLE_CAPACITY) so the
+client's encoder uses (and evicts from) its dynamic table. Self-signed cert is generated on first run —
+the client connects with verifyPeer=false, so the cert identity does not matter.
+"""
+import asyncio
+import datetime
+import os
+import pathlib
+
+from aioquic.asyncio import serve
+from aioquic.asyncio.protocol import QuicConnectionProtocol
+from aioquic.h3.connection import H3Connection
+from aioquic.h3.events import DataReceived, HeadersReceived
+from aioquic.quic.configuration import QuicConfiguration
+from aioquic.quic.events import ProtocolNegotiated, QuicEvent
+
+HOST = os.environ.get("HTTP3_HOST", "0.0.0.0")
+PORT = int(os.environ.get("HTTP3_PORT", "4433"))
+# Smaller capacity forces eviction with fewer/lighter requests; 4096 is the default both ends pick.
+MAX_TABLE_CAPACITY = int(os.environ.get("QPACK_MAX_TABLE_CAPACITY", "4096"))
+BLOCKED_STREAMS = int(os.environ.get("QPACK_BLOCKED_STREAMS", "16"))
+
+CERT = pathlib.Path(__file__).with_name("cert.pem")
+KEY = pathlib.Path(__file__).with_name("key.pem")
+
+
+def ensure_cert() -> None:
+    if CERT.exists() and KEY.exists():
+        return
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName("localhost")]), critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    KEY.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    CERT.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
+class H3EchoProtocol(QuicConnectionProtocol):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._http: H3Connection | None = None
+        self._request_headers: dict[int, list[tuple[bytes, bytes]]] = {}
+        self._answered: set[int] = set()
+
+    def quic_event_received(self, event: QuicEvent) -> None:
+        if isinstance(event, ProtocolNegotiated) and event.alpn_protocol == "h3":
+            # _max_table_capacity/_blocked_streams are read by H3Connection._init_connection() when it
+            # emits SETTINGS, so set them on the instance the constructor path consults.
+            H3Connection._max_table_capacity = MAX_TABLE_CAPACITY
+            H3Connection._blocked_streams = BLOCKED_STREAMS
+            self._http = H3Connection(self._quic)
+        if self._http is not None:
+            for http_event in self._http.handle_event(event):
+                self._handle_http_event(http_event)
+
+    def _handle_http_event(self, event) -> None:
+        if isinstance(event, HeadersReceived):
+            self._request_headers[event.stream_id] = event.headers
+            if event.stream_ended:
+                self._respond(event.stream_id)
+        elif isinstance(event, DataReceived) and event.stream_ended:
+            self._respond(event.stream_id)
+
+    def _respond(self, stream_id: int) -> None:
+        if stream_id in self._answered:
+            return
+        self._answered.add(stream_id)
+        request = self._request_headers.get(stream_id, [])
+        response = [(b":status", b"200")]
+        for name, value in request:
+            if name.startswith(b"x-"):
+                response.append((b"echo-" + name, value))
+        assert self._http is not None
+        self._http.send_headers(stream_id, response, end_stream=False)
+        self._http.send_data(stream_id, b"ok", end_stream=True)
+        self.transmit()
+
+
+async def main() -> None:
+    ensure_cert()
+    configuration = QuicConfiguration(is_client=False, alpn_protocols=["h3"], max_datagram_frame_size=65536)
+    configuration.load_cert_chain(str(CERT), str(KEY))
+    await serve(HOST, PORT, configuration=configuration, create_protocol=H3EchoProtocol)
+    print(
+        f"h3 echo server on udp/{PORT} (QPACK max_table_capacity={MAX_TABLE_CAPACITY}, "
+        f"blocked_streams={BLOCKED_STREAMS})",
+        flush=True,
+    )
+    await asyncio.Future()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
@@ -98,6 +98,12 @@ class Http3Connection private constructor(
     private val pushChannel = Channel<Http3ServerPush>(Channel.UNLIMITED)
     private val controlStreamWriteMutex = Mutex()
 
+    // The live push-id limit (RFC 9114 §7.2.7). Starts at the advertised maxPushId and is re-issued
+    // upward (never down) as pushes are observed, so the server keeps a rolling window of credit
+    // rather than a hard lifetime cap of maxPushId+1 pushes. -1 when push is disabled. Guarded by pushMutex.
+    @Volatile
+    private var currentMaxPushId: Long = maxPushId
+
     private class PushEntry {
         val responseDeferred = CompletableDeferred<Http3Response>()
         var promised = false
@@ -702,18 +708,38 @@ class Http3Connection private constructor(
      * which path — request stream or push stream — detected it.
      */
     private suspend fun validatePushId(pushId: Long) {
-        if (maxPushId in 0..Long.MAX_VALUE && pushId in 0..maxPushId) return
+        if (maxPushId >= 0 && pushId in 0..currentMaxPushId) return
         val error =
             Http3StreamException(
                 if (maxPushId < 0) {
                     "received a push but MAX_PUSH_ID was never sent (push disabled)"
                 } else {
-                    "push id $pushId exceeds the maximum advertised ($maxPushId)"
+                    "push id $pushId exceeds the current maximum ($currentMaxPushId)"
                 },
                 Http3ErrorCode.ID_ERROR,
             )
         abortConnection(error)
         throw error
+    }
+
+    /**
+     * Keep a rolling push window open (RFC 9114 §7.2.7): once an observed push id consumes more than
+     * half the credit above the current maximum, re-issue MAX_PUSH_ID to `observed + window` (window =
+     * the initially advertised maxPushId + 1). MAX_PUSH_ID only ever increases, as the RFC requires.
+     * No-op when push is disabled. Call after [validatePushId], outside any pushMutex section.
+     */
+    private suspend fun maybeExtendMaxPushId(observedPushId: Long) {
+        if (maxPushId < 0) return
+        val window = maxPushId + 1
+        val newMax =
+            pushMutex.withLock {
+                if (currentMaxPushId - observedPushId > window / 2) return // ample headroom remains
+                val target = observedPushId + window
+                if (target <= currentMaxPushId) return
+                currentMaxPushId = target
+                target
+            }
+        writeControlFrame(Http3Frame.MaxPushId(newMax))
     }
 
     /**
@@ -727,6 +753,7 @@ class Http3Connection private constructor(
         requestStreamId: Long,
     ) {
         validatePushId(frame.pushId)
+        maybeExtendMaxPushId(frame.pushId)
         val promised = decodePromisedRequest(frame.encodedFieldSection, requestStreamId)
         pushMutex.withLock {
             val entry = pushEntries.getOrPut(frame.pushId) { PushEntry() }
@@ -774,6 +801,7 @@ class Http3Connection private constructor(
         try {
             val pushId = Http3StreamReader(stream, processor).nextVarInt(options.readTimeout)
             validatePushId(pushId)
+            maybeExtendMaxPushId(pushId)
             entry = pushMutex.withLock { pushEntries.getOrPut(pushId) { PushEntry() }.also { it.pushStream = stream } }
             if (entry.cancelled) {
                 resetStreamQuietly(stream, Http3ErrorCode.REQUEST_CANCELLED)

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -229,9 +229,16 @@ class Http3ServerConnection internal constructor(
     /**
      * Push a resource for the request on [requestStream]: allocate a Push ID within the client's
      * MAX_PUSH_ID limit, send a PUSH_PROMISE (the promised request fields) on the request stream, then
-     * open a push stream (`0x01` + Push ID) and run [respond] to write the pushed response on it. Returns
-     * false — without sending anything — when push is disabled or out of credit. Sent synchronously: the
-     * pushed response is fully written before this returns, so call it before finishing the main response.
+     * write the pushed response on a fresh push stream (`0x01` + Push ID). Returns false — without
+     * sending anything — when push is disabled or out of credit.
+     *
+     * The PUSH_PROMISE is sent synchronously (it rides the request stream, so it must precede that
+     * stream's FIN and keep promise order), but the **push stream's body is written concurrently** in a
+     * child coroutine: this returns as soon as the promise is on the wire, so a handler can push several
+     * resources and write its main response without blocking on the pushed bodies. The push-write
+     * inherits the connection scope, so it is cancelled if the connection closes first; a failure on it
+     * never takes the connection down. [QpackEncoder.encodeSection] is internally serialized, so the
+     * concurrent push bodies and the main response share the dynamic encoder safely.
      */
     private suspend fun pushResource(
         requestStream: QuicByteStream,
@@ -263,12 +270,20 @@ class Http3ServerConnection internal constructor(
         }
         section.freeIfNeeded()
 
-        val pushStream = scope.openUniStream()
-        writePushStreamHeader(pushStream, pushId)
-        val pushResponse =
-            Http3ServerResponse(pushStream, pool, options, pushStream.streamId.id) { fields, sid -> encodeSection(fields, sid) }
-        pushResponse.respond()
-        pushResponse.finish()
+        scope.launch {
+            try {
+                val pushStream = scope.openUniStream()
+                writePushStreamHeader(pushStream, pushId)
+                val pushResponse =
+                    Http3ServerResponse(pushStream, pool, options, pushStream.streamId.id) { fields, sid -> encodeSection(fields, sid) }
+                pushResponse.respond()
+                pushResponse.finish()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                // The pushed response failed (peer STOP_SENDING, connection gone) — the connection survives.
+            }
+        }
         return true
     }
 

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -1,0 +1,298 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.pool.ThreadingMode
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.QuicByteStream
+import com.ditchoom.socket.quic.QuicScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
+
+/**
+ * The **server** side of an HTTP/3 connection (RFC 9114 §3.2) — the production counterpart to the
+ * client [Http3Connection], run once per accepted QUIC connection by [withHttp3Server].
+ *
+ * [serve] opens the server control unidirectional stream (its first frame is the server SETTINGS),
+ * optionally the QPACK encoder/decoder streams when [qpackCapacity] > 0, then routes peer-initiated
+ * streams: the client control stream's SETTINGS sizes the QPACK encoder; the client QPACK streams
+ * drive the decoder/encoder; and each client **bidirectional** stream is one request — decoded into an
+ * [Http3ServerRequest], paired with an [Http3ServerResponse], and handed to [onRequest]. After the
+ * handler returns, any unread request body is drained and the response is FIN'd.
+ *
+ * With [qpackCapacity] > 0 the server speaks dynamic QPACK (RFC 9204) in both directions: it decodes
+ * requests through a [QpackDecoder] fed by the client's encoder stream and compresses responses through
+ * a [QpackEncoder]. With capacity 0 (default) it stays static-table-only, which is always legal.
+ *
+ * This server does not initiate server push (RFC 9114 §4.6) — that is the inverse of the client push
+ * support and a tracked follow-up; the client push API in [Http3Connection.pushes] is independent.
+ */
+class Http3ServerConnection internal constructor(
+    private val scope: QuicScope,
+    private val options: ConnectionOptions,
+    private val qpackCapacity: Long,
+    private val onRequest: suspend Http3ServerExchange.() -> Unit,
+) {
+    // MultiThreaded: per-stream handler coroutines allocate from this pool concurrently.
+    private val pool = BufferPool(threadingMode = ThreadingMode.MultiThreaded, factory = options.bufferFactory)
+
+    private val serverDecoder: QpackDecoder? =
+        if (qpackCapacity > 0) QpackDecoder(qpackCapacity) { writeQpackDecoderInstruction(it) } else null
+
+    @Volatile
+    private var serverEncoder: QpackEncoder? = null
+    private var qpackEncoderStream: QuicByteStream? = null
+    private var qpackDecoderStream: QuicByteStream? = null
+    private val encoderStreamWriteMutex = Mutex()
+    private val decoderStreamWriteMutex = Mutex()
+
+    /** Run the HTTP/3 server role over [scope] (one accepted QUIC connection). Returns when it closes. */
+    suspend fun serve() {
+        writeControlStreamHeader(scope.openUniStream())
+        if (qpackCapacity > 0) {
+            qpackEncoderStream = scope.openUniStream().also { writeStreamType(it, Http3StreamType.QPACK_ENCODER) }
+            qpackDecoderStream = scope.openUniStream().also { writeStreamType(it, Http3StreamType.QPACK_DECODER) }
+        }
+        scope.streams().collect { stream ->
+            scope.launch {
+                try {
+                    if (stream.streamId.isUnidirectional) handleUniStream(stream) else handleRequest(stream)
+                } catch (_: Http3StreamException) {
+                    // A single stream failing must not take the connection down.
+                }
+            }
+        }
+    }
+
+    private suspend fun handleUniStream(stream: QuicByteStream) {
+        val processor = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            when (Http3StreamReader(stream, processor).nextVarInt()) {
+                Http3StreamType.CONTROL -> handleControl(Http3StreamReader(stream, processor))
+                Http3StreamType.QPACK_ENCODER ->
+                    serverDecoder?.let { dec ->
+                        val reader = QpackInstructionReader.encoder(stream, processor, pool)
+                        while (true) dec.applyEncoderInstruction(reader.next(options.readTimeout) ?: break)
+                    } ?: drain(stream)
+                Http3StreamType.QPACK_DECODER ->
+                    if (serverDecoder != null) {
+                        val reader = QpackInstructionReader.decoder(stream, processor)
+                        while (true) serverEncoder?.processDecoderInstruction(reader.next(options.readTimeout) ?: break)
+                    } else {
+                        drain(stream)
+                    }
+                else -> drain(stream)
+            }
+        } finally {
+            processor.release()
+        }
+    }
+
+    /** Read the client control stream: its SETTINGS sizes our encoder; ignore subsequent frames. */
+    private suspend fun handleControl(reader: Http3StreamReader) {
+        val first = reader.nextFrame()
+        if (qpackCapacity > 0 && first is Http3Frame.Settings) {
+            val clientMax = Http3Settings(first.entries).qpackMaxTableCapacity
+            if (clientMax > 0) {
+                serverEncoder =
+                    QpackEncoder(clientMax) { writeQpackEncoderInstruction(it) }
+                        .also { it.setCapacity(minOf(qpackCapacity, clientMax)) }
+            }
+        }
+        while (reader.nextFrame() != null) { /* accept + ignore */ }
+    }
+
+    /** Read one request off a client bidi [stream], run [onRequest], then drain the body + FIN. */
+    private suspend fun handleRequest(stream: QuicByteStream) {
+        val reader = Http3StreamReader.create(stream, pool)
+        try {
+            val first =
+                reader.nextFrame(options.readTimeout)
+                    ?: throw Http3StreamException("request stream ended before a HEADERS frame", Http3ErrorCode.REQUEST_INCOMPLETE)
+            if (first !is Http3Frame.Headers) {
+                throw Http3StreamException(
+                    "request's first frame was ${first::class.simpleName}, expected HEADERS",
+                    Http3ErrorCode.FRAME_UNEXPECTED,
+                )
+            }
+            val streamId = stream.streamId.id
+            val fields = decodeSection(first.encodedFieldSection, streamId)
+            val request =
+                Http3ServerRequest(
+                    method = pseudo(fields, ":method"),
+                    scheme = pseudo(fields, ":scheme"),
+                    authority = pseudo(fields, ":authority"),
+                    path = pseudo(fields, ":path"),
+                    headers = fields.filterNot { it.name.startsWith(":") },
+                    reader = reader,
+                    pool = pool,
+                    readTimeout = options.readTimeout,
+                    decodeFields = { decodeSection(it, streamId) },
+                )
+            val response =
+                Http3ServerResponse(stream, pool, options, streamId) { sectionFields, sid -> encodeSection(sectionFields, sid) }
+            try {
+                Http3ServerExchange(request, response).onRequest()
+            } finally {
+                runCatching { request.drain() }
+                runCatching { response.finish() }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Http3StreamException) {
+            reactToRequestError(stream, e)
+            throw e
+        } finally {
+            reader.release()
+        }
+    }
+
+    /**
+     * React to a violation while reading a request (RFC 9114 §8): a malformed *message*
+     * ([Http3ErrorCode.MESSAGE_ERROR]) resets just this stream; an invalid frame *sequence*
+     * ([Http3ErrorCode.FRAME_UNEXPECTED]) is a connection error, so the whole connection is closed
+     * with the code. Best-effort — a failure because the stream/connection is already gone is ignored.
+     */
+    private suspend fun reactToRequestError(
+        stream: QuicByteStream,
+        error: Http3StreamException,
+    ) {
+        try {
+            when (error.errorCode) {
+                Http3ErrorCode.FRAME_UNEXPECTED -> scope.closeWithError(error.errorCode)
+                else -> stream.reset(error.errorCode)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // Already torn down.
+        }
+    }
+
+    /** Encode a field section through the dynamic encoder (when present) or the static codec. */
+    private suspend fun encodeSection(
+        fields: List<QpackHeaderField>,
+        streamId: Long,
+    ): ReadBuffer {
+        val encoder = serverEncoder
+        return if (encoder != null) {
+            encoder.encodeSection(fields, streamId, pool)
+        } else {
+            val size = (QpackFieldSectionCodec.wireSize(fields, EncodeContext.Empty) as WireSize.Exact).bytes
+            pool.allocate(size).also {
+                QpackFieldSectionCodec.encode(it, fields, EncodeContext.Empty)
+                it.resetForRead()
+            }
+        }
+    }
+
+    /** Decode a field section through the dynamic decoder (when present) or the static codec. */
+    private suspend fun decodeSection(
+        section: ReadBuffer,
+        streamId: Long,
+    ): List<QpackHeaderField> {
+        val decoder = serverDecoder
+        return if (decoder != null) {
+            decoder.decodeSection(section, streamId, pool)
+        } else {
+            QpackFieldSectionCodec.decode(section, DecodeContext.Empty.with(QpackScratchPoolKey, pool))
+        }
+    }
+
+    /** Control stream: the type prefix `0x00` immediately followed by the SETTINGS frame. */
+    private suspend fun writeControlStreamHeader(control: QuicByteStream) {
+        val settings =
+            Http3Frame.Settings(
+                listOf(
+                    Http3Setting(Http3SettingId.QPACK_MAX_TABLE_CAPACITY, qpackCapacity),
+                    Http3Setting(Http3SettingId.QPACK_BLOCKED_STREAMS, if (qpackCapacity > 0) BLOCKED_STREAMS else 0L),
+                ),
+            )
+        val frameSize = (Http3FrameCodec.wireSize(settings, EncodeContext.Empty) as WireSize.Exact).bytes
+        val buffer = pool.allocate(VarIntCodec.encodedLength(Http3StreamType.CONTROL) + frameSize)
+        try {
+            VarIntCodec.encode(buffer, Http3StreamType.CONTROL, EncodeContext.Empty)
+            Http3FrameCodec.encode(buffer, settings, EncodeContext.Empty)
+            buffer.resetForRead()
+            control.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    private suspend fun writeStreamType(
+        stream: QuicByteStream,
+        type: Long,
+    ) {
+        val buffer = pool.allocate(VarIntCodec.encodedLength(type))
+        try {
+            VarIntCodec.encode(buffer, type, EncodeContext.Empty)
+            buffer.resetForRead()
+            stream.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    private suspend fun writeQpackEncoderInstruction(instruction: QpackEncoderInstruction) {
+        val stream = qpackEncoderStream ?: return
+        val capacity =
+            when (instruction) {
+                is QpackEncoderInstruction.InsertWithNameRef -> 32 + qpackUtf8ByteLength(instruction.value)
+                is QpackEncoderInstruction.InsertWithLiteralName ->
+                    32 + qpackUtf8ByteLength(instruction.name) + qpackUtf8ByteLength(instruction.value)
+                else -> 32
+            }
+        val buffer = pool.allocate(capacity)
+        try {
+            QpackEncoderInstructionCodec.encode(buffer, instruction)
+            buffer.resetForRead()
+            encoderStreamWriteMutex.withLock { stream.write(buffer, options.writeTimeout) }
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    private suspend fun writeQpackDecoderInstruction(instruction: QpackDecoderInstruction) {
+        val stream = qpackDecoderStream ?: return
+        val buffer = pool.allocate(16)
+        try {
+            QpackDecoderInstructionCodec.encode(buffer, instruction)
+            buffer.resetForRead()
+            decoderStreamWriteMutex.withLock { stream.write(buffer, options.writeTimeout) }
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    private suspend fun drain(stream: QuicByteStream) {
+        while (true) {
+            when (val result = stream.read(options.readTimeout)) {
+                is ReadResult.Data -> result.buffer.freeIfNeeded()
+                ReadResult.End, ReadResult.Reset -> return
+            }
+        }
+    }
+
+    private fun pseudo(
+        fields: List<QpackHeaderField>,
+        name: String,
+    ): String =
+        fields.firstOrNull { it.name == name }?.value
+            ?: throw Http3StreamException("request HEADERS missing the $name pseudo-header", Http3ErrorCode.MESSAGE_ERROR)
+
+    companion object {
+        /** Blocked-streams we permit the client's encoder to create when dynamic QPACK is on. */
+        private const val BLOCKED_STREAMS: Long = 100
+    }
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -56,6 +56,14 @@ class Http3ServerConnection internal constructor(
     private val encoderStreamWriteMutex = Mutex()
     private val decoderStreamWriteMutex = Mutex()
 
+    // Server-push state (RFC 9114 §4.6). clientMaxPushId is the largest Push ID the client will accept,
+    // learned from its MAX_PUSH_ID frame(s) on the control stream (-1 = push not enabled). The server
+    // allocates push ids 0,1,… up to that limit. Guarded by pushIdMutex.
+    @Volatile
+    private var clientMaxPushId: Long = -1
+    private val pushIdMutex = Mutex()
+    private var nextPushId: Long = 0
+
     /** Run the HTTP/3 server role over [scope] (one accepted QUIC connection). Returns when it closes. */
     suspend fun serve() {
         writeControlStreamHeader(scope.openUniStream())
@@ -109,7 +117,12 @@ class Http3ServerConnection internal constructor(
                         .also { it.setCapacity(minOf(qpackCapacity, clientMax)) }
             }
         }
-        while (reader.nextFrame() != null) { /* accept + ignore */ }
+        // Capture MAX_PUSH_ID so the server knows whether (and how much) it may push (RFC 9114 §7.2.7);
+        // it is non-decreasing, so just take the latest. Other control frames are accepted + ignored.
+        while (true) {
+            val frame = reader.nextFrame() ?: break
+            if (frame is Http3Frame.MaxPushId) clientMaxPushId = frame.pushId
+        }
     }
 
     /** Read one request off a client bidi [stream], run [onRequest], then drain the body + FIN. */
@@ -141,8 +154,10 @@ class Http3ServerConnection internal constructor(
                 )
             val response =
                 Http3ServerResponse(stream, pool, options, streamId) { sectionFields, sid -> encodeSection(sectionFields, sid) }
+            val exchange =
+                Http3ServerExchange(request, response) { spec, respond -> pushResource(stream, spec, respond) }
             try {
-                Http3ServerExchange(request, response).onRequest()
+                exchange.onRequest()
             } finally {
                 runCatching { request.drain() }
                 runCatching { response.finish() }
@@ -206,6 +221,86 @@ class Http3ServerConnection internal constructor(
             decoder.decodeSection(section, streamId, pool)
         } else {
             QpackFieldSectionCodec.decode(section, DecodeContext.Empty.with(QpackScratchPoolKey, pool))
+        }
+    }
+
+    // --- Server push (RFC 9114 §4.6), driven by Http3ServerExchange.push ---
+
+    /**
+     * Push a resource for the request on [requestStream]: allocate a Push ID within the client's
+     * MAX_PUSH_ID limit, send a PUSH_PROMISE (the promised request fields) on the request stream, then
+     * open a push stream (`0x01` + Push ID) and run [respond] to write the pushed response on it. Returns
+     * false — without sending anything — when push is disabled or out of credit. Sent synchronously: the
+     * pushed response is fully written before this returns, so call it before finishing the main response.
+     */
+    private suspend fun pushResource(
+        requestStream: QuicByteStream,
+        spec: PushPromiseSpec,
+        respond: suspend Http3ServerResponse.() -> Unit,
+    ): Boolean {
+        val pushId =
+            pushIdMutex.withLock {
+                if (clientMaxPushId < 0 || nextPushId > clientMaxPushId) return false
+                nextPushId++
+            }
+        val promiseFields =
+            buildList {
+                add(QpackHeaderField(":method", spec.method))
+                add(QpackHeaderField(":scheme", spec.scheme))
+                add(QpackHeaderField(":authority", spec.authority))
+                add(QpackHeaderField(":path", spec.path))
+                addAll(spec.promisedHeaders)
+            }
+        // PUSH_PROMISE rides the request stream; its field section uses that stream's QPACK context.
+        val section = encodeSection(promiseFields, requestStream.streamId.id)
+        try {
+            writeFrame(requestStream, Http3Frame.PushPromise(pushId, section))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            section.freeIfNeeded()
+            return false // request stream already finished/reset — nothing was promised
+        }
+        section.freeIfNeeded()
+
+        val pushStream = scope.openUniStream()
+        writePushStreamHeader(pushStream, pushId)
+        val pushResponse =
+            Http3ServerResponse(pushStream, pool, options, pushStream.streamId.id) { fields, sid -> encodeSection(fields, sid) }
+        pushResponse.respond()
+        pushResponse.finish()
+        return true
+    }
+
+    /** Push stream header (RFC 9114 §4.6): the `0x01` stream-type prefix followed by the Push ID. */
+    private suspend fun writePushStreamHeader(
+        stream: QuicByteStream,
+        pushId: Long,
+    ) {
+        val buffer = pool.allocate(VarIntCodec.encodedLength(Http3StreamType.PUSH) + VarIntCodec.encodedLength(pushId))
+        try {
+            VarIntCodec.encode(buffer, Http3StreamType.PUSH, EncodeContext.Empty)
+            VarIntCodec.encode(buffer, pushId, EncodeContext.Empty)
+            buffer.resetForRead()
+            stream.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    /** Encode [frame] into a pooled buffer and write the whole frame to [stream]. */
+    private suspend fun writeFrame(
+        stream: QuicByteStream,
+        frame: Http3Frame,
+    ) {
+        val size = (Http3FrameCodec.wireSize(frame, EncodeContext.Empty) as WireSize.Exact).bytes
+        val buffer = pool.allocate(size)
+        try {
+            Http3FrameCodec.encode(buffer, frame, EncodeContext.Empty)
+            buffer.resetForRead()
+            stream.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
         }
     }
 

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerRequest.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerRequest.kt
@@ -1,0 +1,100 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.buffer.pool.BufferPool
+import kotlin.time.Duration
+
+/**
+ * An HTTP/3 request as seen by the **server** (RFC 9114 §4.1): the request-line pseudo-headers
+ * ([method], [scheme], [authority], [path]) and regular [headers], decoded from the request's first
+ * HEADERS frame, plus the body streamed frame-by-frame via [nextBodyChunk] (or collected whole with
+ * [readFullBody]). A trailing field section is decoded into [trailers] and ends the body.
+ *
+ * Backed by the request stream's [Http3StreamReader]: a buffer returned by [nextBodyChunk] is
+ * borrowed from the reader and only valid until the next call. The server framework releases the
+ * reader when the exchange completes.
+ */
+class Http3ServerRequest internal constructor(
+    val method: String,
+    val scheme: String,
+    val authority: String,
+    val path: String,
+    val headers: List<QpackHeaderField>,
+    private val reader: Http3StreamReader,
+    private val pool: BufferPool,
+    private val readTimeout: Duration,
+    // Decodes a trailing field section through the server's QPACK decoder (dynamic-table refs resolve).
+    private val decodeFields: suspend (ReadBuffer) -> List<QpackHeaderField>,
+) {
+    /** Trailing header fields, populated once a trailing HEADERS frame is reached (else null). */
+    var trailers: List<QpackHeaderField>? = null
+        private set
+
+    private var bodyDone = false
+
+    /**
+     * The next request-body DATA-frame payload, or null at end of body. The returned buffer is
+     * **borrowed** from the reader — read or copy it before the next call. A trailing HEADERS frame is
+     * decoded into [trailers] and ends the body (returns null); unknown frames are skipped (RFC 9114 §9).
+     */
+    suspend fun nextBodyChunk(): ReadBuffer? {
+        if (bodyDone) return null
+        while (true) {
+            when (val frame = reader.nextFrame(readTimeout)) {
+                null -> {
+                    bodyDone = true
+                    return null
+                }
+                is Http3Frame.Data -> return frame.payload
+                is Http3Frame.Headers -> {
+                    trailers = decodeFields(frame.encodedFieldSection)
+                    bodyDone = true
+                    return null
+                }
+                // Unknown/reserved frame types MUST be ignored (RFC 9114 §9).
+                is Http3Frame.Unknown -> {}
+                // Only DATA and a trailing HEADERS section are valid in a request body; anything else
+                // (SETTINGS, GOAWAY, a second leading HEADERS, …) on a request stream is H3_FRAME_UNEXPECTED.
+                else -> {
+                    bodyDone = true
+                    throw Http3StreamException(
+                        "unexpected ${frame::class.simpleName} in the request body",
+                        Http3ErrorCode.FRAME_UNEXPECTED,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Collect the entire request body into a single buffer. Each chunk is copied out of the borrowed
+     * reader buffer, so the result is independent of the reader's lifetime. The caller owns the
+     * returned buffer (release via `freeIfNeeded()`).
+     */
+    suspend fun readFullBody(): ReadBuffer {
+        val chunks = mutableListOf<ReadBuffer>()
+        var total = 0
+        while (true) {
+            val chunk = nextBodyChunk() ?: break
+            val n = chunk.remaining()
+            val copy = pool.allocate(n.coerceAtLeast(1))
+            if (n > 0) copy.write(chunk)
+            copy.resetForRead()
+            chunks += copy
+            total += n
+        }
+        val out = pool.allocate(total.coerceAtLeast(1))
+        for (chunk in chunks) {
+            if (chunk.remaining() > 0) out.write(chunk)
+            chunk.freeIfNeeded()
+        }
+        out.resetForRead()
+        return out
+    }
+
+    /** Drains any unread body so the request stream reaches its end before the response FIN. */
+    internal suspend fun drain() {
+        while (nextBodyChunk() != null) { /* discard borrowed chunks */ }
+    }
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerResponse.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerResponse.kt
@@ -117,8 +117,11 @@ class Http3ServerExchange internal constructor(
     /**
      * Initiate a server push (RFC 9114 §4.6) for [path]: send a PUSH_PROMISE on this request stream
      * and write the pushed response via [respond] on a fresh push stream. Returns `true` if the push
-     * was sent, or `false` if the client granted no (or insufficient) push credit — call it before
-     * finishing [response], since the PUSH_PROMISE rides this request stream before its FIN.
+     * was promised, or `false` if the client granted no (or insufficient) push credit.
+     *
+     * Call this before finishing [response] — the PUSH_PROMISE rides this request stream before its
+     * FIN. It returns as soon as the promise is on the wire; the pushed [respond] body is written
+     * **concurrently** on the push stream, so pushing several resources doesn't block the main response.
      *
      * [authority] and [scheme] default to the originating request's. The pushed [respond] writes a
      * normal response (`send` or streaming); the framework FINs the push stream when it returns.

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerResponse.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerResponse.kt
@@ -1,0 +1,104 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.QuicByteStream
+
+/**
+ * The response side of a server [Http3ServerExchange] (RFC 9114 §4.1). Write a response either in one
+ * shot with [send], or stream it: [sendHeaders] (the `:status` pseudo-header is added automatically),
+ * then zero or more [writeBody] DATA frames, an optional [sendTrailers], and the framework FINs the
+ * send side when the request handler returns. If the handler sends nothing, a minimal `500` is emitted.
+ */
+class Http3ServerResponse internal constructor(
+    private val stream: QuicByteStream,
+    private val pool: BufferPool,
+    private val options: ConnectionOptions,
+    private val streamId: Long,
+    // Encodes a field section through the server's QPACK (dynamic when capacity > 0, else static).
+    private val encodeSection: suspend (List<QpackHeaderField>, Long) -> ReadBuffer,
+) {
+    private var headersSent = false
+    private var finished = false
+
+    /** Send the response HEADERS frame: `:status` first (RFC 9114 §4.3.1), then [headers]. Once only. */
+    suspend fun sendHeaders(
+        status: Int,
+        headers: List<QpackHeaderField> = emptyList(),
+    ) {
+        check(!headersSent) { "response HEADERS already sent" }
+        check(!finished) { "response already finished" }
+        val fields =
+            buildList {
+                add(QpackHeaderField(":status", status.toString()))
+                addAll(headers)
+            }
+        val section = encodeSection(fields, streamId)
+        try {
+            writeFrame(Http3Frame.Headers(section))
+        } finally {
+            section.freeIfNeeded()
+        }
+        headersSent = true
+    }
+
+    /** Send one response-body DATA frame. Call [sendHeaders] first. Zero-copy; does not take ownership. */
+    suspend fun writeBody(chunk: ReadBuffer) {
+        check(headersSent) { "call sendHeaders before writeBody" }
+        check(!finished) { "response already finished" }
+        if (chunk.remaining() > 0) writeFrame(Http3Frame.Data(chunk))
+    }
+
+    /** Send a trailing field section (RFC 9114 §4.1). Ends the body; no DATA may follow. */
+    suspend fun sendTrailers(trailers: List<QpackHeaderField>) {
+        check(headersSent) { "call sendHeaders before sendTrailers" }
+        check(!finished) { "response already finished" }
+        val section = encodeSection(trailers, streamId)
+        try {
+            writeFrame(Http3Frame.Headers(section))
+        } finally {
+            section.freeIfNeeded()
+        }
+    }
+
+    /** Buffered convenience: HEADERS (`:status` + [headers]), an optional single DATA, then finish. */
+    suspend fun send(
+        status: Int,
+        headers: List<QpackHeaderField> = emptyList(),
+        body: ReadBuffer? = null,
+    ) {
+        sendHeaders(status, headers)
+        body?.let { writeBody(it) }
+        finish()
+    }
+
+    /** FIN the send side, emitting a minimal `500` first if the handler sent no HEADERS. Idempotent. */
+    internal suspend fun finish() {
+        if (finished) return
+        if (!headersSent) sendHeaders(500)
+        stream.shutdownSend()
+        finished = true
+    }
+
+    private suspend fun writeFrame(frame: Http3Frame) {
+        val size = (Http3FrameCodec.wireSize(frame, EncodeContext.Empty) as WireSize.Exact).bytes
+        val buffer = pool.allocate(size)
+        try {
+            Http3FrameCodec.encode(buffer, frame, EncodeContext.Empty)
+            buffer.resetForRead()
+            stream.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+}
+
+/** A server-side request/response pair handed to the `withHttp3Server` request handler. */
+class Http3ServerExchange internal constructor(
+    val request: Http3ServerRequest,
+    val response: Http3ServerResponse,
+)

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerResponse.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerResponse.kt
@@ -97,8 +97,38 @@ class Http3ServerResponse internal constructor(
     }
 }
 
+/** The promised request line of a server push, encoded into the PUSH_PROMISE field section. */
+internal data class PushPromiseSpec(
+    val method: String,
+    val scheme: String,
+    val authority: String,
+    val path: String,
+    val promisedHeaders: List<QpackHeaderField>,
+)
+
 /** A server-side request/response pair handed to the `withHttp3Server` request handler. */
 class Http3ServerExchange internal constructor(
     val request: Http3ServerRequest,
     val response: Http3ServerResponse,
-)
+    // Sends a PUSH_PROMISE on this request stream + a push stream carrying the pushed response;
+    // returns false when the client has not granted (enough) push credit. Provided by the connection.
+    private val pushFn: suspend (PushPromiseSpec, suspend Http3ServerResponse.() -> Unit) -> Boolean,
+) {
+    /**
+     * Initiate a server push (RFC 9114 §4.6) for [path]: send a PUSH_PROMISE on this request stream
+     * and write the pushed response via [respond] on a fresh push stream. Returns `true` if the push
+     * was sent, or `false` if the client granted no (or insufficient) push credit — call it before
+     * finishing [response], since the PUSH_PROMISE rides this request stream before its FIN.
+     *
+     * [authority] and [scheme] default to the originating request's. The pushed [respond] writes a
+     * normal response (`send` or streaming); the framework FINs the push stream when it returns.
+     */
+    suspend fun push(
+        path: String,
+        authority: String = request.authority,
+        method: String = "GET",
+        scheme: String = request.scheme,
+        promisedHeaders: List<QpackHeaderField> = emptyList(),
+        respond: suspend Http3ServerResponse.() -> Unit,
+    ): Boolean = pushFn(PushPromiseSpec(method, scheme, authority, path, promisedHeaders), respond)
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackDynamicTable.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackDynamicTable.kt
@@ -87,6 +87,39 @@ class QpackDynamicTable(
         return absolute
     }
 
+    /**
+     * Insert (name, value) as the newest entry, evicting oldest entries to make room — but **only if
+     * every entry that would have to be evicted satisfies [isEvictable]** (RFC 9204 §2.1.3: an entry
+     * may not be evicted while an outstanding field section still references it). Checks the full
+     * eviction set against the predicate *before* mutating, so a refusal leaves the table untouched.
+     * Returns the new entry's absolute index, or null if it can never fit (entry > [capacity]) or the
+     * eviction it requires is unsafe. The eviction order (oldest-first, to fit exactly this entry) is
+     * identical to [insert], so a safe insert here matches what the peer's decoder will evict.
+     */
+    fun insertIfEvictable(
+        name: String,
+        value: String,
+        isEvictable: (Entry) -> Boolean,
+    ): Long? {
+        val entrySize = qpackEntrySize(name, value)
+        if (entrySize > _capacity) return null
+        // Walk the oldest entries that must go to fit `entrySize`; bail if any is still referenced.
+        var remaining = _size
+        var evictCount = 0
+        while (remaining + entrySize > _capacity) {
+            val candidate = entries[evictCount] // exists: entrySize ≤ capacity guarantees room after full drain
+            if (!isEvictable(candidate)) return null
+            remaining -= candidate.size
+            evictCount++
+        }
+        repeat(evictCount) { _size -= entries.removeFirst().size }
+        val absolute = _insertCount
+        entries.addLast(Entry(absolute, name, value))
+        _size += entrySize
+        _insertCount++
+        return absolute
+    }
+
     private fun evictToFit(incoming: Long) {
         while (_size + incoming > _capacity && entries.isNotEmpty()) {
             _size -= entries.removeFirst().size
@@ -95,8 +128,9 @@ class QpackDynamicTable(
 
     /**
      * True if (name, value) can be inserted *without evicting any live entry* — i.e. it fits in the
-     * remaining capacity. A conservative encoder uses this to keep eviction-safety trivial: it never
-     * evicts an entry an outstanding field section might still reference (RFC 9204 §2.1.3).
+     * remaining capacity. A query for callers that want to avoid eviction entirely; the eviction-aware
+     * path is [insertIfEvictable], which evicts only entries no outstanding section references
+     * (RFC 9204 §2.1.3).
      */
     fun canInsertWithoutEviction(
         name: String,

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackEncoder.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackEncoder.kt
@@ -13,12 +13,20 @@ import kotlinx.coroutines.sync.withLock
  * Received Count so it only *references* entries the peer has confirmed — keeping every emitted
  * section non-blocking.
  *
- * **Strategy (deliberately conservative, always spec-legal):** a field that hits the static or an
+ * **Strategy (always non-blocking, always spec-legal):** a field that hits the static or an
  * *acknowledged* dynamic entry is encoded as an indexed line; an unseen field is inserted into the
- * dynamic table for *future* reuse (when there's room without eviction) but encoded as a literal in
- * the current section, so the section never references an unacknowledged entry and never blocks. The
- * table is never evicted (inserts stop when full), so an outstanding section can never reference an
- * evicted entry. This trades maximal compression for simplicity and correctness.
+ * dynamic table for *future* reuse but encoded as a literal in the current section, so the section
+ * never references an unacknowledged entry and never blocks.
+ *
+ * **Eviction (RFC 9204 §2.1.3).** Inserting into a full table evicts its oldest entries. To stay
+ * correct the encoder must never evict an entry an outstanding (un-acknowledged) field section still
+ * references — otherwise the peer's decoder, which evicts in lockstep, would fail to resolve that
+ * reference. We therefore reference-count: [entryRefCount] tracks, per absolute index, how many
+ * emitted-but-unacked sections reference it (plus the section currently being built), and an insert
+ * may only evict entries with a zero count ([QpackDynamicTable.insertIfEvictable]). A Section
+ * Acknowledgment releases its section's references; a Stream Cancellation releases the stream's. This
+ * keeps the table churning as headers evolve (unlike a never-evict table that freezes once full) while
+ * preserving the non-blocking invariant.
  *
  * [peerMaxCapacity] is the peer's `SETTINGS_QPACK_MAX_TABLE_CAPACITY`; [emit] writes an encoder-stream
  * instruction on our QPACK encoder uni stream.
@@ -34,8 +42,20 @@ class QpackEncoder(
     // processDecoderInstruction (the decoder-stream router) must not interleave on the table/KRC.
     private val mutex = Mutex()
 
-    // Per-stream FIFO of the Required Insert Counts of sections we've emitted but not yet seen acked.
-    private val outstandingSectionRic = mutableMapOf<Long, ArrayDeque<Long>>()
+    // Per-stream FIFO of sections we've emitted but not yet seen acked: each carries its Required
+    // Insert Count (to advance the Known Received Count on ack) and the absolute indices it references
+    // (to release their entry reference counts on ack/cancel). Sections that reference no dynamic
+    // entry (RIC 0) are never recorded — the decoder never acks them.
+    private val outstandingSections = mutableMapOf<Long, ArrayDeque<OutstandingSection>>()
+
+    // Absolute index → number of outstanding sections referencing it. An entry present here (count ≥ 1)
+    // is "pinned": an insert must not evict it (RFC 9204 §2.1.3). Absent ⇒ count 0 ⇒ evictable.
+    private val entryRefCount = HashMap<Long, Int>()
+
+    private class OutstandingSection(
+        val requiredInsertCount: Long,
+        val referencedAbsolutes: List<Long>,
+    )
 
     /** Current dynamic-table insert count — for tests/diagnostics. */
     val insertCountValue: Long get() = table.insertCount
@@ -63,10 +83,14 @@ class QpackEncoder(
         pool: BufferPool,
     ): ReadBuffer =
         mutex.withLock {
+            // Absolute indices this section references. Held locally (not yet committed to entryRefCount)
+            // so a throw mid-build leaks no pins; planField also consults it so an insert later in this
+            // same section never evicts an entry an earlier line already referenced.
+            val sectionRefs = ArrayList<Long>()
             val ops = ArrayList<Op>(fields.size)
             var maxReferencedAbsolute = -1L
             for (field in fields) {
-                val op = planField(field)
+                val op = planField(field, sectionRefs)
                 if (op is Op.DynamicIndexed) maxReferencedAbsolute = maxOf(maxReferencedAbsolute, op.absoluteIndex)
                 ops += op
             }
@@ -80,7 +104,11 @@ class QpackEncoder(
             buffer.resetForRead()
 
             if (requiredInsertCount > 0) {
-                outstandingSectionRic.getOrPut(streamId) { ArrayDeque() }.addLast(requiredInsertCount)
+                // Commit the pins now that the section is fully built and will be sent.
+                for (absolute in sectionRefs) entryRefCount[absolute] = (entryRefCount[absolute] ?: 0) + 1
+                outstandingSections
+                    .getOrPut(streamId) { ArrayDeque() }
+                    .addLast(OutstandingSection(requiredInsertCount, sectionRefs))
             }
             buffer
         }
@@ -90,28 +118,46 @@ class QpackEncoder(
      * effect when the field is new and there is room. Returns the representation to write for *this*
      * occurrence — never a reference to a just-inserted (unacknowledged) entry.
      */
-    private suspend fun planField(field: QpackHeaderField): Op {
+    private suspend fun planField(
+        field: QpackHeaderField,
+        sectionRefs: MutableList<Long>,
+    ): Op {
         QpackStaticTable.findExact(field.name, field.value)?.let { return Op.StaticIndexed(it.toLong()) }
 
         val dynamicExact = table.findExact(field.name, field.value)
         if (dynamicExact != null && dynamicExact < knownReceivedCount) {
+            sectionRefs += dynamicExact // pin: a later insert in this section must not evict it
             return Op.DynamicIndexed(dynamicExact)
         }
 
-        if (table.canInsertWithoutEviction(field.name, field.value)) {
-            // Insert into our table BEFORE emitting, so our insert count already reflects the entry
-            // when the decoder's Insert Count Increment feeds back (it must not exceed our inserts).
-            table.insert(field.name, field.value)
-            val staticName = QpackStaticTable.findName(field.name)
-            if (staticName != null) {
-                emit(QpackEncoderInstruction.InsertWithNameRef(staticName.toLong(), isStatic = true, value = field.value))
-            } else {
-                emit(QpackEncoderInstruction.InsertWithLiteralName(field.name, field.value))
-            }
-        }
+        tryInsertForFutureReuse(field, sectionRefs)
         // Encode this occurrence as a literal regardless of whether we just inserted (non-blocking).
         val staticName = QpackStaticTable.findName(field.name)
         return if (staticName != null) Op.LiteralNameRef(staticName.toLong(), field.value) else Op.LiteralName(field.name, field.value)
+    }
+
+    /**
+     * Try to add [field] to the dynamic table for future reuse, evicting oldest entries if needed but
+     * never one that an outstanding section — or the section currently being built ([sectionRefs]) —
+     * still references. Emits the encoder-stream insert only when the table actually accepted it. Insert
+     * happens BEFORE the emit so our insert count already reflects the entry when the decoder's Insert
+     * Count Increment feeds back (it must never exceed our inserts).
+     */
+    private suspend fun tryInsertForFutureReuse(
+        field: QpackHeaderField,
+        sectionRefs: List<Long>,
+    ) {
+        val inserted =
+            table.insertIfEvictable(field.name, field.value) { entry ->
+                !entryRefCount.containsKey(entry.absoluteIndex) && entry.absoluteIndex !in sectionRefs
+            }
+        if (inserted == null) return // doesn't fit, or fitting would evict a still-referenced entry
+        val staticName = QpackStaticTable.findName(field.name)
+        if (staticName != null) {
+            emit(QpackEncoderInstruction.InsertWithNameRef(staticName.toLong(), isStatic = true, value = field.value))
+        } else {
+            emit(QpackEncoderInstruction.InsertWithLiteralName(field.name, field.value))
+        }
     }
 
     /**
@@ -130,17 +176,26 @@ class QpackEncoder(
                     knownReceivedCount = updated
                 }
                 is QpackDecoderInstruction.SectionAck -> {
-                    val ric =
-                        outstandingSectionRic[instruction.streamId]?.removeFirstOrNull()
+                    val section =
+                        outstandingSections[instruction.streamId]?.removeFirstOrNull()
                             ?: throw decoderStreamError(
                                 "Section Acknowledgment for stream ${instruction.streamId} with no outstanding section",
                             )
-                    if (ric > knownReceivedCount) knownReceivedCount = ric
+                    for (absolute in section.referencedAbsolutes) releaseRef(absolute)
+                    if (section.requiredInsertCount > knownReceivedCount) knownReceivedCount = section.requiredInsertCount
                 }
                 is QpackDecoderInstruction.StreamCancellation ->
-                    outstandingSectionRic.remove(instruction.streamId)
+                    outstandingSections.remove(instruction.streamId)?.forEach { section ->
+                        section.referencedAbsolutes.forEach { releaseRef(it) }
+                    }
             }
         }
+    }
+
+    /** Drop one reference to the entry at [absolute]; once the count hits 0 it becomes evictable. */
+    private fun releaseRef(absolute: Long) {
+        val count = entryRefCount[absolute] ?: return
+        if (count <= 1) entryRefCount.remove(absolute) else entryRefCount[absolute] = count - 1
     }
 
     private fun decoderStreamError(message: String): Http3StreamException =

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WithHttp3Server.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WithHttp3Server.kt
@@ -1,0 +1,63 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.QuicOptions
+import com.ditchoom.socket.quic.QuicServer
+import com.ditchoom.socket.quic.QuicTlsConfig
+import com.ditchoom.socket.quic.withQuicServer
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** A bound HTTP/3 server, handed to the [withHttp3Server] lifecycle block. */
+class Http3Server internal constructor(
+    private val quicServer: QuicServer,
+) {
+    /** The port the server is bound to (resolves an ephemeral port when `port = 0` was requested). */
+    val port: Int get() = quicServer.port
+}
+
+/**
+ * Run an HTTP/3 server (RFC 9114) bound to [port], handling each request with [onRequest], while
+ * [block] runs with the bound [Http3Server] (e.g. to read [Http3Server.port] and drive clients, or
+ * `awaitCancellation()` to serve until cancelled).
+ *
+ * Wraps [withQuicServer] (QUIC over TLS 1.3, `h3` ALPN) + [Http3ServerConnection]: every accepted
+ * connection bootstraps the server control + (optionally) QPACK streams and dispatches its request
+ * streams to [onRequest] as [Http3ServerExchange]s, concurrently. The accept loop is cancelled and
+ * the server torn down when [block] returns (normally or exceptionally).
+ *
+ * [qpackCapacity] > 0 enables dynamic QPACK (RFC 9204) in both directions; 0 (default) is static-only.
+ * [quicOptions] defaults to the `h3` ALPN — keep `"h3"` in [QuicOptions.alpnProtocols] for HTTP/3.
+ *
+ * @throws com.ditchoom.socket.SocketException if the bind fails.
+ * @throws UnsupportedOperationException on platforms without an in-process QUIC server.
+ */
+suspend fun <R> withHttp3Server(
+    port: Int = 0,
+    tlsConfig: QuicTlsConfig,
+    host: String? = null,
+    quicOptions: QuicOptions = QuicOptions(alpnProtocols = listOf(HTTP3_ALPN)),
+    connectionOptions: ConnectionOptions = ConnectionOptions(),
+    qpackCapacity: Long = 0,
+    timeout: Duration = 15.seconds,
+    onRequest: suspend Http3ServerExchange.() -> Unit,
+    block: suspend Http3Server.() -> R,
+): R =
+    withQuicServer(port, host, tlsConfig, quicOptions, timeout) {
+        val server = Http3Server(this)
+        coroutineScope {
+            val acceptJob =
+                launch {
+                    connections {
+                        Http3ServerConnection(this, connectionOptions, qpackCapacity, onRequest).serve()
+                    }
+                }
+            try {
+                server.block()
+            } finally {
+                acceptJob.cancel()
+            }
+        }
+    }

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3DockerInteropTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3DockerInteropTests.kt
@@ -1,0 +1,113 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.QuicOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * **QPACK eviction interop** against an INDEPENDENT HTTP/3 implementation (aioquic / lsqpack) running
+ * in a local Docker container (`socket-http3/docker-interop/`, started via `run-server.sh`).
+ *
+ * Why a third party: the in-process loopback ([Http3LoopbackTestSuite]) round-trips our encoder through
+ * *our own* decoder, so a bug symmetric across both halves could hide. A foreign decoder (lsqpack) can't
+ * be wrong in the same way — if our encoder's dynamic-table **eviction** accounting drifts from the wire
+ * contract (RFC 9204 §2.1.3), lsqpack raises a decompression / decoder-stream error and the connection
+ * dies, failing this test. Running on loopback also avoids the UDP/443 egress flakiness that makes
+ * [Http3PublicEndpointInteropTests] skip on WSL2/CI.
+ *
+ * The driver issues many requests on ONE connection, each carrying a distinct large custom header, to
+ * push the encoder's dynamic table past capacity so it evicts and then re-references / re-inserts entries
+ * — exactly the churn the eviction tune enables. With the default 4096-octet table and ~220-octet
+ * entries, the table fills after ~18 entries, so 64 requests force dozens of evictions. The server echoes
+ * each `x-*` request header back as `echo-x-*`; the test asserts every echo matches, proving lsqpack
+ * decoded our (evicting) encoder stream correctly the whole way through.
+ *
+ * **Skip-on-unreachable, never flaky-fail.** If the Docker server is not up on 127.0.0.1:4433 the
+ * handshake fails before [connected] flips and the test logs a SKIP. A failure *after* the connection is
+ * established (a wrong echo, or a QPACK-triggered connection close) re-throws — that is a real regression.
+ */
+class Http3DockerInteropTests {
+    private val host = "127.0.0.1"
+    private val port = 4433
+
+    private val quicOptions =
+        QuicOptions(
+            alpnProtocols = listOf(HTTP3_ALPN),
+            verifyPeer = false, // the local server uses a self-signed cert; we are testing QPACK, not PKI
+            idleTimeout = 20.seconds,
+        )
+
+    // Zero-copy stream I/O reads each buffer's native address ⇒ native-memory factory on K/N.
+    private val connectionOptions = ConnectionOptions(bufferFactory = BufferFactory.deterministic())
+
+    @Test
+    fun evictingEncoderRoundTripsAgainstAioquic_orSkips() =
+        runTest(timeout = 90.seconds) {
+            withContext(Dispatchers.Default) {
+                var connected = false
+                try {
+                    withHttp3Connection(host, port, quicOptions, connectionOptions, timeout = 8.seconds) {
+                        // Let the server SETTINGS (its QPACK_MAX_TABLE_CAPACITY) arrive so our encoder
+                        // activates its dynamic table before we start issuing requests.
+                        withTimeout(6.seconds) { peerSettings() }
+                        connected = true // past the handshake — failures below are real regressions
+
+                        val recurring = QpackHeaderField("x-recurring", "stable-token-kept-across-every-request")
+                        val total = 64
+                        for (i in 0 until total) {
+                            // ~180-octet value ⇒ entry ≈ name+value+32 ≈ 220 octets; the 4096 table holds
+                            // ~18 of these, so by request ~18 the encoder must evict to keep inserting.
+                            val value = "x".repeat(180) + "-$i"
+                            val fields =
+                                mutableListOf(
+                                    QpackHeaderField("x-evict-$i", value),
+                                    recurring, // re-referenced every request: pinned while in-flight, ages toward eviction
+                                )
+                            // Periodically re-send a header old enough to have been evicted: the encoder
+                            // must treat it as brand-new (re-insert), and lsqpack must still decode it.
+                            if (i >= 24 && i % 4 == 0) {
+                                val old = i - 22
+                                fields += QpackHeaderField("x-evict-$old", "x".repeat(180) + "-$old")
+                            }
+
+                            val response = request(Http3Request("GET", host, "/item-$i", headers = fields))
+                            try {
+                                assertEquals(200, response.status, "request $i status")
+                                assertEquals(
+                                    value,
+                                    response.headers.firstOrNull { it.name == "echo-x-evict-$i" }?.value,
+                                    "request $i: server (lsqpack) must decode our evicting encoder's x-evict-$i",
+                                )
+                                assertEquals(
+                                    recurring.value,
+                                    response.headers.firstOrNull { it.name == "echo-x-recurring" }?.value,
+                                    "request $i: x-recurring must survive table churn",
+                                )
+                                response.readFullBody().freeIfNeeded()
+                            } finally {
+                                response.close()
+                            }
+                        }
+                        assertNull(connectionError, "eviction churn must not raise a QPACK connection error")
+                        println("[Http3DockerInteropTests] OK — $total evicting requests round-tripped through aioquic/lsqpack")
+                    }
+                } catch (t: Throwable) {
+                    if (connected) throw t // a post-handshake failure is a real eviction/QPACK regression
+                    println(
+                        "[Http3DockerInteropTests] SKIP $host:$port — ${t::class.simpleName}: ${t.message} " +
+                            "(start the server: socket-http3/docker-interop/run-server.sh)",
+                    )
+                }
+            }
+        }
+}

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -601,13 +602,23 @@ abstract class Http3LoopbackTestSuite {
                                             it.cancel()
                                         }
                                     }
-                                repeat(3) { i ->
+                                // Drive requests until the window demonstrably rolls (>= 2 distinct pushes),
+                                // waiting REACTIVELY for each push rather than on a fixed sleep budget: a slow
+                                // CI runner can take well over 100ms to round-trip the re-issued MAX_PUSH_ID,
+                                // which made the old `delay(120)` version flaky. A working re-issue yields one
+                                // push per request and reaches 2 in a couple of iterations; a broken re-issue
+                                // never gets a second push, so the iteration cap is hit and the assert below
+                                // fails deterministically (instead of passing or hanging on timing).
+                                var i = 0
+                                while (received.size < 2 && i < 6) {
+                                    val before = received.size
                                     val r = request(Http3Request(method = "GET", authority = "localhost", path = "/p$i"))
                                     r.readFullBody().freeIfNeeded()
                                     r.close()
-                                    delay(120) // let the re-issued MAX_PUSH_ID reach the server before the next request
+                                    i++
+                                    // Wait up to 3s for this request's push to be observed before the next one.
+                                    withTimeoutOrNull(3.seconds) { while (received.size == before) delay(20) }
                                 }
-                                delay(200)
                                 collector.cancel()
                                 received.size
                             }

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -488,6 +490,68 @@ abstract class Http3LoopbackTestSuite {
                     assertEquals(200, result.pushStatus)
                     assertEquals("body{color:green}", result.pushBody)
                     assertEquals("text/css", result.pushContentType)
+                }
+            }
+        }
+
+    @Test
+    fun productionServerPushesMultipleConcurrently() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // The handler pushes THREE resources for one request; since push bodies stream
+                // concurrently (the handler isn't blocked on each), all three promises + responses must
+                // still arrive. Proves the concurrent push-write path.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    onRequest = {
+                        if (request.path == "/index.html") {
+                            repeat(3) { i ->
+                                push(path = "/asset-$i.css") {
+                                    val b = textBuffer("asset-$i")
+                                    try {
+                                        send(200, body = b)
+                                    } finally {
+                                        b.freeIfNeeded()
+                                    }
+                                }
+                            }
+                        }
+                        val html = textBuffer("<html>")
+                        try {
+                            response.send(200, body = html)
+                        } finally {
+                            html.freeIfNeeded()
+                        }
+                    },
+                ) {
+                    delay(100)
+                    val paths =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            quicOptions = clientQuicOptions,
+                            connectionOptions = connectionOptions,
+                            timeout = 15.seconds,
+                            maxPushId = 8,
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            delay(100)
+                            val collected = async { withTimeout(10.seconds) { pushes.take(3).toList() } }
+                            val r = request(Http3Request(method = "GET", authority = "localhost", path = "/index.html"))
+                            r.readFullBody().freeIfNeeded()
+                            r.close()
+                            val received = collected.await()
+                            received.forEach { p ->
+                                val pr = withTimeout(10.seconds) { p.response() }
+                                pr.readFullBody().freeIfNeeded()
+                                pr.close()
+                            }
+                            received.map { it.promisedRequest.path }.sorted()
+                        }
+                    assertEquals(listOf("/asset-0.css", "/asset-1.css", "/asset-2.css"), paths)
                 }
             }
         }

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -2,6 +2,7 @@ package com.ditchoom.socket.http3
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.socket.ConnectionOptions
@@ -22,6 +23,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -74,6 +76,13 @@ abstract class Http3LoopbackTestSuite {
     // live interop test make. Both the client (withHttp3Connection's bootstrap + request frames) and
     // the server (Http3LoopbackServer) allocate through this.
     private val connectionOptions = ConnectionOptions(bufferFactory = BufferFactory.deterministic())
+
+    /** A native-memory (zero-copy-safe) buffer holding [s] as UTF-8, positioned for reading. */
+    private fun textBuffer(s: String): PlatformBuffer =
+        BufferFactory.deterministic().allocate(s.length.coerceAtLeast(1)).apply {
+            writeString(s, Charset.UTF8)
+            resetForRead()
+        }
 
     @Test
     fun getRoundTripsThroughInProcessServer() =
@@ -414,6 +423,198 @@ abstract class Http3LoopbackTestSuite {
         }
 
     @Test
+    fun serverPushWindowRollsViaReIssuedMaxPushId() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // maxPushId = 0 advertises room for exactly ONE push (id 0). The server pushes one
+                // resource per request; the client must re-issue MAX_PUSH_ID as it observes push ids,
+                // or the server runs out of credit after id 0. Receiving more than one push proves the
+                // rolling-window re-issue (RFC 9114 §7.2.7) works end-to-end.
+                val server =
+                    Http3LoopbackServer(
+                        connectionOptions,
+                        serverPushes = { request ->
+                            listOf(
+                                Http3LoopbackServer.Push(
+                                    authority = "localhost",
+                                    path = "${request.path}.css",
+                                    response = Http3LoopbackServer.Response(status = 200, body = "css"),
+                                ),
+                            )
+                        },
+                    ) { Http3LoopbackServer.Response(status = 200, body = "ok") }
+
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = serverQuicOptions) {
+                    val serverJob = launch { connections { server.serve(this) } }
+                    delay(100)
+                    try {
+                        val pushCount =
+                            withHttp3Connection(
+                                "localhost",
+                                port,
+                                quicOptions = clientQuicOptions,
+                                connectionOptions = connectionOptions,
+                                timeout = 15.seconds,
+                                maxPushId = 0,
+                            ) {
+                                withTimeout(5.seconds) { peerSettings() }
+                                delay(50)
+                                val received = mutableListOf<Long>()
+                                val collector =
+                                    launch {
+                                        pushes.collect {
+                                            received += it.pushId
+                                            it.cancel()
+                                        }
+                                    }
+                                repeat(3) { i ->
+                                    val r = request(Http3Request(method = "GET", authority = "localhost", path = "/p$i"))
+                                    r.readFullBody().freeIfNeeded()
+                                    r.close()
+                                    delay(120) // let the re-issued MAX_PUSH_ID reach the server before the next request
+                                }
+                                delay(200)
+                                collector.cancel()
+                                received.size
+                            }
+                        // Without re-issue the server could push only id 0 (one push); > 1 proves the window rolled.
+                        assertTrue(pushCount >= 2, "expected the push window to roll past the initial credit; got $pushCount pushes")
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun productionServerRole_getAndPostRoundTrip() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // The PRODUCTION server role (`withHttp3Server` + Http3ServerConnection) answering a real
+                // `withHttp3Connection` client: GET returns headers+body, POST echoes the request body via
+                // the streaming Http3ServerRequest.readFullBody / Http3ServerResponse.send path.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    onRequest = {
+                        when (request.method) {
+                            "GET" -> {
+                                val body = textBuffer("hi from the h3 server")
+                                try {
+                                    response.send(200, listOf(QpackHeaderField("content-type", "text/plain")), body)
+                                } finally {
+                                    body.freeIfNeeded()
+                                }
+                            }
+                            "POST" -> {
+                                val reqBody = request.readFullBody()
+                                val echo = "echo:" + reqBody.readString(reqBody.remaining(), Charset.UTF8)
+                                reqBody.freeIfNeeded()
+                                val out = textBuffer(echo)
+                                try {
+                                    response.send(201, body = out)
+                                } finally {
+                                    out.freeIfNeeded()
+                                }
+                            }
+                            else -> response.send(404)
+                        }
+                    },
+                ) {
+                    delay(100) // let the accept loop start before the client connects
+                    val result =
+                        withHttp3Connection("localhost", port, clientQuicOptions, connectionOptions, 15.seconds) {
+                            val g = request(Http3Request(method = "GET", authority = "localhost", path = "/hi"))
+                            val gBody = g.readFullBody()
+                            val gText = gBody.readString(gBody.remaining(), Charset.UTF8)
+                            gBody.freeIfNeeded()
+                            val gOut = Triple(g.status, gText, g.headers.firstOrNull { it.name == "content-type" }?.value)
+                            g.close()
+
+                            val reqBuf = textBuffer("server-echo-me")
+                            val p =
+                                try {
+                                    request(Http3Request(method = "POST", authority = "localhost", path = "/echo", body = reqBuf))
+                                } finally {
+                                    reqBuf.freeIfNeeded()
+                                }
+                            val pBody = p.readFullBody()
+                            val pText = pBody.readString(pBody.remaining(), Charset.UTF8)
+                            pBody.freeIfNeeded()
+                            val pStatus = p.status
+                            p.close()
+                            ServerRoleResult(gOut.first, gOut.second, gOut.third, pStatus, pText)
+                        }
+                    assertEquals(200, result.getStatus)
+                    assertEquals("hi from the h3 server", result.getBody)
+                    assertEquals("text/plain", result.getContentType)
+                    assertEquals(201, result.postStatus)
+                    assertEquals("echo:server-echo-me", result.postBody)
+                }
+            }
+        }
+
+    @Test
+    fun productionServerRole_dynamicQpackRoundTrip() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // The production server with dynamic QPACK (capacity 4096): it decodes the client's
+                // dynamically-compressed request header and compresses its own response header back,
+                // across repeated requests that drive entries into both dynamic tables.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    qpackCapacity = 4096,
+                    onRequest = {
+                        val echoed = request.headers.firstOrNull { it.name == "x-client" }?.value
+                        val out = textBuffer("echo:$echoed")
+                        try {
+                            response.send(200, listOf(QpackHeaderField("x-server", "server-token")), out)
+                        } finally {
+                            out.freeIfNeeded()
+                        }
+                    },
+                ) {
+                    delay(100)
+                    withHttp3Connection("localhost", port, clientQuicOptions, connectionOptions, 15.seconds) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        delay(50)
+                        repeat(3) { i ->
+                            val response =
+                                request(
+                                    Http3Request(
+                                        method = "GET",
+                                        authority = "localhost",
+                                        path = "/item-$i",
+                                        headers = listOf(QpackHeaderField("x-client", "client-token")),
+                                    ),
+                                )
+                            try {
+                                val body = response.readFullBody()
+                                val text = body.readString(body.remaining(), Charset.UTF8)
+                                body.freeIfNeeded()
+                                assertEquals(200, response.status, "request $i status")
+                                assertEquals(
+                                    "server-token",
+                                    response.headers.firstOrNull { it.name == "x-server" }?.value,
+                                    "request $i x-server",
+                                )
+                                assertEquals("echo:client-token", text, "request $i body")
+                            } finally {
+                                response.close()
+                            }
+                        }
+                        assertNull(connectionError, "production server dynamic-QPACK exchange must not raise a connection error")
+                    }
+                }
+            }
+        }
+
+    @Test
     fun clientReceivesServerSettings() =
         runHttp3LoopbackTest {
             wrapTestBody {
@@ -445,6 +646,15 @@ abstract class Http3LoopbackTestSuite {
             }
         }
 }
+
+/** Result holder for the production server-role test (the block returns GET + POST results). */
+private data class ServerRoleResult(
+    val getStatus: Int,
+    val getBody: String,
+    val getContentType: String?,
+    val postStatus: Int,
+    val postBody: String,
+)
 
 /** Result holder for the server-push test (its withHttp3Connection block returns several values). */
 private data class PushResult(

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -423,6 +423,76 @@ abstract class Http3LoopbackTestSuite {
         }
 
     @Test
+    fun productionServerInitiatedPush() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // The PRODUCTION server (withHttp3Server) initiates a push: for GET /index.html its
+                // handler calls exchange.push("/style.css") { … }, sending a PUSH_PROMISE on the request
+                // stream + a push stream. The real client (push enabled) receives it on `pushes`.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    onRequest = {
+                        if (request.path == "/index.html") {
+                            push(path = "/style.css") {
+                                val css = textBuffer("body{color:green}")
+                                try {
+                                    send(200, listOf(QpackHeaderField("content-type", "text/css")), css)
+                                } finally {
+                                    css.freeIfNeeded()
+                                }
+                            }
+                        }
+                        val html = textBuffer("<html>")
+                        try {
+                            response.send(200, body = html)
+                        } finally {
+                            html.freeIfNeeded()
+                        }
+                    },
+                ) {
+                    delay(100)
+                    val result =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            quicOptions = clientQuicOptions,
+                            connectionOptions = connectionOptions,
+                            timeout = 15.seconds,
+                            maxPushId = 8,
+                        ) {
+                            // Let our MAX_PUSH_ID reach the server before it handles the request.
+                            withTimeout(5.seconds) { peerSettings() }
+                            delay(100)
+                            val pushDeferred = async { withTimeout(10.seconds) { pushes.first() } }
+                            val r = request(Http3Request(method = "GET", authority = "localhost", path = "/index.html"))
+                            val htmlBody = r.readFullBody()
+                            val htmlText = htmlBody.readString(htmlBody.remaining(), Charset.UTF8)
+                            htmlBody.freeIfNeeded()
+                            r.close()
+
+                            val push = pushDeferred.await()
+                            val pushResponse = withTimeout(10.seconds) { push.response() }
+                            val pb = pushResponse.readFullBody()
+                            val pText = pb.readString(pb.remaining(), Charset.UTF8)
+                            pb.freeIfNeeded()
+                            val ct = pushResponse.headers.firstOrNull { it.name == "content-type" }?.value
+                            pushResponse.close()
+                            assertNull(connectionError, "server-initiated push must not raise a connection error")
+                            PushResult(htmlText, push.promisedRequest.path, pushResponse.status, pText, ct)
+                        }
+                    assertEquals("<html>", result.mainBody)
+                    assertEquals("/style.css", result.promisedPath)
+                    assertEquals(200, result.pushStatus)
+                    assertEquals("body{color:green}", result.pushBody)
+                    assertEquals("text/css", result.pushContentType)
+                }
+            }
+        }
+
+    @Test
     fun serverPushWindowRollsViaReIssuedMaxPushId() =
         runHttp3LoopbackTest {
             wrapTestBody {

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackDynamicTableTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackDynamicTableTests.kt
@@ -85,6 +85,44 @@ class QpackDynamicTableTests {
     }
 
     @Test
+    fun insertIfEvictableEvictsOnlyWhenEveryVictimIsEvictable() {
+        // capacity 70 holds two 34-octet entries; inserting a third must evict the oldest (absolute 0).
+        val t = table(70)
+        t.insert("a", "1") // abs 0
+        t.insert("b", "2") // abs 1
+
+        // Victim (abs 0) refused by the predicate ⇒ no insert, table untouched.
+        val refused = t.insertIfEvictable("c", "3") { it.absoluteIndex != 0L }
+        assertNull(refused)
+        assertEquals(2L, t.insertCount, "refused insert does not advance insertCount")
+        assertEquals(68L, t.size)
+        assertTrue(t.isLive(0), "refused insert evicts nothing")
+
+        // Victim allowed ⇒ evicts abs 0 and inserts at abs 2.
+        val accepted = t.insertIfEvictable("c", "3") { true }
+        assertEquals(2L, accepted)
+        assertNull(t.getByAbsolute(0), "oldest evicted once allowed")
+        assertEquals("c", t.getByAbsolute(2)?.name)
+    }
+
+    @Test
+    fun insertIfEvictableFitsWithoutEvictionNeverConsultsPredicate() {
+        val t = table(1000)
+        t.insert("a", "1")
+        // Plenty of room ⇒ predicate must not even be asked (no eviction needed).
+        val abs = t.insertIfEvictable("b", "2") { error("predicate consulted though no eviction was needed") }
+        assertEquals(1L, abs)
+        assertTrue(t.isLive(0) && t.isLive(1))
+    }
+
+    @Test
+    fun insertIfEvictableRejectsEntryLargerThanCapacity() {
+        val t = table(40)
+        assertNull(t.insertIfEvictable("name", "a-very-long-value-that-exceeds-capacity") { true })
+        assertEquals(0L, t.insertCount)
+    }
+
+    @Test
     fun maxEntriesIsMaxCapacityOver32() {
         assertEquals(31L, QpackDynamicTable(1000).maxEntries) // floor(1000/32)
         assertEquals(0L, QpackDynamicTable(0).maxEntries)

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackEncoderTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackEncoderTests.kt
@@ -37,6 +37,16 @@ class QpackEncoderTests {
                 while (decoderToEncoder.isNotEmpty()) encoder.processDecoderInstruction(decoderToEncoder.removeFirst())
             }
         }
+
+        /** Deliver only our encoder-stream instructions (inserts) to the decoder — leaves acks pending. */
+        suspend fun flushEncoderStream() {
+            while (encoderToDecoder.isNotEmpty()) decoder.applyEncoderInstruction(encoderToDecoder.removeFirst())
+        }
+
+        /** Deliver only the decoder-stream instructions (acks/cancellations/increments) back to the encoder. */
+        suspend fun flushDecoderStream() {
+            while (decoderToEncoder.isNotEmpty()) encoder.processDecoderInstruction(decoderToEncoder.removeFirst())
+        }
     }
 
     private fun wired(maxCapacity: Long = 4096) = Pair(maxCapacity)
@@ -96,6 +106,98 @@ class QpackEncoderTests {
             }
             // The table filled up and stopped inserting (no eviction), but every request still decoded.
             assertEquals(p.encoder.insertCountValue, p.decoder.insertCountValue)
+        }
+
+    @Test
+    fun tableChurnsViaEvictionAndReReferencesPostEvictionEntry() =
+        runTest {
+            // capacity 72 holds exactly two 36-octet entries; a third forces eviction of the oldest.
+            val p = wired(maxCapacity = 72)
+            p.encoder.setCapacity(72)
+            val a = QpackHeaderField("aa", "11")
+            val b = QpackHeaderField("bb", "22")
+            val c = QpackHeaderField("cc", "33")
+
+            assertEquals(listOf(a), roundTrip(p, listOf(a), streamId = 0)) // insert A (abs 0)
+            assertEquals(listOf(b), roundTrip(p, listOf(b), streamId = 4)) // insert B (abs 1) — table now full
+            assertEquals(2L, p.encoder.insertCountValue)
+
+            // C is new and the table is full; A (abs 0) is unreferenced, so eviction is safe.
+            assertEquals(listOf(c), roundTrip(p, listOf(c), streamId = 8)) // evict A, insert C (abs 2)
+            assertEquals(3L, p.encoder.insertCountValue)
+            assertEquals(3L, p.decoder.insertCountValue, "decoder evicted + inserted in lockstep")
+
+            // C is now an acknowledged, still-live entry ⇒ referenced (no new insert) and decodes fine.
+            assertEquals(listOf(c), roundTrip(p, listOf(c), streamId = 12))
+            assertEquals(3L, p.encoder.insertCountValue, "re-reference of a post-eviction entry inserts nothing")
+
+            // A was evicted, so it is unknown again ⇒ treated as brand-new (evicting B this time).
+            assertEquals(listOf(a), roundTrip(p, listOf(a), streamId = 16))
+            assertEquals(4L, p.encoder.insertCountValue, "evicted entry re-inserted as new")
+        }
+
+    @Test
+    fun inFlightSectionPreventsEvictionOfItsReferencedEntry() =
+        runTest {
+            val p = wired(maxCapacity = 72) // two 36-octet entries
+            p.encoder.setCapacity(72)
+            val a = QpackHeaderField("aa", "11")
+            val b = QpackHeaderField("bb", "22")
+            val c = QpackHeaderField("cc", "33")
+
+            // Fill the table with A (abs 0) and B (abs 1); full round-trips acknowledge both inserts.
+            assertEquals(listOf(a), roundTrip(p, listOf(a), streamId = 0))
+            assertEquals(listOf(b), roundTrip(p, listOf(b), streamId = 4))
+            assertEquals(2L, p.encoder.insertCountValue)
+
+            // Emit a section on stream 8 that references A (abs 0) and deliver it to the decoder, but
+            // HOLD the decoder's Section Acknowledgment — A is now pinned by an in-flight reference.
+            val pinning = p.encoder.encodeSection(listOf(a), streamId = 8, pool)
+            p.flushEncoderStream()
+            assertEquals(listOf(a), p.decoder.decodeSection(pinning, streamId = 8, scratchPool = null))
+            // NOTE: deliberately not flushing the decoder stream — the ack stays in flight.
+
+            // C is new and the table is full, but evicting A (the only candidate) is unsafe while the
+            // stream-8 section still references it ⇒ the encoder must NOT insert (encodes C literally).
+            val held = p.encoder.encodeSection(listOf(c), streamId = 12, pool)
+            p.flushEncoderStream()
+            assertEquals(2L, p.encoder.insertCountValue, "pinned entry blocks eviction → no insert")
+            assertEquals(listOf(c), p.decoder.decodeSection(held, streamId = 12, scratchPool = null))
+
+            // Now deliver the held acknowledgment; A is released and eviction becomes safe.
+            p.flushDecoderStream()
+            assertEquals(listOf(c), roundTrip(p, listOf(c), streamId = 16)) // evict A, insert C (abs 2)
+            assertEquals(3L, p.encoder.insertCountValue, "once unpinned, the entry is evictable")
+        }
+
+    @Test
+    fun streamCancellationReleasesPinnedEntryForEviction() =
+        runTest {
+            val p = wired(maxCapacity = 72)
+            p.encoder.setCapacity(72)
+            val a = QpackHeaderField("aa", "11")
+            val b = QpackHeaderField("bb", "22")
+            val c = QpackHeaderField("cc", "33")
+
+            assertEquals(listOf(a), roundTrip(p, listOf(a), streamId = 0))
+            assertEquals(listOf(b), roundTrip(p, listOf(b), streamId = 4))
+
+            // Pin A via an in-flight section on stream 8 (held, unacked).
+            p.encoder.encodeSection(listOf(a), streamId = 8, pool)
+            p.flushEncoderStream()
+            val blocked = p.encoder.encodeSection(listOf(c), streamId = 12, pool)
+            p.flushEncoderStream()
+            assertEquals(2L, p.encoder.insertCountValue, "pinned → eviction blocked")
+            // Consume the literally-encoded section so the decoder table stays consistent.
+            assertEquals(listOf(c), p.decoder.decodeSection(blocked, streamId = 12, scratchPool = null))
+            p.flushDecoderStream() // ack for stream 12 (no pin to release)
+
+            // The peer abandons stream 8 → Stream Cancellation releases A's reference.
+            p.decoder.cancelStream(8)
+            p.flushDecoderStream()
+
+            assertEquals(listOf(c), roundTrip(p, listOf(c), streamId = 16)) // now free to evict A, insert C
+            assertEquals(3L, p.encoder.insertCountValue, "cancellation unpinned the entry")
         }
 
     @Test


### PR DESCRIPTION
Builds on #124 (merged). Adds the production HTTP/3 **server role** with **server push in both roles**, plus two "minor tune" follow-ups.

## Server role (the inverse of `Http3Connection`)
- `withHttp3Server(port, tlsConfig, …, onRequest, block)` + `Http3ServerConnection` (per accepted QUIC connection: server control stream + SETTINGS, QPACK streams, routes client uni/bidi streams).
- `Http3ServerRequest` — streaming body (`nextBodyChunk`/`readFullBody`) + trailers.
- `Http3ServerResponse` — one-shot `send(status, headers, body)` or streaming `sendHeaders`/`writeBody`/`sendTrailers`; auto-FIN, minimal `500` if the handler sends nothing.
- `Http3ServerExchange` (request + response) is the handler receiver.
- Dynamic QPACK both directions when `qpackCapacity > 0`. Hand-rolled codecs (consistent with the module).

## Server-initiated push (RFC 9114 §4.6)
`Http3ServerExchange.push(path, …) { respond }` allocates a Push ID within the client's MAX_PUSH_ID credit, sends a PUSH_PROMISE on the request stream, opens a push stream, and writes the pushed response via `respond` (synchronous — call before finishing the main response). Returns `false` when the client granted no/insufficient credit. With the client push support from #124, push is now proven in **both roles**.

## Rolling push window (RFC 9114 §7.2.7)
The client re-issues MAX_PUSH_ID upward as it observes push ids, so `maxPushId` is a rolling credit rather than a hard lifetime cap.

## CI
`:socket-http3:testDebugUnitTest` → build-linux (Android unit; validated locally), `:socket-http3:macosArm64Test` → build-apple.

## Tests (jvm + linuxX64)
`productionServerRole_getAndPostRoundTrip`, `…_dynamicQpackRoundTrip`, `productionServerInitiatedPush`, `serverPushWindowRollsViaReIssuedMaxPushId`. 184 linuxX64 / 173 Android-unit, 0 fail.

## Deliberately NOT in this PR
Smarter QPACK encoder eviction (correctness-critical — its own effort), concurrent/non-blocking server push, the Apple `reset()` follow-up, and WebTransport Phase 2.