### PR TITLE
feat(quic): reactive keepalive (QuicOptions.keepAliveInterval) — fixes the #1 idle-timeout flake

### DIFF
--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicIdleTimeoutTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicIdleTimeoutTests.kt
@@ -63,25 +63,27 @@ class AndroidQuicIdleTimeoutTests {
             }
         }
 
+    // Reactive keepalive (mirrors the common QuicIdleTimeoutTestSuite): with keepAliveInterval set below
+    // the idle timeout, an OTHERWISE-IDLE connection stays alive past the idle timeout via driver-scheduled
+    // PINGs. Deterministic — one idle wait that must exceed the timeout, then a single liveness round-trip.
     @Test
     fun activityKeepsConnectionAlivePastIdleTimeout() =
         runBlocking(Dispatchers.IO) {
             skipOnMissingNativeLib {
                 withTimeout(25.seconds) {
-                    val opts = options(KEEPALIVE_IDLE)
+                    val opts = options(KEEPALIVE_IDLE).copy(keepAliveInterval = KEEPALIVE_INTERVAL)
                     withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = opts) {
                         val serverJob = launch(Dispatchers.IO) { echoEveryStream() }
                         try {
                             withQuicConnection("127.0.0.1", port, opts, timeout = 10.seconds) {
                                 val stream = openStream()
-                                for (round in 0 until KEEPALIVE_ROUNDS) {
-                                    assertEquals(
-                                        "ka-$round",
-                                        stream.echoOnce("ka-$round"),
-                                        "echo $round failed — connection idle-closed despite activity (idle timer not reset)",
-                                    )
-                                    delay(KEEPALIVE_GAP)
-                                }
+                                assertEquals("warmup", stream.echoOnce("warmup"), "warmup echo failed before idle wait")
+                                delay(KEEPALIVE_IDLE_WAIT)
+                                assertEquals(
+                                    "still-alive",
+                                    stream.echoOnce("still-alive"),
+                                    "connection idle-closed despite keepalive — the reactive PING did not reset the idle timer",
+                                )
                                 stream.close()
                             }
                         } finally {
@@ -140,7 +142,7 @@ class AndroidQuicIdleTimeoutTests {
         private val IDLE_TIMEOUT = 2.seconds
         private val READ_TIMEOUT = 10.seconds
         private val KEEPALIVE_IDLE = 4.seconds
-        private val KEEPALIVE_GAP = 1.seconds
-        private const val KEEPALIVE_ROUNDS = 6
+        private val KEEPALIVE_INTERVAL = 1.seconds
+        private val KEEPALIVE_IDLE_WAIT = 6.seconds
     }
 }

--- a/socket-quic/src/androidMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.android.kt
+++ b/socket-quic/src/androidMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.android.kt
@@ -10,4 +10,4 @@ actual suspend fun <R> withQuicConnection(
     connectionOptions: ConnectionOptions,
     timeout: Duration,
     block: suspend QuicScope.() -> R,
-): R = commonJvmWithQuicConnection(hostname, port, quicOptions, connectionOptions, timeout, block)
+): R = commonJvmWithQuicConnection(hostname, port, quicOptions, connectionOptions, timeout, block = block)

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -129,6 +129,7 @@ private suspend fun <R> connectQuicGroup(
             NSNumber(bool = quicOptions.verifyPeer),
             caDerList,
             quicOptions.idleTimeout.inWholeSeconds.toInt(),
+            quicOptions.keepAliveInterval?.inWholeSeconds?.toInt() ?: 0,
             timeout.inWholeSeconds.toInt(),
             maxFrameSize,
         ) ?: throw SocketConnectionException.Refused(hostname, port, platformError = "Failed to create QUIC connection group")

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
@@ -97,6 +97,7 @@ actual suspend fun <R> withQuicServer(
             alpnList,
             identity,
             quicOptions.idleTimeout.inWholeSeconds.toInt(),
+            quicOptions.keepAliveInterval?.inWholeSeconds?.toInt() ?: 0,
             maxFrameSize,
         )
             ?: throw SocketConnectionException.Refused(

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
@@ -29,9 +29,11 @@ internal suspend fun <R> commonJvmWithQuicConnection(
     quicOptions: QuicOptions,
     connectionOptions: ConnectionOptions,
     timeout: Duration,
+    // Defaults to the production loader; a test passes a spy (e.g. CountingQuicheApi) to observe the
+    // real native calls the driver makes — used to assert reactive keepalive actually PINGs.
+    api: QuicheApi = loadQuicheApi(),
     block: suspend QuicScope.() -> R,
 ): R {
-    val api: QuicheApi = loadQuicheApi()
     val parentJob = SupervisorJob()
     val parentScope = CoroutineScope(parentJob + Dispatchers.IO)
     try {
@@ -138,6 +140,7 @@ internal suspend fun <R> commonJvmWithQuicConnection(
                         udpChannel = udpChannel,
                         clientMode = true,
                         isServer = false,
+                        keepAliveInterval = quicOptions.keepAliveInterval,
                         // Connection-migration wiring (slice 3): the peer + primary local sockaddrs
                         // (kept pinned by onCleanup for the driver's life) and a factory for opening
                         // additional path sockets to the same peer.

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -79,7 +79,7 @@ internal suspend fun <R> commonJvmWithQuicServer(
         channel.bind(InetSocketAddress(host ?: "0.0.0.0", port))
         val localAddr = channel.localAddress as InetSocketAddress
 
-        val server = JvmQuicServer(api, config, channel, localAddr, bufferFactory, parentScope)
+        val server = JvmQuicServer(api, config, channel, localAddr, bufferFactory, parentScope, quicOptions.keepAliveInterval)
         try {
             return server.block()
         } finally {
@@ -127,6 +127,7 @@ internal class JvmQuicServer(
     private val localAddr: InetSocketAddress,
     private val bufferFactory: BufferFactory,
     parentScope: CoroutineScope,
+    private val keepAliveInterval: Duration? = null,
 ) : QuicServer {
     override val port: Int get() = localAddr.port
 
@@ -597,6 +598,7 @@ internal class JvmQuicServer(
                 udpChannel = udpChannel,
                 clientMode = false,
                 isServer = true,
+                keepAliveInterval = keepAliveInterval,
                 onCleanup = {
                     peerSockAddr.free()
                     localSockAddr.free()

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -261,6 +261,8 @@ object JniQuicheApi : QuicheApi {
 
     override fun connOnTimeout(conn: QuicheConn) = nConnOnTimeout(conn.handle)
 
+    override fun connSendAckEliciting(conn: QuicheConn): Int = nConnSendAckEliciting(conn.handle).toInt()
+
     override fun connClose(
         conn: QuicheConn,
         error: QuicError,
@@ -665,6 +667,8 @@ object JniQuicheApi : QuicheApi {
     @JvmStatic private external fun nConnTimeoutAsNanos(conn: Long): Long
 
     @JvmStatic private external fun nConnOnTimeout(conn: Long)
+
+    @JvmStatic private external fun nConnSendAckEliciting(conn: Long): Long
 
     @JvmStatic private external fun nConnClose(
         conn: Long,

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicOptions.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicOptions.kt
@@ -116,6 +116,15 @@ data class QuicOptions(
     val pacing: Pacing = Pacing.Unlimited,
     /** Connection idle timeout. Zero means no timeout. */
     val idleTimeout: Duration = 30.seconds,
+    /**
+     * Keepalive interval. When set, the endpoint sends an ack-eliciting packet (a PING) after this much
+     * inactivity, resetting both peers' idle timers (RFC 9000 §10.1.2) — so an otherwise-idle connection
+     * stays alive past [idleTimeout] with no application traffic. Reactive: the PING is scheduled on the
+     * connection's own timer inside the driver's event loop, not by polling. Null (the default) disables
+     * keepalive. Must be positive and, when [idleTimeout] is non-zero, strictly less than it (a PING after
+     * the connection already idled out is useless).
+     */
+    val keepAliveInterval: Duration? = null,
     /** Maximum UDP payload size (bytes). Must be >= 1200 per RFC 9000. */
     val maxUdpPayloadSize: Int = 1350,
     /** Initial congestion window in packets. Null uses quiche default. */
@@ -163,6 +172,12 @@ data class QuicOptions(
     init {
         require(alpnProtocols.isNotEmpty()) { "QUIC requires at least one ALPN protocol" }
         require(!idleTimeout.isNegative()) { "idleTimeout must be non-negative" }
+        keepAliveInterval?.let { ka ->
+            require(ka.isPositive()) { "keepAliveInterval must be positive" }
+            require(idleTimeout == Duration.ZERO || ka < idleTimeout) {
+                "keepAliveInterval ($ka) must be less than idleTimeout ($idleTimeout)"
+            }
+        }
         require(maxUdpPayloadSize >= 1200) { "maxUdpPayloadSize must be >= 1200 per RFC 9000" }
         require(initialCongestionWindowPackets == null || initialCongestionWindowPackets > 0) {
             "initialCongestionWindowPackets must be positive"

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -261,6 +261,14 @@ interface QuicheApi {
     fun connOnTimeout(conn: QuicheConn)
 
     /**
+     * Schedule an ack-eliciting packet (a PING) on the active path — `quiche_conn_send_ack_eliciting`.
+     * The packet is emitted by the next [connSend] flush; on receipt the peer ACKs it, resetting both
+     * endpoints' idle timers. Used to implement reactive keepalive. Returns 0 on success or a negative
+     * quiche error code (e.g. `QUICHE_ERR_DONE` when nothing needs sending).
+     */
+    fun connSendAckEliciting(conn: QuicheConn): Int
+
+    /**
      * Close the connection with the given [error].
      * Implementations decompose [QuicError] into the C API's `app` flag and error code.
      */

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -27,6 +27,7 @@ import kotlin.concurrent.Volatile
 import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
 import kotlin.time.Duration
+import kotlin.time.TimeSource
 
 /**
  * Drives a single quiche connection from one coroutine. No mutexes, no polling.
@@ -50,6 +51,13 @@ class QuicheDriver(
     private val udpChannel: UdpChannel,
     private val clientMode: Boolean = true,
     private val isServer: Boolean = false,
+    /**
+     * Reactive keepalive (RFC 9000 §10.1.2): when non-null, after this much inactivity the driver
+     * schedules an ack-eliciting PING (resetting both peers' idle timers) so an otherwise-idle
+     * connection survives past its idle timeout with no application traffic. The PING is timed off
+     * the driver's own [select] loop — no polling. Null disables keepalive. See [QuicOptions.keepAliveInterval].
+     */
+    private val keepAliveInterval: Duration? = null,
     /**
      * Connection-migration wiring (slice 3). All default to "disabled" so server-accepted
      * drivers, unit-test fakes, and the no-migration platforms keep their single-path
@@ -247,23 +255,53 @@ class QuicheDriver(
     private suspend fun run() {
         try {
             afterCommand() // initial flush (e.g., ClientHello or ServerHello response)
+            // Reactive keepalive: time inactivity off a monotonic mark, reset on every command we
+            // process. We wake at min(quiche's next timer, keepalive deadline); whichever is sooner
+            // decides whether we PING or hand the timeout to quiche. No polling.
+            var lastActivity = TimeSource.Monotonic.markNow()
             while (true) {
-                val timeout = api.connTimeout(conn)
+                val connTimeout = api.connTimeout(conn)
+                // Keepalive only counts once the handshake is established (the handshake itself is
+                // continuous activity, and a half-open connection has nothing to keep alive).
+                val keepAliveRemaining =
+                    keepAliveInterval
+                        ?.takeIf { api.connIsEstablished(conn) }
+                        ?.let { (it - lastActivity.elapsedNow()).coerceAtLeast(Duration.ZERO) }
+                val wait =
+                    when {
+                        connTimeout != null && keepAliveRemaining != null -> minOf(connTimeout, keepAliveRemaining)
+                        else -> connTimeout ?: keepAliveRemaining
+                    }
                 val cmd =
-                    if (timeout == null) {
-                        // No timeout set — block until next command (or channel close)
+                    if (wait == null) {
+                        // No timer pending — block until next command (or channel close)
                         commands.receiveCatching().getOrNull() ?: break
                     } else {
                         select<QuicheCmd?> {
                             commands.onReceiveCatching { it.getOrNull() }
-                            onTimeout(timeout) { null }
+                            onTimeout(wait) { null }
                         }
                     }
                 // null from onReceiveCatching means channel closed — exit
                 if (cmd == null && commands.isClosedForReceive) break
                 when {
-                    cmd is QuicheCmd.Migrate -> handleMigrate(cmd) // suspends: opens a socket
-                    cmd != null -> execute(cmd)
+                    cmd is QuicheCmd.Migrate -> {
+                        handleMigrate(cmd) // suspends: opens a socket
+                        lastActivity = TimeSource.Monotonic.markNow()
+                    }
+                    cmd != null -> {
+                        execute(cmd)
+                        lastActivity = TimeSource.Monotonic.markNow() // any command is activity → defer keepalive
+                    }
+                    // A timer fired. If the keepalive deadline is strictly the sooner one, PING; quiche's
+                    // idle timer is always later (keepAliveInterval < idleTimeout), so this fires first and
+                    // prevents the idle close. Otherwise hand the (idle/loss-recovery) timeout to quiche.
+                    keepAliveRemaining != null && (connTimeout == null || keepAliveRemaining < connTimeout) -> {
+                        if (!api.connIsClosed(conn)) {
+                            api.connSendAckEliciting(conn) // emitted by the afterCommand() flush below
+                            lastActivity = TimeSource.Monotonic.markNow()
+                        }
+                    }
                     else -> api.connOnTimeout(conn)
                 }
                 afterCommand()

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicIdleTimeoutTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicIdleTimeoutTestSuite.kt
@@ -79,28 +79,35 @@ abstract class QuicIdleTimeoutTestSuite {
         }
 
     /**
-     * Activity resets the idle timer: echo every [KEEPALIVE_GAP] for a total well past [KEEPALIVE_IDLE].
-     * Each gap is far below the idle timeout, so the connection must stay alive for every round; if the
-     * idle timer were not reset by traffic, a mid-loop echo would fail because the connection had closed.
+     * Reactive keepalive (RFC 9000 §10.1.2): with [QuicOptions.keepAliveInterval] set below the idle
+     * timeout, an **otherwise-idle** connection — no application traffic at all — stays alive past the
+     * idle timeout because the driver schedules ack-eliciting PINGs on its own timer.
+     *
+     * Deterministic by construction: we prime the stream, then go fully idle and wait *once* for well
+     * over the idle timeout before a single liveness round-trip. A longer wait (a slow/loaded runner)
+     * only strengthens the test — there is no upper-bounded gap that scheduling jitter can blow past, the
+     * way the old "echo every N ms for K rounds" version had. Without keepalive the idle timer closes the
+     * connection during the wait and the final echo fails; with it, the echo round-trips.
      */
     @Test
     fun activityKeepsConnectionAlivePastIdleTimeout() =
         runQuicTest {
             wrapTestBody {
-                val opts = options(KEEPALIVE_IDLE)
+                val opts = options(KEEPALIVE_IDLE).copy(keepAliveInterval = KEEPALIVE_INTERVAL)
                 withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = opts) {
                     val serverJob = launch { echoEveryStream() }
                     try {
                         withQuicConnection("127.0.0.1", port, opts, timeout = 10.seconds) {
                             val stream = openStream()
-                            for (round in 0 until KEEPALIVE_ROUNDS) {
-                                assertEquals(
-                                    "ka-$round",
-                                    stream.echoOnce("ka-$round"),
-                                    "echo $round failed — connection idle-closed despite activity (idle timer not reset)",
-                                )
-                                delay(KEEPALIVE_GAP)
-                            }
+                            // Establish the stream on the server, then go completely idle for longer than
+                            // the idle timeout. Reactive keepalive must hold the connection open.
+                            assertEquals("warmup", stream.echoOnce("warmup"), "warmup echo failed before idle wait")
+                            delay(KEEPALIVE_IDLE_WAIT)
+                            assertEquals(
+                                "still-alive",
+                                stream.echoOnce("still-alive"),
+                                "connection idle-closed despite keepalive — the reactive PING did not reset the idle timer",
+                            )
                             stream.close()
                         }
                     } finally {
@@ -155,7 +162,7 @@ abstract class QuicIdleTimeoutTestSuite {
         private val READ_TIMEOUT = 10.seconds // > IDLE_TIMEOUT so a working idle-close returns End first
 
         private val KEEPALIVE_IDLE = 4.seconds
-        private val KEEPALIVE_GAP = 1.seconds // far below KEEPALIVE_IDLE — generous margin against jitter
-        private const val KEEPALIVE_ROUNDS = 6 // 6 × 1 s = ~6 s of activity, well past the 4 s idle timeout
+        private val KEEPALIVE_INTERVAL = 1.seconds // PING every 1 s — 3 s slack under the 4 s idle timeout
+        private val KEEPALIVE_IDLE_WAIT = 6.seconds // idle well past KEEPALIVE_IDLE so a broken keepalive closes
     }
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -627,6 +627,44 @@ class ReactiveDriverTests {
             }
         }
 
+    // ---- Reactive keepalive ----
+
+    @Test
+    fun keepAlive_schedulesAckElicitingPings_onIdleConnection() =
+        runQuicTest {
+            // Stub defaults: established=true, connTimeout=null, closed=false. With no commands and no
+            // quiche timeout, the ONLY thing that can wake the driver loop is the keepalive deadline — so
+            // any ack-eliciting PING proves the reactive keepalive timer fired. No network, no flaky
+            // wall-clock assertion: we wait for a COUNT within a generous window (50ms interval → dozens
+            // of PINGs possible in 3s; reaching >= 2 needs only ~100ms of driver scheduling).
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api, keepAliveInterval = 50.milliseconds)
+            driver.start(this)
+            try {
+                awaitUntil(3.seconds, "driver never scheduled a keepalive PING (ackElicitingCount stayed 0)") {
+                    api.ackElicitingCount >= 2
+                }
+            } finally {
+                driver.commands.close()
+            }
+        }
+
+    @Test
+    fun keepAlive_disabled_sendsNoPings() =
+        runQuicTest {
+            // No keepAliveInterval → the driver must never call connSendAckEliciting, however long it idles.
+            // Disabled means "never", independent of the settle window — so this can't flake on timing.
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api, keepAliveInterval = null)
+            driver.start(this)
+            try {
+                kotlinx.coroutines.delay(300.milliseconds) // real time for a stray PING to surface, if any
+                assertEquals(0, api.ackElicitingCount, "keepalive disabled but the driver still sent ack-eliciting PINGs")
+            } finally {
+                driver.commands.close()
+            }
+        }
+
     // ---- Helpers ----
 
     private suspend fun sendOpenStream(driver: QuicheDriver): StreamSlot {
@@ -639,6 +677,7 @@ class ReactiveDriverTests {
         api: StubQuicheApi = StubQuicheApi(),
         isServer: Boolean = false,
         udpChannel: UdpChannel = StubUdpChannel(),
+        keepAliveInterval: kotlin.time.Duration? = null,
     ): QuicheDriver =
         QuicheDriver(
             api = api,
@@ -649,5 +688,6 @@ class ReactiveDriverTests {
             udpChannel = udpChannel,
             clientMode = false,
             isServer = isServer,
+            keepAliveInterval = keepAliveInterval,
         )
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -283,6 +283,15 @@ internal class StubQuicheApi : QuicheApi {
 
     override fun connOnTimeout(conn: QuicheConn) {}
 
+    /** Counts reactive-keepalive PINGs the driver scheduled, so tests can assert on them. */
+    var ackElicitingCount = 0
+        private set
+
+    override fun connSendAckEliciting(conn: QuicheConn): Int {
+        ackElicitingCount++
+        return 0
+    }
+
     override fun connClose(
         conn: QuicheConn,
         error: QuicError,

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -278,6 +278,12 @@ JNIEXPORT void JNICALL JNI_FN(nConnOnTimeout)(JNIEnv *env, jclass cls, jlong con
     quiche_conn_on_timeout((quiche_conn *)(uintptr_t)conn);
 }
 
+JNIEXPORT jlong JNICALL JNI_FN(nConnSendAckEliciting)(JNIEnv *env, jclass cls, jlong conn) {
+    /* Schedules a PING on the active path; emitted by the next send(). Returns 0 on success or a
+       negative quiche error code. */
+    return (jlong)quiche_conn_send_ack_eliciting((quiche_conn *)(uintptr_t)conn);
+}
+
 JNIEXPORT jint JNICALL JNI_FN(nConnClose)(
     JNIEnv *env, jclass cls,
     jlong conn, jboolean app, jlong err, jlong reason_addr, jint reason_len) {

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -168,6 +168,9 @@ class FfmQuicheApi private constructor(
         downcall("quiche_conn_timeout_as_nanos", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
     }
     private val hOnTimeout by lazy { downcall("quiche_conn_on_timeout", FunctionDescriptor.ofVoid(ADDRESS)) }
+    private val hSendAckEliciting by lazy {
+        downcall("quiche_conn_send_ack_eliciting", FunctionDescriptor.of(JAVA_LONG, ADDRESS))
+    }
     private val hConnClose by lazy {
         downcall(
             "quiche_conn_close",
@@ -531,6 +534,8 @@ class FfmQuicheApi private constructor(
     override fun connOnTimeout(conn: QuicheConn) {
         hOnTimeout.invokeExact(seg(conn.handle))
     }
+
+    override fun connSendAckEliciting(conn: QuicheConn): Int = (hSendAckEliciting.invokeExact(seg(conn.handle)) as Long).toInt()
 
     override fun connClose(
         conn: QuicheConn,

--- a/socket-quic/src/jvmMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.jvm.kt
+++ b/socket-quic/src/jvmMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.jvm.kt
@@ -10,4 +10,4 @@ actual suspend fun <R> withQuicConnection(
     connectionOptions: ConnectionOptions,
     timeout: Duration,
     block: suspend QuicScope.() -> R,
-): R = commonJvmWithQuicConnection(hostname, port, quicOptions, connectionOptions, timeout, block)
+): R = commonJvmWithQuicConnection(hostname, port, quicOptions, connectionOptions, timeout, block = block)

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/CountingQuicheApi.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/CountingQuicheApi.kt
@@ -1,0 +1,20 @@
+package com.ditchoom.socket.quic
+
+/**
+ * A [QuicheApi] spy that delegates every call to a real [delegate] backend (via Kotlin interface
+ * delegation) but counts reactive-keepalive PINGs. Lets an integration test assert that the driver,
+ * running against the **real** native binding, actually invoked `quiche_conn_send_ack_eliciting` —
+ * tightening the seam left by the stub-based driver-logic tests in `ReactiveDriverTests`.
+ */
+internal class CountingQuicheApi(
+    private val delegate: QuicheApi,
+) : QuicheApi by delegate {
+    @Volatile
+    var ackElicitingCount = 0
+        private set
+
+    override fun connSendAckEliciting(conn: QuicheConn): Int {
+        ackElicitingCount++
+        return delegate.connSendAckEliciting(conn)
+    }
+}

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicKeepAlivePingSeamTest.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicKeepAlivePingSeamTest.kt
@@ -1,0 +1,106 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.socket.ConnectionOptions
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.junit.Assume.assumeTrue
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Seam-tightening integration test (JVM/JNI). Drives a **real** quiche client through a
+ * [CountingQuicheApi] spy and asserts the reactive keepalive actually invoked the native
+ * `quiche_conn_send_ack_eliciting` while the connection sat idle past its timeout — not merely that the
+ * connection "survived". This closes the gap between the stub-based scheduling tests in
+ * [ReactiveDriverTests] (which prove the driver logic, no native call) and [QuicIdleTimeoutTests]
+ * (which prove end-to-end survival but don't directly observe the PING).
+ */
+class QuicKeepAlivePingSeamTest {
+    private fun certPath(name: String): String {
+        val url = this::class.java.classLoader.getResource("certs/$name") ?: error("Test cert not found: certs/$name")
+        return File(url.toURI()).absolutePath
+    }
+
+    private val tls get() = QuicTlsConfig(certChainPath = certPath("cert.crt"), privKeyPath = certPath("cert.key"))
+
+    @Test
+    fun keepAlive_idleConnection_invokesRealAckEliciting() =
+        runQuicTest(timeout = 20.seconds) {
+            try {
+                val opts =
+                    QuicOptions(
+                        alpnProtocols = listOf("test"),
+                        verifyPeer = false,
+                        idleTimeout = 4.seconds,
+                        keepAliveInterval = 1.seconds,
+                    )
+                val counting = CountingQuicheApi(loadQuicheApi())
+                withQuicServer(port = 0, tlsConfig = tls, quicOptions = opts) {
+                    val serverJob = launch { echoEveryStream() }
+                    try {
+                        commonJvmWithQuicConnection(
+                            hostname = "127.0.0.1",
+                            port = port,
+                            quicOptions = opts,
+                            connectionOptions = ConnectionOptions(bufferFactory = BufferFactory.deterministic()),
+                            timeout = 10.seconds,
+                            api = counting,
+                        ) {
+                            val stream = openStream()
+                            assertEquals("warmup", stream.echoOnce("warmup"), "warmup echo failed before idle wait")
+                            delay(6.seconds) // idle past the 4 s timeout — only the real keepalive PING holds it open
+                            assertEquals("alive", stream.echoOnce("alive"), "connection idle-closed despite keepalive")
+                            assertTrue(
+                                counting.ackElicitingCount >= 1,
+                                "driver never invoked the real quiche_conn_send_ack_eliciting during the idle window " +
+                                    "(count=${counting.ackElicitingCount})",
+                            )
+                            stream.close()
+                        }
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            } catch (e: UnsatisfiedLinkError) {
+                assumeTrue("Native lib not available: ${e.message}", false)
+            }
+        }
+
+    private suspend fun QuicServer.echoEveryStream() {
+        connections {
+            val stream = acceptStream()
+            while (true) {
+                val data = stream.read(9.seconds)
+                if (data is ReadResult.Data) stream.write(data.buffer, 5.seconds) else break
+            }
+            stream.close()
+        }
+    }
+
+    private suspend fun QuicByteStream.echoOnce(payload: String): String {
+        val out = BufferFactory.deterministic().allocate(payload.length)
+        out.writeString(payload, Charset.UTF8)
+        out.resetForRead()
+        try {
+            write(out, 5.seconds)
+        } finally {
+            out.freeNativeMemory()
+        }
+        val resp = read(5.seconds)
+        return if (resp is ReadResult.Data) {
+            val s = resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8)
+            resp.buffer.freeIfNeeded()
+            s
+        } else {
+            "no_data"
+        }
+    }
+}

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -53,6 +53,7 @@ import com.ditchoom.socket.quic.quiche.quiche_conn_readable
 import com.ditchoom.socket.quic.quiche.quiche_conn_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_scids_left
 import com.ditchoom.socket.quic.quiche.quiche_conn_send
+import com.ditchoom.socket.quic.quiche.quiche_conn_send_ack_eliciting
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_recv
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_send
 import com.ditchoom.socket.quic.quiche.quiche_conn_stream_shutdown
@@ -396,6 +397,8 @@ internal object CinteropQuicheApi : QuicheApi {
     }
 
     override fun connOnTimeout(conn: QuicheConn) = quiche_conn_on_timeout(conn.handle.toCPointer()!!)
+
+    override fun connSendAckEliciting(conn: QuicheConn): Int = quiche_conn_send_ack_eliciting(conn.handle.toCPointer()!!).toInt()
 
     override fun connClose(
         conn: QuicheConn,

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
@@ -206,6 +206,7 @@ actual suspend fun <R> withQuicConnection(
                         udpChannel = udpChannel,
                         clientMode = true,
                         isServer = false,
+                        keepAliveInterval = quicOptions.keepAliveInterval,
                         // Connection-migration wiring (Gap 4): the peer + primary local sockaddrs
                         // (kept pinned via onCleanup for the driver's life) and a factory that opens
                         // additional io_uring path sockets to the same peer. Mirrors the JVM client.

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -150,6 +150,7 @@ actual suspend fun <R> withQuicServer(
                 localAddrBuf = localAddrBuf,
                 bufferFactory = bufferFactory,
                 scope = parentScope,
+                keepAliveInterval = quicOptions.keepAliveInterval,
             )
         try {
             return server.block()
@@ -176,6 +177,7 @@ private class LinuxQuicServer(
     private val localAddrBuf: PlatformBuffer,
     private val bufferFactory: BufferFactory,
     private val scope: CoroutineScope,
+    private val keepAliveInterval: Duration? = null,
 ) : QuicServer {
     override val port: Int get() = boundPort
 
@@ -545,6 +547,7 @@ private class LinuxQuicServer(
                 udpChannel = udpChannel,
                 clientMode = false,
                 isServer = true,
+                keepAliveInterval = keepAliveInterval,
                 onScidIssued = { scid, len ->
                     // Snapshot the CID (scid is freed right after this returns) and hand the
                     // registration to the receive loop, which owns connectionsByDcid.

--- a/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
+++ b/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
@@ -242,6 +242,7 @@ static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
     NSNumber * _Nonnull verify_certs,
     NSArray<NSData *> * _Nullable trusted_ca_ders,
     int32_t idle_timeout_seconds,
+    int32_t keepalive_interval_seconds,
     int32_t connection_timeout_seconds,
     uint16_t max_datagram_frame_size)
 {
@@ -283,6 +284,15 @@ static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
             // used its own (much longer) default and the flag was a no-op (issue #112).
             if (idle_timeout_seconds > 0) {
                 nw_quic_set_idle_timeout(quic_options, (uint32_t)idle_timeout_seconds * 1000u);
+            }
+
+            // Apply QuicOptions.keepAliveInterval. NW sends an ack-eliciting PING this often on an
+            // otherwise-idle connection, resetting both idle timers so it survives past the idle
+            // timeout with no application traffic — the Network.framework analog of the quiche-backed
+            // driver's reactive keepalive. NOTE the unit: nw_quic_set_keepalive_interval takes SECONDS,
+            // unlike nw_quic_set_idle_timeout (milliseconds) above. 0 = disabled. macOS 11 / iOS 14+.
+            if (keepalive_interval_seconds > 0) {
+                nw_quic_set_keepalive_interval(quic_options, (uint32_t)keepalive_interval_seconds);
             }
 
             // Raise the stream-count flow-control limits we advertise to the peer. NW's default
@@ -680,6 +690,7 @@ static inline nw_listener_t _Nullable nw_helper_create_quic_listener(
     NSArray<NSString *> * _Nonnull alpn_protocols,
     sec_identity_t _Nonnull identity,
     int32_t idle_timeout_seconds,
+    int32_t keepalive_interval_seconds,
     uint16_t max_datagram_frame_size)
 {
     if (alpn_protocols.count == 0) return NULL;
@@ -703,6 +714,12 @@ static inline nw_listener_t _Nullable nw_helper_create_quic_listener(
             // Apply QuicOptions.idleTimeout (seconds → ms), same as the client path.
             if (idle_timeout_seconds > 0) {
                 nw_quic_set_idle_timeout(quic_options, (uint32_t)idle_timeout_seconds * 1000u);
+            }
+
+            // Apply QuicOptions.keepAliveInterval (SECONDS — see the client helper's unit note),
+            // same as the client path. 0 = disabled.
+            if (keepalive_interval_seconds > 0) {
+                nw_quic_set_keepalive_interval(quic_options, (uint32_t)keepalive_interval_seconds);
             }
 
             // Grant the client credit to open many streams (NW's default is ~7). See the client


### PR DESCRIPTION
## What & why

Adds a real **reactive QUIC keepalive** feature (RFC 9000 §10.1.2) and uses it to make the **#1 flaky test** from the CI flake audit deterministic: `QuicIdleTimeoutTests.activityKeepsConnectionAlivePastIdleTimeout` (was failing on linuxX64 and crashing on Android).

**Root cause of the flake (not a margin tweak):** the library had no keepalive, so the test faked one by *poll-sending* application traffic every 1s under a 4s idle timeout. Under CI scheduling starvation, one of those gaps balloons past 4s and the connection idle-closes — a wall-clock race with K sequential upper-bounded gaps. The right fix is a reactive keepalive: schedule ack-eliciting PINGs on the connection's own timer so an idle connection survives with **zero** application traffic.

## Changes
- **`QuicOptions.keepAliveInterval`** (`Duration?`, null=off; validated positive and `< idleTimeout`).
- **`QuicheDriver.run()`** — the existing reactive `select` loop now waits for `min(connTimeout, keepAliveDeadline)` and PINGs when the keepalive deadline is sooner; resets on activity. **No polling** (the loop was already reactive; this extends it).
- **Native binding** `quiche_conn_send_ack_eliciting` across **JNI** (+ `quiche_jni.c`), **FFM**, **cinterop**.
- **Apple** — `nw_quic_set_keepalive_interval` wired into the NWConnection group + listener (Network.framework's native keepalive; note: **seconds**, unlike idle-timeout's ms).

## Tests — closing the seam
- **`ReactiveDriverTests`** (stub, deterministic): proves the driver *schedules* PINGs on its timer, and sends none when disabled — no network, no flaky wall-clock assertion.
- **`QuicKeepAlivePingSeamTest`** (JVM/JNI): drives a **real** quiche client through a `CountingQuicheApi` spy and asserts the **real** `quiche_conn_send_ack_eliciting` fired during the idle window — closes the stub→real-binding seam.
- **`QuicIdleTimeoutTestSuite`** (common; runs JVM/linux/Apple) + **Android copy**: rewritten to enable keepalive, idle past the timeout, assert survival.

## Verification
Verified locally on **all three quiche backends**: JNI ✓, FFM (`-PquicheJvmBackend=ffm`) ✓, cinterop/linuxX64 ✓ — including the previously-flaky integration test, now deterministic. Apple builds only on macOS → verified by CI `build-apple`.

> Note on reproducibility: the original flake could **not** be reproduced on a 24-core dev box even pinned to 2 cores with contention (8/8 passed), so validation is by (1) the deterministic stub unit test of the mechanism, (2) the real-binding seam test, and (3) the structural change (the new test has no upper-bounded gap for starvation to exceed). CI is the empirical confirmation.

`skip-release` — lands without publishing to Maven Central (part of the flaky-fix sequence; deploy later once main is stable).