### PR TITLE
feat(http3): complete QPACK encoder — blocking references + draining-duplicate (RFC 9204)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ if (gradle.startParameter.logLevel != LogLevel.QUIET) {
 }
 
 repositories {
-    mavenLocal()
     google()
     mavenCentral()
     maven { setUrl("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers/") }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mavenPublish = "0.36.0"
 dokka = "2.2.0"
 kotlinxCoroutines = "1.11.0"
 kotlinWrappers = "2026.6.0"
-buffer = "5.3.1"
+buffer = "5.5.0"
 ksp = "2.3.9"
 # held at 1.18.0: androidx-core 1.19.0 requires compileSdk 37 (we compile against 36)
 androidxCore = "1.18.0"

--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -374,13 +374,23 @@ jvm + linuxX64; the existing dynamic-QPACK loopback now runs *through* the block
 **aioquic/lsqpack docker interop** (`blocked_streams=16`, 64 evicting requests) passes against a
 foreign decoder — i.e. our blocking encoder stream is accepted by lsqpack end-to-end.
 
-**Still open — Duplicate-of-draining-entries sub-tune (a FRESH session).** The one remaining QPACK
-compression tune: emit a `Duplicate` instruction for a still-useful entry that is close to the
-eviction end ("draining", RFC 9204 §2.1.3) so a new section can reference the fresh copy instead of
-re-inserting or falling to a literal. This is the part with the trickiest eviction-vs-reference
-interaction; do it adversarially-tested. Encoder is `QpackEncoder.kt` (`mutex`-guarded;
-`encodeSection`/`planField`/`processDecoderInstruction`). `QpackEncoderInstruction.Duplicate` and the
-decoder's handling of it already exist.
+## ✅ DONE — Duplicate-of-draining-entries (RFC 9204 §2.1.3, branch `feat/qpack-blocking-encoder`)
+
+Commit `bae8086`. When a re-used header matches an entry in the table's **draining region** (new
+`QpackDynamicTable.isDraining` — the oldest `capacity/8` octets) **and** the table is under pressure (a
+same-size insert would need eviction), the encoder refreshes it with a `Duplicate` (a cheap
+encoder-stream relative index — no value resend) and references the fresh copy, so the old copy stays
+evictable instead of being pinned by the reference. Only taken with blocked-stream budget (the fresh
+copy is unacknowledged). `tryDuplicate` captures the relative index *before* the insert (which advances
+`insertCount`) and evicts only unreferenced entries via `insertIfEvictable`; the decoder reads the
+source before its own duplicate-insert evicts it, so the tables stay in lockstep — encoder-only change
+(decoder already handled `Duplicate`). **Validated:** `isDraining` unit tests + 2 E2E `QpackEncoderTests`
+(refresh-via-Duplicate under pressure; no Duplicate when the table has room), green jvm + linuxX64 +
+jsNode; the aioquic/lsqpack docker interop (64 evicting requests with a recurring header) passes at both
+4096 and thrash-256 capacity with **zero QPACK errors** — lsqpack accepts our Duplicate instructions.
+
+**The QPACK encoder is now complete** — static + dynamic with eviction (ref-counted), blocking
+references (budget-bounded), and draining-duplicate. No known QPACK compression gaps remain.
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under
    `if (isMacOS)`); verify on a macOS runner / CI. Optionally run Apple/Android *tests* in their CI workflows.
 6. **WebTransport** (Phase 2): RFC 9220 Extended CONNECT (gate on `peerSettings().enableConnectProtocol`)

--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -329,8 +329,8 @@ Stacked on `feat/http3-gaps`; green jvm + linuxX64 (183 linuxX64 tests, 0 fail) 
   test (never flaky-fails; fails only on a post-handshake QPACK regression). Not in CI by default — needs a
   Docker sidecar; see `docker-interop/README.md`. (toxiproxy can't help — it's TCP-only, QUIC is UDP;
   netem can layer reorder/loss on the container veth.)
-  *Still deferred:* reference-the-newest + **blocking** encoding (Duplicate of draining entries,
-  RIC > Known Received Count) — a further compression tune that would engage QPACK_BLOCKED_STREAMS.
+  *Still deferred:* the **Duplicate-of-draining-entries** sub-tune (see below — the blocking encoder
+  itself landed on `feat/qpack-blocking-encoder`).
 
 ## NEXT (start here)
 
@@ -355,12 +355,32 @@ invariant — `entryRefCount` + `QpackDynamicTable.insertIfEvictable`. Validated
 loopback + new adversarial eviction tests (jvm + linuxX64). See the "QPACK encoder eviction tune — DONE"
 bullet under "full server role" above for the full description.
 
