### PR TITLE
fix(apple): implement QUIC stream reset() on Network.framework (#81)

### DIFF
--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -23,9 +23,11 @@ import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_set_state_handler
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_group_start
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_max_datagram_size
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_receive
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_reset_stream
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_send
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_set_state_handler
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_start
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_stream_application_error
 import kotlinx.cinterop.convert
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -444,7 +446,8 @@ internal class AppleQuicGroupConnection(
  */
 internal class NWQuicByteStream(
     private val nwConn: nw_connection_t,
-) : HalfCloseableByteStream {
+) : HalfCloseableByteStream,
+    ResettableByteStream {
     @Volatile
     private var streamClosed = false
 
@@ -470,11 +473,20 @@ internal class NWQuicByteStream(
                             buffer.resetForRead()
                             if (cont.isActive) cont.resume(ReadResult.Data(buffer))
                         }
+                        errorCode != 0 -> {
+                            // A peer RESET_STREAM/STOP_SENDING surfaces as an nw_error AND
+                            // is_complete=true (the stream is done), so the error must be
+                            // examined before the is_complete check below — otherwise an
+                            // abrupt reset is misreported as a graceful end-of-stream. But a
+                            // transport-level close (idle timeout, connection close) is ALSO an
+                            // nw_error; only a real stream reset carries a QUIC application
+                            // error code. Use it to tell them apart. (Issue #81.)
+                            val appErr = nw_helper_quic_stream_application_error(nwConn)
+                            val result = if (appErr != ULong.MAX_VALUE) ReadResult.Reset else ReadResult.End
+                            if (cont.isActive) cont.resume(result)
+                        }
                         isComplete?.boolValue == true -> {
                             if (cont.isActive) cont.resume(ReadResult.End)
-                        }
-                        errorCode != 0 -> {
-                            if (cont.isActive) cont.resume(ReadResult.Reset)
                         }
                         else -> {
                             if (cont.isActive) cont.resume(ReadResult.End)
@@ -535,6 +547,16 @@ internal class NWQuicByteStream(
         streamClosed = true
         // Avoid a duplicate FIN if the send side was already shut down.
         if (!sendFinished) sendFin()
+    }
+
+    override suspend fun reset(errorCode: Long) {
+        if (streamClosed) return
+        streamClosed = true
+        // Abort both directions with the application error code — RESET_STREAM (send)
+        // + STOP_SENDING (read), RFC 9000 §19.4/§19.5 — matching QuicheStreamByteStream.
+        // NW stamps the error onto the stream metadata and cancels (no FIN); fire-and-
+        // forget, so no send-complete callback to await (unlike sendFin). (Issue #81.)
+        nw_helper_quic_reset_stream(nwConn, errorCode.toULong())
     }
 
     /**

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
@@ -250,7 +250,8 @@ private val PHANTOM_PEEK_TIMEOUT: Duration = 30.seconds
 private class PrefixedByteStream(
     first: ReadResult.Data,
     private val delegate: ByteStream,
-) : ByteStream {
+) : HalfCloseableByteStream,
+    ResettableByteStream {
     private var pending: ReadResult.Data? = first
 
     override val isOpen: Boolean get() = delegate.isOpen
@@ -267,6 +268,18 @@ private class PrefixedByteStream(
         buffer: ReadBuffer,
         timeout: Duration,
     ): BytesWritten = delegate.write(buffer, timeout)
+
+    override suspend fun shutdownSend() {
+        (delegate as? HalfCloseableByteStream)?.shutdownSend()
+    }
+
+    override suspend fun reset(errorCode: Long) {
+        // Drop the replay buffer and forward the abrupt reset (RESET_STREAM +
+        // STOP_SENDING) so server-accepted streams reset like client streams; a
+        // non-resettable delegate just gets a graceful close. (Issue #81.)
+        pending = null
+        (delegate as? ResettableByteStream)?.reset(errorCode) ?: delegate.close()
+    }
 
     override suspend fun close() = delegate.close()
 }

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicServerTests.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/AppleQuicServerTests.kt
@@ -23,4 +23,18 @@ class AppleQuicServerTests : QuicServerTestSuite() {
         if (shouldSkipQuicHarnessOnSimulator()) return
         block()
     }
+
+    /**
+     * Network.framework surfaces a peer RESET_STREAM distinctly as [ReadResult.Reset]
+     * (unlike the quiche driver, which collapses it to EOF). This is the regression guard
+     * for issue #81: before the fix, [NWQuicByteStream] didn't implement [ResettableByteStream],
+     * so [QuicByteStream.reset] degraded to a graceful FIN and the peer saw `End`, not `Reset`.
+     */
+    override fun assertResetObservedByPeer(resultClassName: String?) {
+        kotlin.test.assertEquals(
+            "Reset",
+            resultClassName,
+            "Apple must surface a peer RESET_STREAM as ReadResult.Reset, not a graceful close",
+        )
+    }
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicServerTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicServerTestSuite.kt
@@ -157,6 +157,85 @@ abstract class QuicServerTestSuite {
             }
         }
 
+    /**
+     * The [ReadResult] a peer observes when the remote abruptly resets a stream.
+     * Apple's Network.framework surfaces it as [ReadResult.Reset]; the quiche driver
+     * (JVM/Linux) collapses a stream reset to EOF ([ReadResult.End]). Both are terminal
+     * (never [ReadResult.Data]) — the default accepts either; Apple tightens it to Reset.
+     */
+    protected open fun assertResetObservedByPeer(resultClassName: String?) {
+        assertTrue(
+            resultClassName == "End" || resultClassName == "Reset",
+            "expected a terminal read after peer reset, got $resultClassName",
+        )
+    }
+
+    /**
+     * A client that opens a stream, sends a chunk, then [reset]s it with an application
+     * error code must (a) still deliver the pre-reset data to the server and (b) make the
+     * server's next read terminate rather than hang. Regression guard for the Apple bug
+     * where [QuicByteStream.reset] silently degraded to a graceful FIN because the
+     * Network.framework stream didn't implement [ResettableByteStream] — so no RESET_STREAM
+     * was ever sent. (Issue #81.) [assertResetObservedByPeer] pins the platform-exact result.
+     */
+    @Test
+    fun clientResetStreamIsObservedByServer() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = testQuicOptions) {
+                    val serverGotData = CompletableDeferred<String>()
+                    val clientMayReset = CompletableDeferred<Unit>()
+                    val serverSecondRead = CompletableDeferred<String?>()
+
+                    val serverJob =
+                        launch {
+                            connections {
+                                val stream = acceptStream()
+                                val first = stream.read(5.seconds)
+                                serverGotData.complete(
+                                    if (first is ReadResult.Data) {
+                                        first.buffer.readString(first.buffer.remaining(), Charset.UTF8)
+                                    } else {
+                                        "no_data:${first::class.simpleName}"
+                                    },
+                                )
+                                clientMayReset.complete(Unit)
+                                // After the peer's RESET_STREAM the next read must terminate, not deliver Data.
+                                val second = stream.read(5.seconds)
+                                serverSecondRead.complete(second::class.simpleName)
+                                stream.close()
+                            }
+                        }
+                    delay(100)
+
+                    val clientJob =
+                        launch {
+                            withQuicConnection("localhost", port, testQuicOptions, timeout = 10.seconds) {
+                                val stream = openStream()
+                                val sendBuf = BufferFactory.deterministic().allocate(5)
+                                sendBuf.writeString("hello", Charset.UTF8)
+                                sendBuf.resetForRead()
+                                stream.write(sendBuf, 5.seconds)
+                                clientMayReset.await()
+                                stream.reset(0x10cL) // HTTP/3 REQUEST_CANCELLED
+                                // Keep the connection alive until the reset is observed so the
+                                // RESET_STREAM frame is flushed before the connection tears down.
+                                serverSecondRead.await()
+                            }
+                        }
+
+                    try {
+                        assertEquals("hello", kotlinx.coroutines.withTimeout(10.seconds) { serverGotData.await() })
+                        val second = kotlinx.coroutines.withTimeout(10.seconds) { serverSecondRead.await() }
+                        assertResetObservedByPeer(second)
+                    } finally {
+                        clientJob.cancel()
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
     // --- Pinned CA trust (#99) ---
     // QuicOptions.trustedCaCertificatesPem must drive real chain validation on the
     // quiche-backed targets (JVM/Android/Linux), matching the Apple path. Before #99 the

--- a/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
+++ b/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
@@ -202,6 +202,51 @@ static inline void nw_helper_quic_force_cancel(nw_connection_t _Nonnull connecti
     nw_connection_force_cancel(connection);
 }
 
+/**
+ * Abruptly reset a QUIC stream with an application error code — the wire
+ * equivalent of quiche's RESET_STREAM (send side) + STOP_SENDING (read side)
+ * (RFC 9000 §19.4/§19.5), as opposed to the graceful FIN of nw_helper_quic_send
+ * with is_complete=true.
+ *
+ * Network.framework has no dedicated reset call: you stamp the application error
+ * onto the stream's QUIC metadata (nw_quic_set_stream_application_error) and then
+ * cancel the stream's nw_connection. NW emits RESET_STREAM/STOP_SENDING carrying
+ * that error_code instead of a clean close. If the metadata can't be copied (the
+ * stream is already gone) we still cancel so teardown is unconditional. (Issue #81.)
+ */
+static inline void nw_helper_quic_reset_stream(
+    nw_connection_t _Nonnull connection,
+    uint64_t error_code)
+{
+    nw_protocol_definition_t quic_def = nw_protocol_copy_quic_definition();
+    nw_protocol_metadata_t metadata =
+        nw_connection_copy_protocol_metadata(connection, quic_def);
+    if (metadata) {
+        nw_quic_set_stream_application_error(metadata, error_code);
+    }
+    nw_connection_cancel(connection);
+}
+
+/**
+ * The QUIC application error code the peer sent when it reset this stream
+ * (RESET_STREAM / STOP_SENDING), or UINT64_MAX if the stream wasn't reset.
+ *
+ * Used by the receive path to tell an abrupt stream reset (a non-MAX app error →
+ * ReadResult.Reset) apart from a transport-level close such as an idle timeout or
+ * connection close (no stream app error → ReadResult.End). Both surface to
+ * nw_connection_receive as an nw_error, so the error alone can't distinguish them.
+ * (Issue #81.)
+ */
+static inline uint64_t nw_helper_quic_stream_application_error(
+    nw_connection_t _Nonnull connection)
+{
+    nw_protocol_definition_t quic_def = nw_protocol_copy_quic_definition();
+    nw_protocol_metadata_t metadata =
+        nw_connection_copy_protocol_metadata(connection, quic_def);
+    if (!metadata) return UINT64_MAX;
+    return nw_quic_get_stream_application_error(metadata);
+}
+
 #pragma mark - QUIC Multiplex Group (streams + datagram flow) — RFC 9221 (issue #109)
 
 /**


### PR DESCRIPTION
## Problem

Calling `QuicByteStream.reset(errorCode)` on Apple silently degraded to a graceful FIN instead of a QUIC **RESET_STREAM**. Two coupled defects:

1. **Send side never reset.** Neither `NWQuicByteStream` nor the server-side `PrefixedByteStream` implemented `ResettableByteStream`, so common `QuicByteStream.reset()` hit `(delegate as? ResettableByteStream)?.reset() ?: delegate.close()` and fell through to a plain `close()`. The peer never saw RESET_STREAM/STOP_SENDING or the application error code. (The Linux/JVM quiche path was already correct.)

2. **Receive side misclassified a reset.** A peer RESET_STREAM arrives at `nw_connection_receive` as an `nw_error` **and** `is_complete=true`, but the read mapping checked `is_complete` first → reported `End`.

This matters for layered protocols (e.g. HTTP/3's `resetStreamQuietly` aborting streams with `REQUEST_CANCELLED` / `MESSAGE_ERROR`) — on Apple those resets were wrong on the wire.

## Fix

Network.framework has no dedicated stream-reset call, so:

- **Send** (`nw_helper_quic_reset_stream`): stamp the application error onto the stream's QUIC metadata (`nw_quic_set_stream_application_error`) then `nw_connection_cancel()` — emits RESET_STREAM/STOP_SENDING carrying the code. `NWQuicByteStream` and `PrefixedByteStream` now implement `ResettableByteStream`.
- **Receive discriminator** (`nw_helper_quic_stream_application_error`): an idle timeout / transport close is *also* an `nw_error` (and must stay `End`). The only way to tell them apart is `nw_quic_get_stream_application_error`, which returns the peer's reset code or `UINT64_MAX` if not a stream reset. So: error + app-error → `Reset`; error + no app error → `End`; clean FIN → `End`.

All three NW APIs are `API_AVAILABLE(macos 12, ios 15)`.

## Tests

`reset()` had **zero** test coverage before — which is why this gap went unnoticed.

- New shared `QuicServerTestSuite.clientResetStreamIsObservedByServer`: client writes, server reads the data, client resets; server's next read must terminate (not hang, not `Data`). Accepts `End`-or-`Reset` via the `assertResetObservedByPeer` hook because the quiche driver collapses a peer reset to EOF (`ReadResult.End`) — only Apple distinguishes it.
- `AppleQuicServerTests` overrides the hook to require `ReadResult.Reset` — the exact regression guard for this bug.

Verified on Apple hardware (macosArm64): the reset test + full `AppleQuicServerTests`, idle-timeout, large-payload, malformed-packet, lifecycle, impairment, datagram, and passive-migration suites pass; `clientResetStreamIsObservedByServer` also passes on JVM.

## Note (unrelated, pre-existing)

`AppleQuicIdleTimeoutTests.activityKeepsConnectionAlivePastIdleTimeout` fails on macosArm64 with `QUIC write error: 57` (ENOTCONN). Confirmed it fails identically on clean `origin/main` without this branch's changes — it came in with the keepalive merge (#130) and is **not** caused by this PR. Flagging for a separate investigation.

## Cross-platform inconsistency (left as-is)

The quiche driver (`QuicheDriver.kt`) surfaces a peer stream reset as `ReadResult.End`, not `Reset` — so JVM/Linux can't distinguish reset from clean EOF at the `ReadResult` level. Only Apple now can. Unifying that is a separate change.