### PR TITLE
fix(quic): stream STOP_SENDING/RESET must not close the connection

### DIFF
--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
@@ -13,6 +13,7 @@ import com.ditchoom.buffer.stream.StreamProcessor
 import com.ditchoom.socket.ConnectionOptions
 import com.ditchoom.socket.quic.QuicByteStream
 import com.ditchoom.socket.quic.QuicScope
+import com.ditchoom.socket.quic.QuicStreamException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
@@ -555,6 +556,10 @@ class Http3Connection private constructor(
         } catch (e: Http3StreamException) {
             // One stream erroring must not take down the connection. The control handler has
             // already recorded any SETTINGS failure into peerSettingsDeferred.
+        } catch (e: QuicStreamException) {
+            // Peer STOP_SENDING / RESET_STREAM on this one stream (e.g. cancelling a server PUSH this
+            // router was reading) — stream-scoped, not connection loss. A genuine connection-close still
+            // surfaces as QuicCloseException and propagates to tear the connection down.
         } finally {
             if (!handlerOwnsStream) {
                 processor.release()

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -13,6 +13,7 @@ import com.ditchoom.buffer.stream.StreamProcessor
 import com.ditchoom.socket.ConnectionOptions
 import com.ditchoom.socket.quic.QuicByteStream
 import com.ditchoom.socket.quic.QuicScope
+import com.ditchoom.socket.quic.QuicStreamException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -77,6 +78,9 @@ class Http3ServerConnection internal constructor(
                     if (stream.streamId.isUnidirectional) handleUniStream(stream) else handleRequest(stream)
                 } catch (_: Http3StreamException) {
                     // A single stream failing must not take the connection down.
+                } catch (_: QuicStreamException) {
+                    // Peer STOP_SENDING / RESET_STREAM on this one stream (e.g. a client cancelling a
+                    // request mid-response) — stream-scoped; the connection keeps serving other streams.
                 }
             }
         }

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackServer.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackServer.kt
@@ -13,6 +13,8 @@ import com.ditchoom.buffer.stream.StreamProcessor
 import com.ditchoom.socket.ConnectionOptions
 import com.ditchoom.socket.quic.QuicByteStream
 import com.ditchoom.socket.quic.QuicScope
+import com.ditchoom.socket.quic.QuicStreamException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -131,6 +133,9 @@ internal class Http3LoopbackServer(
                     if (stream.streamId.isUnidirectional) handleUniStream(stream) else handleRequest(scope, stream)
                 } catch (_: Http3StreamException) {
                     // A single stream failing must not take the connection down.
+                } catch (_: QuicStreamException) {
+                    // Peer STOP_SENDING / RESET_STREAM on one stream (e.g. a client cancelling a server
+                    // PUSH, RFC 9114 §7.2.3) — stream-scoped, the connection stays up for other streams.
                 }
             }
         }