-**Still open — reference-the-newest + blocking encoder (a FRESH session).** The remaining compression
-tune: reference *unacknowledged* entries (RIC > Known Received Count) and Duplicate entries close to
-eviction (RFC 9204 §2.1.3 draining), which engages **QPACK_BLOCKED_STREAMS** (currently advertised 0).
-That is the part with eviction-vs-blocked-stream interaction; do it adversarially-tested, validating
-against the live interop GET. Encoder is `QpackEncoder.kt` (`mutex`-guarded;
-`encodeSection`/`processDecoderInstruction`).
+## ✅ DONE — blocking QPACK encoder (RFC 9204 §2.1.2, branch `feat/qpack-blocking-encoder`)
+
+Commit `bf09fc9`. The encoder now **references unacknowledged entries** within a budget instead of
+always falling back to a literal on first use, so it actually engages **QPACK_BLOCKED_STREAMS** (both
+peers already advertise 100). `QpackEncoder` gained a `peerMaxBlockedStreams` ctor param (plumbed from
+peer SETTINGS at both the `Http3Connection` client and `Http3ServerConnection` server construction
+sites; default 0 ⇒ strictly non-blocking, fully backwards-compatible). `canBlockStream(streamId)`
+caps concurrently-blocked streams at the peer's advertised value — a stream counts as blocked while it
+has an outstanding section with RIC > Known Received Count; once the budget is spent the encoder falls
+back to the literal path. Within budget, `planField` references a just-inserted or
+present-but-unacknowledged entry directly. Also stopped inserting a wasteful **duplicate** when a
+present-but-unacked entry can't be referenced. The eviction-safety pins (`entryRefCount` +
+`insertIfEvictable`) and the reactively-blocking decoder already existed, so this was an encoder-policy
+flip + a budget counter — no decoder change. **Validated:** 3 new `QpackEncoderTests` (blocking
+first-use reference, reference-existing-unacked-without-duplicating, budget-exhaustion fallback) green
+jvm + linuxX64; the existing dynamic-QPACK loopback now runs *through* the blocking path; and the
+**aioquic/lsqpack docker interop** (`blocked_streams=16`, 64 evicting requests) passes against a
+foreign decoder — i.e. our blocking encoder stream is accepted by lsqpack end-to-end.
+
+**Still open — Duplicate-of-draining-entries sub-tune (a FRESH session).** The one remaining QPACK
+compression tune: emit a `Duplicate` instruction for a still-useful entry that is close to the
+eviction end ("draining", RFC 9204 §2.1.3) so a new section can reference the fresh copy instead of
+re-inserting or falling to a literal. This is the part with the trickiest eviction-vs-reference
+interaction; do it adversarially-tested. Encoder is `QpackEncoder.kt` (`mutex`-guarded;
+`encodeSection`/`planField`/`processDecoderInstruction`). `QpackEncoderInstruction.Duplicate` and the
+decoder's handling of it already exist.
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under
    `if (isMacOS)`); verify on a macOS runner / CI. Optionally run Apple/Android *tests* in their CI workflows.
 6. **WebTransport** (Phase 2): RFC 9220 Extended CONNECT (gate on `peerSettings().enableConnectProtocol`)

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
@@ -442,17 +442,18 @@ class Http3Connection private constructor(
      */
     private fun startEncoderSetup() {
         scope.launch {
-            val peerMax =
+            val settings =
                 try {
-                    peerSettings().qpackMaxTableCapacity
+                    peerSettings()
                 } catch (e: CancellationException) {
                     throw e
                 } catch (_: Throwable) {
                     return@launch // SETTINGS never arrived / connection failed — stay static-only
                 }
+            val peerMax = settings.qpackMaxTableCapacity
             if (peerMax <= 0) return@launch
             val capacity = minOf(QPACK_MAX_TABLE_CAPACITY, peerMax)
-            val newEncoder = QpackEncoder(peerMax) { writeEncoderInstruction(it) }
+            val newEncoder = QpackEncoder(peerMax, settings.qpackBlockedStreams) { writeEncoderInstruction(it) }
             newEncoder.setCapacity(capacity)
             encoder = newEncoder
         }

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -110,10 +110,11 @@ class Http3ServerConnection internal constructor(
     private suspend fun handleControl(reader: Http3StreamReader) {
         val first = reader.nextFrame()
         if (qpackCapacity > 0 && first is Http3Frame.Settings) {
-            val clientMax = Http3Settings(first.entries).qpackMaxTableCapacity
+            val clientSettings = Http3Settings(first.entries)
+            val clientMax = clientSettings.qpackMaxTableCapacity
             if (clientMax > 0) {
                 serverEncoder =
-                    QpackEncoder(clientMax) { writeQpackEncoderInstruction(it) }
+                    QpackEncoder(clientMax, clientSettings.qpackBlockedStreams) { writeQpackEncoderInstruction(it) }
                         .also { it.setCapacity(minOf(qpackCapacity, clientMax)) }
             }
         }

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackDynamicTable.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackDynamicTable.kt
@@ -158,4 +158,28 @@ class QpackDynamicTable(
 
     /** Absolute index of an entry whose name matches (any value), or null (newest-first preference). */
     fun findName(name: String): Long? = entries.lastOrNull { it.name == name }?.absoluteIndex
+
+    /**
+     * True if the live entry [absoluteIndex] sits in the **draining region** (RFC 9204 §2.1.1.1): the
+     * oldest entries occupying the bottom 1/[DRAINING_RESERVE_DIVISOR] of [capacity]. An encoder avoids
+     * pinning draining entries (so they stay evictable) and instead refreshes a still-useful one via a
+     * Duplicate (§2.1.3). Position-based on [capacity], so it measures closeness to the eviction edge —
+     * the caller decides whether the table is also under enough pressure to act on it.
+     */
+    fun isDraining(absoluteIndex: Long): Boolean {
+        val threshold = _capacity / DRAINING_RESERVE_DIVISOR
+        if (threshold <= 0) return false
+        var cumulative = 0L
+        for (entry in entries) { // oldest (lowest absolute index) first
+            cumulative += entry.size
+            if (entry.absoluteIndex == absoluteIndex) return cumulative <= threshold
+            if (cumulative > threshold) return false // past the draining region; the target is newer
+        }
+        return false // not a live entry
+    }
+
+    companion object {
+        /** The draining region is the oldest `capacity / DRAINING_RESERVE_DIVISOR` octets (RFC 9204 §2.1.1.1). */
+        private const val DRAINING_RESERVE_DIVISOR = 8L
+    }
 }

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackEncoder.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackEncoder.kt
@@ -24,6 +24,11 @@ import kotlinx.coroutines.sync.withLock
  *    streams it lets become blocked at the peer's advertised `SETTINGS_QPACK_BLOCKED_STREAMS`
  *    ([peerMaxBlockedStreams]); once that many streams are blocked it falls back to the literal path.
  *
+ * **Draining (RFC 9204 §2.1.3).** When a matched entry is in the table's draining region (the oldest,
+ * about-to-be-evicted entries) and the table is under pressure, the encoder — if it may block — refreshes
+ * it with a `Duplicate` (a cheap encoder-stream index, no value resend) and references the fresh copy, so
+ * the old copy stays evictable instead of being pinned by the reference.
+ *
  * **Eviction (RFC 9204 §2.1.3).** Inserting into a full table evicts its oldest entries. To stay
  * correct the encoder must never evict an entry an outstanding (un-acknowledged) field section still
  * references — otherwise the peer's decoder, which evicts in lockstep, would fail to resolve that
@@ -140,6 +145,17 @@ class QpackEncoder(
 
         val dynamicExact = table.findExact(field.name, field.value)
         if (dynamicExact != null) {
+            // The match is in the draining region (about to be evicted) and the table is under pressure:
+            // refresh it via a cheap Duplicate (encoder-stream index, no value resend) and reference the
+            // fresh copy, so the old one stays evictable instead of being pinned (RFC 9204 §2.1.3). Only
+            // worthwhile with blocked-stream budget, since the fresh copy is unacknowledged.
+            if (canBlock && table.isDraining(dynamicExact) && !table.canInsertWithoutEviction(field.name, field.value)) {
+                val refreshed = tryDuplicate(dynamicExact, sectionRefs)
+                if (refreshed != null) {
+                    sectionRefs += refreshed
+                    return Op.DynamicIndexed(refreshed)
+                }
+            }
             // Reference it when it's acknowledged (never blocks) or when blocked-stream budget lets us
             // risk a reference the peer may not have processed yet (RFC 9204 §2.1.2). A pin keeps a later
             // insert in this same section from evicting it.
@@ -214,6 +230,32 @@ class QpackEncoder(
         } else {
             emit(QpackEncoderInstruction.InsertWithLiteralName(field.name, field.value))
         }
+        return inserted
+    }
+
+    /**
+     * Refresh a still-useful but **draining** entry (RFC 9204 §2.1.3): insert a fresh copy of the entry
+     * at [absoluteIndex] via a Duplicate instruction — which references the source by its encoder-stream
+     * relative index, so the value is not resent — then the old copy can drain out. Evicts oldest entries
+     * as needed but never one that an outstanding section ([entryRefCount]) or the section being built
+     * ([sectionRefs]) still references. Returns the fresh copy's absolute index, or null if the duplicate
+     * can't be inserted safely.
+     *
+     * The relative index is captured BEFORE the insert (which advances `insertCount`); on the decoder side
+     * the Duplicate is read against the same pre-insert state and the source entry is read before its own
+     * duplicate-insert evicts it, so encoder and decoder stay in lockstep.
+     */
+    private suspend fun tryDuplicate(
+        absoluteIndex: Long,
+        sectionRefs: List<Long>,
+    ): Long? {
+        val entry = table.getByAbsolute(absoluteIndex) ?: return null
+        val relativeIndex = table.insertCount - 1 - absoluteIndex
+        val inserted =
+            table.insertIfEvictable(entry.name, entry.value) { e ->
+                !entryRefCount.containsKey(e.absoluteIndex) && e.absoluteIndex !in sectionRefs
+            } ?: return null
+        emit(QpackEncoderInstruction.Duplicate(relativeIndex))
         return inserted
     }
 

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackEncoder.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/QpackEncoder.kt
@@ -10,13 +10,19 @@ import kotlinx.coroutines.sync.withLock
  * The stateful QPACK **encoder** for one connection (RFC 9204): compresses outbound field sections
  * using the static table plus a dynamic table it grows by sending instructions on our QPACK encoder
  * stream ([emit]). Tracks the decoder's acknowledgments ([processDecoderInstruction]) as a Known
- * Received Count so it only *references* entries the peer has confirmed — keeping every emitted
- * section non-blocking.
+ * Received Count so it knows which entries the peer has confirmed.
  *
- * **Strategy (always non-blocking, always spec-legal):** a field that hits the static or an
- * *acknowledged* dynamic entry is encoded as an indexed line; an unseen field is inserted into the
- * dynamic table for *future* reuse but encoded as a literal in the current section, so the section
- * never references an unacknowledged entry and never blocks.
+ * **Strategy:** a field that hits the static or an *acknowledged* dynamic entry is encoded as an
+ * indexed line and never blocks. An unseen field is inserted into the dynamic table; whether *this*
+ * occurrence is then encoded as an index or a literal depends on the blocked-stream budget:
+ *  - **Non-blocking (default / no budget):** the current occurrence is encoded as a literal and a
+ *    *later* section references the entry once the peer acknowledges the insert. Never blocks.
+ *  - **Blocking (within [peerMaxBlockedStreams]):** the current occurrence references the just-inserted
+ *    (or an existing unacknowledged) entry directly — the section's Required Insert Count then exceeds
+ *    the Known Received Count, so the peer's decoder may briefly block until our encoder-stream insert
+ *    arrives (RFC 9204 §2.1.2). This compresses even first occurrences. The encoder caps the number of
+ *    streams it lets become blocked at the peer's advertised `SETTINGS_QPACK_BLOCKED_STREAMS`
+ *    ([peerMaxBlockedStreams]); once that many streams are blocked it falls back to the literal path.
  *
  * **Eviction (RFC 9204 §2.1.3).** Inserting into a full table evicts its oldest entries. To stay
  * correct the encoder must never evict an entry an outstanding (un-acknowledged) field section still
@@ -28,11 +34,13 @@ import kotlinx.coroutines.sync.withLock
  * keeps the table churning as headers evolve (unlike a never-evict table that freezes once full) while
  * preserving the non-blocking invariant.
  *
- * [peerMaxCapacity] is the peer's `SETTINGS_QPACK_MAX_TABLE_CAPACITY`; [emit] writes an encoder-stream
- * instruction on our QPACK encoder uni stream.
+ * [peerMaxCapacity] is the peer's `SETTINGS_QPACK_MAX_TABLE_CAPACITY`; [peerMaxBlockedStreams] is its
+ * `SETTINGS_QPACK_BLOCKED_STREAMS` (0 ⇒ the encoder stays strictly non-blocking); [emit] writes an
+ * encoder-stream instruction on our QPACK encoder uni stream.
  */
 class QpackEncoder(
     peerMaxCapacity: Long,
+    private val peerMaxBlockedStreams: Long = 0,
     private val emit: suspend (QpackEncoderInstruction) -> Unit,
 ) {
     private val table = QpackDynamicTable(peerMaxCapacity)
@@ -89,8 +97,12 @@ class QpackEncoder(
             val sectionRefs = ArrayList<Long>()
             val ops = ArrayList<Op>(fields.size)
             var maxReferencedAbsolute = -1L
+            // One blocking decision per section: referencing unacknowledged entries makes the whole
+            // section block on the peer's decoder, but every such reference still costs only this one
+            // stream against the peer's blocked-stream budget.
+            val canBlock = canBlockStream(streamId)
             for (field in fields) {
-                val op = planField(field, sectionRefs)
+                val op = planField(field, sectionRefs, canBlock)
                 if (op is Op.DynamicIndexed) maxReferencedAbsolute = maxOf(maxReferencedAbsolute, op.absoluteIndex)
                 ops += op
             }
@@ -115,25 +127,69 @@ class QpackEncoder(
 
     /**
      * Plan one field, performing the dynamic-table insertion (and the encoder-stream emit) as a side
-     * effect when the field is new and there is room. Returns the representation to write for *this*
-     * occurrence — never a reference to a just-inserted (unacknowledged) entry.
+     * effect when the field is new and there is room. When [canBlock] is true this may reference a
+     * just-inserted or otherwise-unacknowledged entry (a blocking reference); otherwise it returns a
+     * literal for unacknowledged entries so the section never blocks.
      */
     private suspend fun planField(
         field: QpackHeaderField,
         sectionRefs: MutableList<Long>,
+        canBlock: Boolean,
     ): Op {
         QpackStaticTable.findExact(field.name, field.value)?.let { return Op.StaticIndexed(it.toLong()) }
 
         val dynamicExact = table.findExact(field.name, field.value)
-        if (dynamicExact != null && dynamicExact < knownReceivedCount) {
-            sectionRefs += dynamicExact // pin: a later insert in this section must not evict it
-            return Op.DynamicIndexed(dynamicExact)
+        if (dynamicExact != null) {
+            // Reference it when it's acknowledged (never blocks) or when blocked-stream budget lets us
+            // risk a reference the peer may not have processed yet (RFC 9204 §2.1.2). A pin keeps a later
+            // insert in this same section from evicting it.
+            if (dynamicExact < knownReceivedCount || canBlock) {
+                sectionRefs += dynamicExact
+                return Op.DynamicIndexed(dynamicExact)
+            }
+            // Present but unacknowledged and out of budget: literal this time (a later section references
+            // it once acked). It already exists, so don't insert a duplicate.
+            return literalFor(field)
         }
 
-        tryInsertForFutureReuse(field, sectionRefs)
-        // Encode this occurrence as a literal regardless of whether we just inserted (non-blocking).
+        // Not in either table: insert for future reuse. With budget, reference the fresh insert now (the
+        // section blocks until our encoder-stream insert reaches the peer); otherwise literal this time.
+        val inserted = tryInsertForFutureReuse(field, sectionRefs)
+        if (inserted != null && canBlock) {
+            sectionRefs += inserted
+            return Op.DynamicIndexed(inserted)
+        }
+        return literalFor(field)
+    }
+
+    /** The literal representation of [field] — name-reference when the static table has the name, else fully literal. */
+    private fun literalFor(field: QpackHeaderField): Op {
         val staticName = QpackStaticTable.findName(field.name)
-        return if (staticName != null) Op.LiteralNameRef(staticName.toLong(), field.value) else Op.LiteralName(field.name, field.value)
+        return if (staticName != null) {
+            Op.LiteralNameRef(staticName.toLong(), field.value)
+        } else {
+            Op.LiteralName(field.name, field.value)
+        }
+    }
+
+    /**
+     * Whether a section on [streamId] may include blocking references. True only when the peer permits
+     * blocked streams ([peerMaxBlockedStreams] > 0) and either this stream is already counted as blocked
+     * (so another blocking reference adds no new blocked stream) or we are still under the peer's budget.
+     * A stream counts as blocked while it has an outstanding section whose Required Insert Count exceeds
+     * the Known Received Count — i.e. one the peer's decoder might not yet be able to resolve.
+     */
+    private fun canBlockStream(streamId: Long): Boolean {
+        if (peerMaxBlockedStreams <= 0) return false
+        var blocked = 0
+        var thisStreamAlreadyBlocking = false
+        for ((id, sections) in outstandingSections) {
+            if (sections.any { it.requiredInsertCount > knownReceivedCount }) {
+                blocked++
+                if (id == streamId) thisStreamAlreadyBlocking = true
+            }
+        }
+        return thisStreamAlreadyBlocking || blocked < peerMaxBlockedStreams
     }
 
     /**
@@ -141,23 +197,24 @@ class QpackEncoder(
      * never one that an outstanding section — or the section currently being built ([sectionRefs]) —
      * still references. Emits the encoder-stream insert only when the table actually accepted it. Insert
      * happens BEFORE the emit so our insert count already reflects the entry when the decoder's Insert
-     * Count Increment feeds back (it must never exceed our inserts).
+     * Count Increment feeds back (it must never exceed our inserts). Returns the new entry's absolute
+     * index, or null if it didn't fit / fitting would evict a still-referenced entry.
      */
     private suspend fun tryInsertForFutureReuse(
         field: QpackHeaderField,
         sectionRefs: List<Long>,
-    ) {
+    ): Long? {
         val inserted =
             table.insertIfEvictable(field.name, field.value) { entry ->
                 !entryRefCount.containsKey(entry.absoluteIndex) && entry.absoluteIndex !in sectionRefs
-            }
-        if (inserted == null) return // doesn't fit, or fitting would evict a still-referenced entry
+            } ?: return null
         val staticName = QpackStaticTable.findName(field.name)
         if (staticName != null) {
             emit(QpackEncoderInstruction.InsertWithNameRef(staticName.toLong(), isStatic = true, value = field.value))
         } else {
             emit(QpackEncoderInstruction.InsertWithLiteralName(field.name, field.value))
         }
+        return inserted
     }
 
     /**

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackDynamicTableTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackDynamicTableTests.kt
@@ -129,6 +129,26 @@ class QpackDynamicTableTests {
     }
 
     @Test
+    fun isDrainingMarksOldestEntriesWithinTheReserve() {
+        // capacity 512 ⇒ draining reserve = 512/8 = 64 octets. Each entry is 34 octets, so only the
+        // single oldest entry (cumulative 34 ≤ 64) is draining; the next (cumulative 68 > 64) is not.
+        val t = table(512)
+        t.insert("a", "1") // abs 0, cumulative 34
+        t.insert("b", "2") // abs 1, cumulative 68
+        t.insert("c", "3") // abs 2, cumulative 102
+        assertTrue(t.isDraining(0), "oldest entry is within the draining reserve")
+        assertFalse(t.isDraining(1), "second entry is past the reserve")
+        assertFalse(t.isDraining(2))
+        assertFalse(t.isDraining(5), "a non-live index is never draining")
+    }
+
+    @Test
+    fun isDrainingIsFalseWhenTableUnusable() {
+        // capacity 0 (never raised) ⇒ no draining region at all.
+        assertFalse(QpackDynamicTable(512).isDraining(0))
+    }
+
+    @Test
     fun freshTableHasZeroCapacityUntilRaised() {
         val t = QpackDynamicTable(1000) // not yet setCapacity
         assertEquals(0L, t.capacity)

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackEncoderTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackEncoderTests.kt
@@ -34,7 +34,14 @@ class QpackEncoderTests {
     ) {
         private val encoderToDecoder = ArrayDeque<QpackEncoderInstruction>() // our encoder stream → peer decoder
         private val decoderToEncoder = ArrayDeque<QpackDecoderInstruction>() // peer decoder stream → our encoder
-        val encoder = QpackEncoder(maxCapacity, maxBlockedStreams) { encoderToDecoder.addLast(it) }
+
+        /** Log of every encoder-stream instruction emitted, for asserting the encoding strategy. */
+        val encoderInstructions = mutableListOf<QpackEncoderInstruction>()
+        val encoder =
+            QpackEncoder(maxCapacity, maxBlockedStreams) {
+                encoderInstructions += it
+                encoderToDecoder.addLast(it)
+            }
         val decoder = QpackDecoder(maxCapacity) { decoderToEncoder.addLast(it) }
 
         suspend fun pump() {
@@ -277,6 +284,49 @@ class QpackEncoderTests {
             assertFalse(decoding.isCompleted, "the in-budget section blocks until its insert arrives")
             p.flushEncoderStream()
             assertEquals(listOf(QpackHeaderField("x-a", "1")), decoding.await())
+        }
+
+    @Test
+    fun drainingEntryIsRefreshedViaDuplicateUnderPressure() =
+        runTest {
+            // capacity 512 ⇒ draining reserve = 64 octets → only the single oldest 50-octet entry drains.
+            val p = wired(maxCapacity = 512, maxBlockedStreams = 100)
+            p.encoder.setCapacity(512)
+
+            fun f(i: Int) = QpackHeaderField("name-${i.toString().padStart(4, '0')}", "val-${i.toString().padStart(5, '0')}") // 50 octets
+
+            // Fill: 10 * 50 = 500 ≤ 512; an 11th 50-octet entry would need eviction (pressure). Ack all.
+            for (i in 0 until 10) assertEquals(listOf(f(i)), roundTrip(p, listOf(f(i)), streamId = (i * 4).toLong()))
+            assertEquals(10L, p.encoder.insertCountValue)
+            p.encoderInstructions.clear()
+
+            // Re-reference the oldest entry (abs 0): draining + table full ⇒ refreshed via a Duplicate
+            // (a cheap encoder-stream index, no value resend) rather than pinned or re-inserted literally.
+            assertEquals(listOf(f(0)), roundTrip(p, listOf(f(0)), streamId = 100))
+            assertEquals(11L, p.encoder.insertCountValue, "the draining entry was duplicated (a fresh insert)")
+            assertEquals(11L, p.decoder.insertCountValue, "decoder applied the Duplicate in lockstep")
+            assertEquals(
+                1,
+                p.encoderInstructions.count { it is QpackEncoderInstruction.Duplicate },
+                "refreshed via a Duplicate, not a literal re-insert",
+            )
+        }
+
+    @Test
+    fun drainingDuplicateSkippedWhenTableHasRoom() =
+        runTest {
+            // A near-empty table has no eviction pressure, so even a positionally-draining entry is
+            // referenced directly — no wasteful Duplicate.
+            val p = wired(maxCapacity = 4096, maxBlockedStreams = 100)
+            p.encoder.setCapacity(4096)
+            val f = QpackHeaderField("x", "y")
+
+            assertEquals(listOf(f), roundTrip(p, listOf(f), streamId = 0))
+            p.encoderInstructions.clear()
+
+            assertEquals(listOf(f), roundTrip(p, listOf(f), streamId = 4))
+            assertEquals(1L, p.encoder.insertCountValue, "no duplicate — the table has room")
+            assertEquals(0, p.encoderInstructions.count { it is QpackEncoderInstruction.Duplicate })
         }
 
     @Test

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackEncoderTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/QpackEncoderTests.kt
@@ -4,10 +4,14 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.pool.BufferPool
 import com.ditchoom.buffer.pool.ThreadingMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 /**
  * [QpackEncoder] round-trips against a wired [QpackDecoder] — the encoder's instructions feed the
@@ -15,6 +19,7 @@ import kotlin.test.assertFailsWith
  * miniature. This is the integration test for the whole dynamic stack (prefix + table + instructions
  * + both stateful halves).
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class QpackEncoderTests {
     private val pool = BufferPool(threadingMode = ThreadingMode.SingleThreaded, factory = BufferFactory.Default)
 
@@ -25,10 +30,11 @@ class QpackEncoderTests {
      */
     private inner class Pair(
         maxCapacity: Long,
+        maxBlockedStreams: Long = 0,
     ) {
         private val encoderToDecoder = ArrayDeque<QpackEncoderInstruction>() // our encoder stream → peer decoder
         private val decoderToEncoder = ArrayDeque<QpackDecoderInstruction>() // peer decoder stream → our encoder
-        val encoder = QpackEncoder(maxCapacity) { encoderToDecoder.addLast(it) }
+        val encoder = QpackEncoder(maxCapacity, maxBlockedStreams) { encoderToDecoder.addLast(it) }
         val decoder = QpackDecoder(maxCapacity) { decoderToEncoder.addLast(it) }
 
         suspend fun pump() {
@@ -49,7 +55,10 @@ class QpackEncoderTests {
         }
     }
 
-    private fun wired(maxCapacity: Long = 4096) = Pair(maxCapacity)
+    private fun wired(
+        maxCapacity: Long = 4096,
+        maxBlockedStreams: Long = 0,
+    ) = Pair(maxCapacity, maxBlockedStreams)
 
     private suspend fun roundTrip(
         p: Pair,
@@ -198,6 +207,76 @@ class QpackEncoderTests {
 
             assertEquals(listOf(c), roundTrip(p, listOf(c), streamId = 16)) // now free to evict A, insert C
             assertEquals(3L, p.encoder.insertCountValue, "cancellation unpinned the entry")
+        }
+
+    @Test
+    fun blockingEncoderReferencesUnacknowledgedEntryOnFirstUse() =
+        runTest {
+            // With blocked-stream budget, a brand-new header is inserted AND referenced in the same
+            // section — the section's Required Insert Count then exceeds what the decoder has, so the
+            // decoder must block until the encoder-stream insert arrives. (Non-blocking would be literal.)
+            val p = wired(maxBlockedStreams = 100)
+            p.encoder.setCapacity(4096)
+            val fields = listOf(QpackHeaderField(":method", "GET"), QpackHeaderField("x-custom", "v1"))
+
+            val section = p.encoder.encodeSection(fields, streamId = 0, pool)
+            assertEquals(1L, p.encoder.insertCountValue, "the new field was inserted")
+
+            val decoding = async { p.decoder.decodeSection(section, streamId = 0, scratchPool = null) }
+            runCurrent()
+            assertFalse(decoding.isCompleted, "decode blocks until the insert arrives — proves a blocking reference")
+
+            p.flushEncoderStream() // deliver the insert → unblocks the decoder
+            assertEquals(fields, decoding.await())
+        }
+
+    @Test
+    fun blockingEncoderReferencesExistingUnacknowledgedEntryWithoutDuplicating() =
+        runTest {
+            // An entry that is present but still unacknowledged is referenced directly (blocking) rather
+            // than inserting a wasteful duplicate, as the non-blocking path would.
+            val p = wired(maxBlockedStreams = 100)
+            p.encoder.setCapacity(4096)
+            val field = QpackHeaderField("x-c", "v")
+
+            // Stream 0: insert + reference x-c (abs 0); deliver the insert and decode, but hold the ack
+            // so x-c stays unacknowledged (Known Received Count = 0).
+            val s0 = p.encoder.encodeSection(listOf(field), streamId = 0, pool)
+            p.flushEncoderStream()
+            assertEquals(listOf(field), p.decoder.decodeSection(s0, streamId = 0, scratchPool = null))
+
+            // Stream 4 reuses x-c while it is unacknowledged → referenced, no second insert.
+            val s4 = p.encoder.encodeSection(listOf(field), streamId = 4, pool)
+            assertEquals(1L, p.encoder.insertCountValue, "referenced the existing entry — no duplicate insert")
+            assertEquals(listOf(field), p.decoder.decodeSection(s4, streamId = 4, scratchPool = null))
+        }
+
+    @Test
+    fun blockedStreamBudgetFallsBackToLiteralWhenExhausted() =
+        runTest {
+            // Budget of 1: the first new-header stream becomes blocking; a second one, while the first is
+            // still unacknowledged, exceeds the budget and must fall back to a non-blocking literal.
+            val p = wired(maxBlockedStreams = 1)
+            p.encoder.setCapacity(4096)
+
+            val s0 = p.encoder.encodeSection(listOf(QpackHeaderField("x-a", "1")), streamId = 0, pool)
+            val s4 = p.encoder.encodeSection(listOf(QpackHeaderField("x-b", "2")), streamId = 4, pool)
+            assertEquals(2L, p.encoder.insertCountValue, "both headers inserted for future reuse")
+
+            // s4 was forced literal (budget spent on stream 0): it decodes immediately with NO inserts
+            // delivered — a blocking section would have to wait.
+            assertEquals(
+                listOf(QpackHeaderField("x-b", "2")),
+                p.decoder.decodeSection(s4, streamId = 4, scratchPool = null),
+                "the over-budget section is non-blocking (literal)",
+            )
+
+            // s0 is the one blocking section: it must wait for its insert before it can decode.
+            val decoding = async { p.decoder.decodeSection(s0, streamId = 0, scratchPool = null) }
+            runCurrent()
+            assertFalse(decoding.isCompleted, "the in-budget section blocks until its insert arrives")
+            p.flushEncoderStream()
+            assertEquals(listOf(QpackHeaderField("x-a", "1")), decoding.await())
         }
 
     @Test


### PR DESCRIPTION
## Summary

Completes the QPACK encoder, closing the last two compression tunes the HANDOFF flagged. The encoder was correct but conservative — strictly non-blocking and never duplicating — so `SETTINGS_QPACK_BLOCKED_STREAMS` went unused and hot recurring headers were eventually evicted and re-sent as full literals. This PR adds **blocking references** (RFC 9204 §2.1.2) and **draining-duplicate** (§2.1.3).

After this, the encoder is full dynamic QPACK: static + dynamic with ref-counted eviction, budget-bounded blocking, and draining-duplicate. No known QPACK compression gaps remain.

Backwards-compatible: `QpackEncoder` gained a `peerMaxBlockedStreams` param defaulting to `0`, which preserves the prior strictly-non-blocking behavior when a peer advertises no budget.

## 1. Blocking encoder references (§2.1.2) — `bf09fc9`

- Within the peer's advertised `QPACK_BLOCKED_STREAMS` budget, a section may reference a just-inserted or otherwise-unacknowledged entry directly (RIC > Known Received Count), compressing even first occurrences. `canBlockStream(streamId)` caps concurrently-blocked streams; once spent, falls back to the literal path so we never exceed what the peer permits.
- `peerMaxBlockedStreams` plumbed from peer SETTINGS at both the client (`Http3Connection`) and server (`Http3ServerConnection`) construction sites.
- Also stopped inserting a wasteful duplicate when a present-but-unacknowledged entry can't be referenced.

## 2. Duplicate draining entries (§2.1.3) — `bae8086`

- When a re-used header matches an entry in the table's draining region (`QpackDynamicTable.isDraining` — the oldest `capacity/8` octets) **and** the table is under pressure (a same-size insert would need eviction), the encoder refreshes it with a `Duplicate` (a cheap encoder-stream relative index, no value resend) and references the fresh copy, so the old copy stays evictable instead of being pinned.
- `tryDuplicate` captures the relative index before the insert (which advances `insertCount`) and evicts only unreferenced entries; the decoder reads the source before its own duplicate-insert evicts it, so both tables stay in lockstep. Encoder-only — the decoder already handled `Duplicate`.

No decoder changes: the eviction-safety pins (`entryRefCount` + `insertIfEvictable`) and the reactively-blocking decoder already existed.

## Testing

- New unit tests: `QpackDynamicTableTests.isDraining*`; `QpackEncoderTests` for blocking first-use reference, reference-existing-unacked-without-duplicating, budget-exhaustion fallback, refresh-via-Duplicate-under-pressure, and no-Duplicate-when-room. Green on **jvm + linuxX64 + jsNode**.
- The existing dynamic-QPACK loopback now runs *through* the blocking path (both peers advertise `blocked_streams=100`).
- **Foreign-decoder interop:** the aioquic/lsqpack docker interop (64 evicting requests with a recurring header) passes at both **4096** and **thrash-256** capacity with **zero QPACK errors** — lsqpack accepts our blocking encoder stream and `Duplicate` instructions end-to-end.

## Notes

- The draining reserve (`capacity/8`) is a heuristic; the RFC leaves the size to the implementation.
- Remaining HTTP/3-to-spec work is unrelated to QPACK: Apple `reset()` parity (needs a Mac) and WebTransport Phase 2.