### PR TITLE
fix(linux): cancel timed-out io_uring ops instead of freeing in-flight buffers

### DIFF
--- a/src/linuxMain/kotlin/com/ditchoom/socket/IoUringUtils.kt
+++ b/src/linuxMain/kotlin/com/ditchoom/socket/IoUringUtils.kt
@@ -13,10 +13,19 @@ import kotlin.time.TimeSource
 
 /**
  * Pending operation state - tracks deferred and optional deadline.
+ *
+ * [cancelRequested] is set once the deadline has passed and an `io_uring_prep_cancel64` has
+ * been submitted for this op. The op is NOT completed/removed on expiry — it stays in
+ * `pendingOps` until the kernel produces its CQE (with `-ECANCELED`, or the real result if it
+ * raced in). This preserves the invariant that a buffer handed to io_uring is only freed by the
+ * caller after the kernel is done with it; completing on bare timeout let the caller free a
+ * buffer the kernel still owned, so a later datagram wrote into freed memory (UAF / heap
+ * corruption — the linuxX64 idle-timeout crash).
  */
-private data class PendingOperation(
+private class PendingOperation(
     val deferred: CompletableDeferred<Int>,
     val deadline: TimeSource.Monotonic.ValueTimeMark?,
+    var cancelRequested: Boolean = false,
 )
 
 /**
@@ -255,6 +264,9 @@ object IoUringManager {
 
         for ((_, op) in pendingOps) {
             val deadline = op.deadline ?: continue
+            // Already cancel-requested: its deadline is moot, we're just awaiting the kernel CQE.
+            // Counting it would peg the wait at ZERO and busy-spin until that CQE lands.
+            if (op.cancelRequested) continue
             val remaining = -deadline.elapsedNow()
             if (earliest == null || remaining < earliest) {
                 earliest = remaining
@@ -269,19 +281,36 @@ object IoUringManager {
     }
 
     /**
-     * Check for expired operations and complete them with -ETIMEDOUT.
+     * Handle expired operations. On deadline, submit an `io_uring_prep_cancel64` for the op's
+     * userData rather than completing its deferred — the op stays in [pendingOps] until the kernel
+     * delivers its CQE (which the normal CQE path completes with `-ECANCELED`, or the real result
+     * if a completion raced the deadline). The kernel may still be holding the op's buffer pointer;
+     * fabricating a `-ETIMEDOUT` completion here let the caller free that buffer while the recv was
+     * still in flight, so a later datagram wrote into freed memory — the UAF behind the linuxX64
+     * idle-timeout crash. Mirrors the coroutine-cancellation path in [submitAndWait].
+     *
      * Only called from the event loop thread (no synchronization needed).
+     * Returns true if any cancel SQEs were prepared (caller must `io_uring_submit`).
      */
-    private fun processExpiredOperations(pendingOps: HashMap<Long, PendingOperation>) {
-        val iterator = pendingOps.iterator()
-        while (iterator.hasNext()) {
-            val (_, op) = iterator.next()
+    private fun processExpiredOperations(
+        ring: CPointer<io_uring>,
+        pendingOps: HashMap<Long, PendingOperation>,
+    ): Boolean {
+        var submittedCancel = false
+        for ((userData, op) in pendingOps) {
             val deadline = op.deadline ?: continue
-            if (deadline.hasPassedNow() && !op.deferred.isCompleted) {
-                op.deferred.complete(-ETIMEDOUT)
-                iterator.remove()
-            }
+            if (op.cancelRequested || op.deferred.isCompleted) continue
+            if (!deadline.hasPassedNow()) continue
+            val sqe = io_uring_get_sqe(ring) ?: break // ring full — retry next iteration
+            io_uring_prep_cancel64(sqe, userData.toULong(), 0)
+            // The cancel's own CQE carries a fresh userData → ignored by the CQE dispatcher
+            // (pendingOps.remove returns null). The original op's CQE completes the deferred.
+            io_uring_sqe_set_data64(sqe, nextUserData().toULong())
+            op.cancelRequested = true
+            timeoutCancelSubmitCount.incrementAndGet()
+            submittedCancel = true
         }
+        return submittedCancel
     }
 
     /**
@@ -363,8 +392,10 @@ object IoUringManager {
                 val waitRet = io_uring_wait_cqe_timeout(ring, cqePtr.ptr, ts.ptr)
                 pollerSleeping.value = 0
 
-                // 5. Process expired operations
-                processExpiredOperations(pendingOps)
+                // 5. Process expired operations — submit cancels for any that timed out
+                if (processExpiredOperations(ring, pendingOps)) {
+                    io_uring_submit(ring)
+                }
 
                 if (waitRet == -ETIME || waitRet == -ETIMEDOUT) {
                     continue
@@ -404,7 +435,13 @@ object IoUringManager {
                     // Dispatch to waiting coroutine
                     val op = pendingOps.remove(userData)
                     if (op != null && !op.deferred.isCompleted) {
-                        op.deferred.complete(result)
+                        // A timeout-cancelled op reports -ETIMEDOUT to the caller (preserving
+                        // SocketTimeoutException semantics), unless a datagram actually arrived
+                        // before the cancel landed (result >= 0) — then deliver the real result.
+                        // Crucially the deferred completes only now, on the CQE, so the caller
+                        // frees its buffer only after the kernel is done with it (no UAF).
+                        val toComplete = if (op.cancelRequested && result < 0) -ETIMEDOUT else result
+                        op.deferred.complete(toComplete)
                     }
                 } while (io_uring_peek_cqe(ring, cqePtr.ptr) >= 0)
             }
@@ -583,6 +620,14 @@ object IoUringManager {
      * read, instead of racing close() vs read() on wall-clock timing (issue #83).
      */
     internal val cancelSubmitCount = AtomicInt(0)
+
+    /**
+     * Test-observable count of cancel SQEs submitted by [processExpiredOperations] when an op's
+     * deadline passes. A deterministic test asserts this increments so a timed-out op is cancelled
+     * in the kernel (and its buffer freed only after the resulting CQE) rather than completed while
+     * the recv is still in flight — the UAF behind the linuxX64 idle-timeout crash.
+     */
+    internal val timeoutCancelSubmitCount = AtomicInt(0)
 
     /**
      * Submit a fire-and-forget io_uring cancel for an in-flight operation identified

--- a/src/linuxTest/kotlin/com/ditchoom/socket/IoUringManagerTests.kt
+++ b/src/linuxTest/kotlin/com/ditchoom/socket/IoUringManagerTests.kt
@@ -294,6 +294,56 @@ class IoUringManagerTests {
         }
 
     /**
+     * Regression for the linuxX64 idle-timeout crash (project_ci_backend_coverage): a recv that hits
+     * its deadline must be cancelled in the kernel — not completed while still in flight. Completing
+     * a timed-out recv let the caller free the buffer the kernel still owned, so a later datagram
+     * wrote into freed memory (UAF / heap corruption). This asserts deterministically that the
+     * expiry path submits a cancel SQE (via the [IoUringManager.timeoutCancelSubmitCount] counter)
+     * AND that the timeout still surfaces as [SocketTimeoutException] (semantics preserved), rather
+     * than racing a real crash on wall-clock timing.
+     */
+    @Test
+    fun timedOutReadCancelsKernelOpAndStillReportsTimeout() =
+        runTestNoTimeSkipping {
+            val server = ServerSocket.allocate()
+            val serverJob =
+                launch {
+                    try {
+                        // Accept and hold the connection open without ever sending — the client's
+                        // read must time out (and be kernel-cancelled), not receive data.
+                        server.bind(0, "127.0.0.1").collect { delay(30.seconds) }
+                    } catch (e: Exception) {
+                        // Server closed
+                    }
+                }
+
+            delay(100.milliseconds)
+            val port = server.port()
+
+            val client = ClientSocket.allocate()
+            client.open(port, 5.seconds, "127.0.0.1")
+
+            val before = IoUringManager.timeoutCancelSubmitCount.value
+            var timedOut = false
+            try {
+                client.read(200.milliseconds)
+            } catch (e: SocketTimeoutException) {
+                timedOut = true
+            }
+
+            assertTrue(timedOut, "read with no incoming data should surface SocketTimeoutException")
+            assertTrue(
+                IoUringManager.timeoutCancelSubmitCount.value > before,
+                "an expired recv must submit an io_uring cancel so the kernel releases the buffer " +
+                    "(counter ${IoUringManager.timeoutCancelSubmitCount.value} did not advance past $before)",
+            )
+
+            client.close()
+            server.close()
+            serverJob.cancel()
+        }
+
+    /**
      * Stress test: many rapid cleanup/reinitialize cycles.
      */
     @Test


### PR DESCRIPTION
## Problem

`LinuxQuicIdleTimeoutTests` crashed the Kotlin/Native (linuxX64) test process ~60% locally — a native crash ("Test running process exited unexpectedly", no assertion), with the crash point moving between `idleConnectionTimesOutWithCleanEnd` and `activityKeepsConnectionAlivePastIdleTimeout`. Buffer-version-independent (reproduced on both buffer 5.3.1 and 5.5.0).

## Root cause — use-after-free in the io_uring timeout path

`IoUringManager`'s event loop completed an expired op with `-ETIMEDOUT` and dropped it from `pendingOps` **without cancelling the in-flight kernel recv**. The QUIC UDP reader loop (`QuicheDriver.udpReaderLoop`) then saw the negative result and freed that buffer (`buf.freeNativeMemory()`) while the kernel still owned the recv SQE pointing at it. When a later datagram arrived — e.g. the peer's `CONNECTION_CLOSE` during idle teardown — the kernel wrote into freed memory → heap corruption → process crash. The reader's 1s idle re-submit loop made this fire repeatedly during teardown, hence the high local rate.

## Fix

On deadline, submit an `io_uring_prep_cancel64` for the op and **keep it pending** until the kernel delivers its CQE. The waiter (and therefore the buffer free) completes only once the kernel is done with the buffer — restoring the invariant that a buffer handed to io_uring is freed only after its CQE. This mirrors the existing coroutine-cancellation path in `submitAndWait`.

Timeout **semantics are preserved**: a timeout-cancelled op still reports `-ETIMEDOUT` to the caller (so `SocketTimeoutException` is unchanged), unless a datagram actually raced in before the cancel landed (then the real result is delivered).

## Test

Adds a deterministic regression test (`IoUringManagerTests.timedOutReadCancelsKernelOpAndStillReportsTimeout`) using a new test-observable `timeoutCancelSubmitCount` counter — asserts an expired recv submits a cancel SQE *and* still surfaces `SocketTimeoutException`, instead of racing a real crash on wall-clock timing.

## Verification (local)

- `LinuxQuicIdleTimeoutTests`: **8/8 green** (was ~60% crash).
- Full `:linuxX64Test` + `:socket-quic:linuxX64Test` + io_uring close-cancel tests: green.
- `ktlintCheck`: green.

The fix is in shared `linuxMain` io_uring code, so the new regression test also exercises the **ARM64** native job (relevant given the related cancel work in #83 was ARM64-specific).