@@ -230,7 +235,16 @@ internal class Http3LoopbackServer(
             val allocated = allocatePushes(if (clientMaxPushId >= 0) serverPushes(request) else emptyList())
             for ((pushId, push) in allocated) writePushPromise(stream, pushId, push)
             writeResponse(stream, response)
-            for ((pushId, push) in allocated) writePushStream(scope, pushId, push)
+            for ((pushId, push) in allocated) {
+                try {
+                    writePushStream(scope, pushId, push)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: QuicStreamException) {
+                    // Client cancelled this push (STOP_SENDING) — abandon just this push stream and
+                    // continue emitting the others; the request response was already written above.
+                }
+            }
         } finally {
             reader.release()
         }

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -494,6 +494,16 @@ internal class NWQuicByteStream(
             val nsData = buffer.toNativeData().nsData
 
             suspendCancellableCoroutine { cont ->
+                // NB (stream-vs-connection conflation): the quiche driver maps a peer STOP_SENDING /
+                // RESET_STREAM on one stream to [QuicStreamException] (the connection survives) instead of
+                // [QuicCloseException]. Network.framework does NOT expose a documented per-stream-reset
+                // signal here distinct from a connection error — the send-complete callback surfaces only an
+                // (err_domain, err_code) pair (the helper already passes the domain; this call site ignores
+                // it). A POSIX ECONNRESET-domain code is the likely stream-reset shape, but mapping it to
+                // [QuicStreamException] requires verification on real Apple hardware: mis-classifying a
+                // genuine connection error as a recoverable stream error would mask a dead connection. Until
+                // that is confirmed on a Mac, this path conservatively reports [QuicCloseException]. See
+                // project_quic_stream_stopped_bug.
                 nw_helper_quic_send(nwConn, nsData, NSNumber(bool = false)) { _, errorCode, _ ->
                     if (errorCode != 0) {
                         if (cont.isActive) {

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicStreamException.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicStreamException.kt
@@ -1,0 +1,26 @@
+package com.ditchoom.socket.quic
+
+/**
+ * Thrown when a single QUIC stream is aborted by the peer, while the connection itself stays healthy:
+ *
+ * - **STOP_SENDING** (quiche `QUICHE_ERR_STREAM_STOPPED`, RFC 9000 §19.5) — the peer no longer wants
+ *   what we are sending and asked us to stop. A legitimate, routine event: e.g. an HTTP/3 client
+ *   cancelling a server PUSH it didn't want (RFC 9114 §7.2.3).
+ * - **RESET_STREAM** (quiche `QUICHE_ERR_STREAM_RESET`, RFC 9000 §19.4) — the peer abruptly terminated
+ *   the stream it was sending.
+ *
+ * This is deliberately **not** a [QuicCloseException] (nor a `SocketClosedException`): a stopped/reset
+ * stream says nothing about the connection, which keeps carrying every other stream. Conflating the two
+ * — mapping a stream-level quiche error to a connection-close — tears down a perfectly good connection
+ * when a peer cancels one stream. Callers should abandon just this stream and continue.
+ *
+ * [streamId] is the affected stream. [quicheErrorCode] is the raw quiche sentinel
+ * ([QuicheDriver.QUICHE_ERR_STREAM_STOPPED] or [QuicheDriver.QUICHE_ERR_STREAM_RESET]) so callers can
+ * distinguish STOP_SENDING from RESET_STREAM without parsing the message.
+ */
+class QuicStreamException(
+    val streamId: Long,
+    val quicheErrorCode: Int,
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -810,6 +810,19 @@ class QuicheDriver(
          * already maps it to [StreamRecvResult.Done].)
          */
         const val QUICHE_ERR_DONE = -1
+
+        /**
+         * `QUICHE_ERR_STREAM_STOPPED` (quiche.h). The peer sent STOP_SENDING (RFC 9000 §19.5): it no
+         * longer wants what we are writing to THIS stream. A stream-level event — the connection is
+         * healthy — so a stream *write* hitting it raises [QuicStreamException], not [QuicCloseException].
+         */
+        const val QUICHE_ERR_STREAM_STOPPED = -15
+
+        /**
+         * `QUICHE_ERR_STREAM_RESET` (quiche.h). The peer sent RESET_STREAM (RFC 9000 §19.4) on THIS
+         * stream. Like [QUICHE_ERR_STREAM_STOPPED], stream-scoped — the connection survives.
+         */
+        const val QUICHE_ERR_STREAM_RESET = -16
     }
 }
 
@@ -941,6 +954,17 @@ class DriverStreamAdapter(
                         else ->
                             if (written > 0) {
                                 return@withTimeout written
+                            } else if (written == QuicheDriver.QUICHE_ERR_STREAM_STOPPED ||
+                                written == QuicheDriver.QUICHE_ERR_STREAM_RESET
+                            ) {
+                                // Peer sent STOP_SENDING / RESET_STREAM on THIS stream (RFC 9000 §19.4-19.5).
+                                // Stream-scoped, not connection loss — surface a stream error the caller can
+                                // catch to abandon just this stream; the connection keeps every other stream.
+                                throw QuicStreamException(
+                                    streamId.id,
+                                    written,
+                                    "quiche stream ${streamId.id} aborted by peer (error $written)",
+                                )
                             } else {
                                 throw QuicCloseException(
                                     driver.closeReasonOr(QuicError.InternalError("quiche stream write error: $written")),

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -447,6 +447,83 @@ class ReactiveDriverTests {
             }
         }
 
+    /**
+     * Peer STOP_SENDING / RESET_STREAM on ONE stream (quiche `STREAM_STOPPED` -15 / `STREAM_RESET` -16,
+     * RFC 9000 §19.4-19.5) is a STREAM-level event — the connection is healthy. The write must raise a
+     * stream-scoped [QuicStreamException], **not** a connection-close [QuicCloseException] /
+     * [SocketClosedException]: conflating the two tears down a good connection when a peer merely cancels
+     * one stream (e.g. an HTTP/3 client cancelling a server PUSH). Regression for
+     * project_quic_stream_stopped_bug. Negative-check = revert the -15/-16 branch in
+     * [DriverStreamAdapter.streamWrite] and this fails with a SocketClosedException.
+     */
+    @Test
+    fun streamWrite_peerStopSendingOrReset_throwsStreamErrorNotConnectionClose() =
+        runQuicTest {
+            for (code in listOf(QuicheDriver.QUICHE_ERR_STREAM_STOPPED, QuicheDriver.QUICHE_ERR_STREAM_RESET)) {
+                val api = StubQuicheApi()
+                val driver = createTestDriver(api)
+                driver.start(this)
+                try {
+                    val slot = sendOpenStream(driver)
+                    val adapter = DriverStreamAdapter(driver, slot)
+                    val buf = bufferFactory.allocate(64)
+
+                    api.connStreamSendResult = code
+                    val ex =
+                        assertFailsWith<QuicStreamException>("stream-level quiche error $code must throw a stream error") {
+                            withTimeout(2.seconds) { adapter.streamWrite(slot.id, buf, 2.seconds) }
+                        }
+                    assertEquals(slot.id.id, ex.streamId, "exception must carry the affected stream id")
+                    assertEquals(code, ex.quicheErrorCode, "exception must carry the raw quiche code")
+                    assertTrue(
+                        ex !is SocketClosedException,
+                        "a stopped/reset stream is not a closed connection — must not be a SocketClosedException",
+                    )
+
+                    buf.freeNativeMemory()
+                } finally {
+                    driver.destroy()
+                }
+            }
+        }
+
+    /**
+     * The connection survives a peer stopping one stream: after a write hits `STREAM_STOPPED` and throws
+     * a stream error, a write on a DIFFERENT stream of the same driver still goes through. This is the
+     * behavioural contract the [QuicStreamException]/[QuicCloseException] split exists to protect.
+     */
+    @Test
+    fun streamStopped_connectionStaysUsable_anotherStreamRoundTrips() =
+        runQuicTest {
+            val api = StubQuicheApi()
+            val driver = createTestDriver(api)
+            driver.start(this)
+            try {
+                val stopped = sendOpenStream(driver)
+                val stoppedAdapter = DriverStreamAdapter(driver, stopped)
+                val buf1 = bufferFactory.allocate(64)
+                api.connStreamSendResult = QuicheDriver.QUICHE_ERR_STREAM_STOPPED
+                assertFailsWith<QuicStreamException> {
+                    withTimeout(2.seconds) { stoppedAdapter.streamWrite(stopped.id, buf1, 2.seconds) }
+                }
+                buf1.freeNativeMemory()
+
+                // The connection is unaffected — a fresh stream writes normally.
+                val healthy = sendOpenStream(driver)
+                val healthyAdapter = DriverStreamAdapter(driver, healthy)
+                val buf2 = bufferFactory.allocate(64)
+                api.connStreamSendResult = 64
+                assertEquals(
+                    64,
+                    withTimeout(2.seconds) { healthyAdapter.streamWrite(healthy.id, buf2, 2.seconds) },
+                    "the connection must stay usable after one stream was stopped",
+                )
+                buf2.freeNativeMemory()
+            } finally {
+                driver.destroy()
+            }
+        }
+
     /** An empty write is a 0-byte no-op — it must never park, even when the window is full. */
     @Test
     fun streamWrite_emptyBuffer_returnsZeroWithoutParking() =


### PR DESCRIPTION
## Problem

`QuicheDriver.streamWrite` mapped **every** negative `quiche_conn_stream_send` return to a connection-level `QuicCloseException`. But quiche's `QUICHE_ERR_STREAM_STOPPED` (-15) and `QUICHE_ERR_STREAM_RESET` (-16) are **stream-level** — the peer sent STOP_SENDING / RESET_STREAM on **one** stream (RFC 9000 §19.4-19.5); the connection is healthy. Only `QUICHE_ERR_DONE` (-1) was handled (flow-control park).

So a peer cancelling a single stream — e.g. an HTTP/3 client cancelling a server PUSH it didn't want (RFC 9114 §7.2.3, legitimate) — tore down the **whole** connection.

### How it surfaced
`Http3LoopbackTestSuite.serverPushWindowRollsViaReIssuedMaxPushId` flaked intermittently on loaded CI (`QuicCloseException` at `QuicheDriver.kt`). The test cancels every push → STOP_SENDING lands mid push-body-write under load → server's push write got -15 → `QuicCloseException` escaped the loopback server's narrow `catch (Http3StreamException)` → cancelled the connection scope → the client's next request threw. Needs CI-level scheduling latency to reproduce (40/40 green locally including 24-core load), so the regression is pinned at the deterministic driver layer instead.

## Fix

- **New `QuicStreamException`** (`streamId` + raw quiche code), deliberately **not** a `SocketClosedException` — a stopped/reset stream is never conflated with a closed connection.
- `streamWrite` raises it for -15/-16; all other negatives still close the connection (`QuicCloseException`).
- **Sweep follow-up:** `Http3Connection.route()` and `Http3ServerConnection.serve()` run per-stream handlers inside a connection-scoped `scope.launch` but caught only `Http3StreamException` — the new stream exception would escape and cancel the connection the same way. Both now also `catch (QuicStreamException)`. (The production server PUSH path already catches `Throwable` broadly.)
- **Apple:** documented the matching conflation in `NWQuicByteStream.write` — Network.framework exposes no reliable per-stream-reset signal there, so it conservatively keeps reporting connection-close pending verification on Apple hardware.

## Tests

- `ReactiveDriverTests.streamWrite_peerStopSendingOrReset_throwsStreamErrorNotConnectionClose` — -15/-16 raise a `QuicStreamException` carrying the stream id + code, and it is **not** a `SocketClosedException`.
- `ReactiveDriverTests.streamStopped_connectionStaysUsable_anotherStreamRoundTrips` — after one stream is stopped, a write on another stream of the same driver still succeeds.
- Full `:socket-quic:jvmTest` and `:socket-http3:jvmTest` green.

`skip-release` per the flaky-fix merge strategy (land code, no Maven publish while CI stabilizes).