### PR TITLE
ci: capture native crash logs + decouple FFM/JNI test steps (diagnose the quic SIGABRT flake)

### DIFF
--- a/.github/workflows/build-apple.yaml
+++ b/.github/workflows/build-apple.yaml
@@ -194,7 +194,12 @@ jobs:
       # (FFM) output so its loader shadows the base JNI one, then loads the
       # self-contained shim via Panama. Exercises FfmQuicheApi's IS_BSD decode and
       # the FFM migration flush path on BSD layout.
+      #
+      # `if: !cancelled()` so FFM runs even when the JNI step above crashed — the
+      # two backends are independent and a native abort in one must not blind us to
+      # the other (matches build-linux.yaml).
       - name: Run socket-quic JVM tests (FFM backend)
+        if: ${{ !cancelled() }}
         timeout-minutes: 8
         env:
           QUIC_MIGRATION_REQUIRE_RUN: "1"
@@ -454,7 +459,10 @@ jobs:
           retention-days: 1
           if-no-files-found: warn
 
-      # Test reports on failure — see build-linux.yaml for the why.
+      # Test reports on failure — see build-linux.yaml for the why. Includes the JVM
+      # hs_err/replay crash logs: a native abort (quiche/JNI/FFM SIGABRT/SIGSEGV) shows
+      # only as "exit value 134" with no failing JUnit case, so without the dump the
+      # crash is undiagnosable — same instrumentation as build-linux.yaml.
       - name: Upload test reports (on failure)
         if: failure()
         uses: actions/upload-artifact@v7
@@ -466,6 +474,8 @@ jobs:
             build/reports/ktlint/
             socket-quic/build/reports/tests/
             socket-quic/build/test-results/
+            **/hs_err_pid*.log
+            **/replay_pid*.log
           retention-days: 7
           if-no-files-found: ignore
 


### PR DESCRIPTION
## Why
The intermittent `:socket-quic:jvmTest` **SIGABRT (exit 134)** — a native quiche/JNI crash under connection churn — has hit a PR check (#119) and a release deploy (#118), on both Linux and Apple runners. It's the systemic CI flake.

The problem: a native abort shows up only as `exit value 134` with **no failing JUnit case** (the JVM is killed before it writes one), and the `hs_err_pid*.log` (with the native stack) was never uploaded. So the crash was **undiagnosable** — we couldn't tell which backend, which call, or even which test.

## What this does (instrumentation, not a speculative fix)
`build-linux.yaml` already got this (in #125). This applies the same to `build-apple.yaml` — and since `merged.yaml` (the release pipeline) **reuses** both via `uses:`, the deploy pipeline is covered too:

1. **`if: !cancelled()`** on the FFM test step → it runs even when the default JNI step crashes, so the two backends always report independently. Previously a JNI SIGABRT skipped the FFM run entirely (zero FFM coverage on crash runs; no way to tell if the bug is JNI-only).
2. **Capture `hs_err_pid*` / `replay_pid*`** on failure → the native stack is preserved.

## Deliberately NOT included
A code fix. The server teardown is already hardened against this UAF class (#101), and the crash originates earlier than where it surfaces — inspection can't pin it. The honest path is: instrument → let CI capture the stack → targeted deterministic `StubQuicheApi` regression + fix. This PR is step 1.