### PR TITLE
ci: stop download-artifact@v8 digest check reding the QUIC Interop Summary

### DIFF
--- a/.github/workflows/merged.yaml
+++ b/.github/workflows/merged.yaml
@@ -143,6 +143,9 @@ jobs:
           pattern: quic-audit-*
           path: /tmp/quic-audit
           merge-multiple: true
+          # See review.yaml: `warn` (not the v8 default `error`) so a digest check on the tiny audit
+          # files doesn't abort the download and red the summary on every merge.
+          digest-mismatch: warn
         continue-on-error: true
 
       - name: Build interop matrix

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -48,6 +48,10 @@ jobs:
           pattern: quic-audit-*
           path: /tmp/quic-audit
           merge-multiple: true
+          # download-artifact@v8 defaults digest-mismatch to `error`, which aborts the WHOLE download
+          # (delivering zero files) when GHA's per-artifact digest check trips on these tiny audit
+          # files — reding the summary on every PR. `warn` keeps the files so the summary still runs.
+          digest-mismatch: warn
         continue-on-error: true
 
       - name: Build interop matrix


### PR DESCRIPTION
The `quic-interop-summary` job has been **red on every PR/merge** — not from QUIC coverage, but from `actions/download-artifact@v8` defaulting `digest-mismatch: error`, which aborts the whole download of the tiny `quic-audit-*` files when GHA's per-artifact digest check trips. A pre-existing CI-infra regression (likely a github-actions version bump).

**Fix:** set `digest-mismatch: warn` on both quic-audit downloads (review.yaml + merged.yaml) so the files are delivered and the summary runs on real data. The download already has `continue-on-error` and the script already handles empty-files gracefully — this restores genuine green/red signal.

**Validation:** this PR's own `QUIC Interop Summary` check should now go green (review.yaml runs from the PR head). `skip-release`.