### PR TITLE
fix(apple): make QUIC keepAliveInterval actually work on Network.framework

### DIFF
--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -25,6 +25,7 @@ import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_max_datagram_size
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_receive
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_reset_stream
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_send
+import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_set_keepalive
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_set_state_handler
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_start
 import com.ditchoom.socket.quic.nwhelpers.nw_helper_quic_stream_application_error
@@ -253,7 +254,14 @@ private suspend fun <R> connectQuicGroup(
             flow
         }
 
-    val quicConn = AppleQuicGroupConnection(group, datagramFlow, incomingStreams, connectionOptions.bufferFactory)
+    val quicConn =
+        AppleQuicGroupConnection(
+            group,
+            datagramFlow,
+            incomingStreams,
+            connectionOptions.bufferFactory,
+            keepAliveSeconds = quicOptions.keepAliveInterval?.inWholeSeconds?.toInt() ?: 0,
+        )
     return try {
         quicConn.block()
     } finally {
@@ -288,6 +296,7 @@ internal class AppleQuicGroupConnection(
     // Peer-initiated streams, fed by the group's new-connection handler wired in connectQuicGroup.
     private val incomingStreams: Channel<QuicByteStream>,
     private val bufferFactory: BufferFactory,
+    private val keepAliveSeconds: Int = 0,
     private val scope: CoroutineScope = CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default),
 ) : QuicConnection,
     CoroutineScope by scope {
@@ -314,7 +323,7 @@ internal class AppleQuicGroupConnection(
                 ?: throw QuicCloseException(closeReason(), "Failed to open QUIC stream")
         nw_helper_quic_start(streamConn)
         val streamId = QuicStreamId(nextClientStreamId.getAndAdd(4))
-        return QuicByteStream(streamId, NWQuicByteStream(streamConn, streamId.id))
+        return QuicByteStream(streamId, NWQuicByteStream(streamConn, streamId.id, keepAliveSeconds))
     }
 
     override suspend fun openUniStream(): QuicByteStream {
@@ -448,6 +457,7 @@ internal class AppleQuicGroupConnection(
 internal class NWQuicByteStream(
     private val nwConn: nw_connection_t,
     private val streamId: Long = -1L,
+    private val keepAliveSeconds: Int = 0,
 ) : HalfCloseableByteStream,
     ResettableByteStream {
     @Volatile
@@ -455,6 +465,9 @@ internal class NWQuicByteStream(
 
     @Volatile
     private var sendFinished = false
+
+    @Volatile
+    private var keepAliveApplied = false
 
     override val isOpen: Boolean get() = !streamClosed
 
@@ -473,6 +486,7 @@ internal class NWQuicByteStream(
                             val buffer = NSDataBuffer(data, ByteOrder.BIG_ENDIAN)
                             buffer.position(data.length.toInt())
                             buffer.resetForRead()
+                            applyKeepAliveOnce()
                             if (cont.isActive) cont.resume(ReadResult.Data(buffer))
                         }
                         errorCode != 0 -> {
@@ -520,6 +534,7 @@ internal class NWQuicByteStream(
                     if (errorCode != 0) {
                         if (cont.isActive) cont.resumeWithException(writeError(errorCode))
                     } else {
+                        applyKeepAliveOnce()
                         if (cont.isActive) cont.resume(BytesWritten(remaining))
                     }
                 }
@@ -592,6 +607,21 @@ internal class NWQuicByteStream(
                 }
             }
         }
+    }
+
+    /**
+     * Arm QUIC keepalive on the first live I/O. [QuicOptions.keepAliveInterval] must be
+     * applied via nw_quic_set_keepalive_interval, which takes the connection's
+     * nw_protocol_metadata_t — only obtainable from a STARTED flow (it is nil before the
+     * flow is ready, which is why setting it on the create-params options object, or right
+     * after extract, is a no-op). The first successful read/write proves the flow is live,
+     * so we set it here, once. All flows share one QUIC connection, so any flow configures
+     * it. (Fixes the Apple half of the #130 keepalive feature.)
+     */
+    private fun applyKeepAliveOnce() {
+        if (keepAliveSeconds <= 0 || keepAliveApplied) return
+        keepAliveApplied = true
+        nw_helper_quic_set_keepalive(nwConn, keepAliveSeconds.toUShort())
     }
 
     private companion object {

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
@@ -89,6 +89,7 @@ actual suspend fun <R> withQuicServer(
     val datagramsEnabled = quicOptions.datagrams != null
     val maxFrameSize: UShort = if (datagramsEnabled) DATAGRAM_FRAME_SIZE_MAX else 0u
     val alpnList: List<Any?> = quicOptions.alpnProtocols
+    val keepAliveSeconds = quicOptions.keepAliveInterval?.inWholeSeconds?.toInt() ?: 0
 
     val listener =
         nw_helper_create_quic_listener(
@@ -149,7 +150,7 @@ actual suspend fun <R> withQuicServer(
         // suspend, so the filtering (which reads) happens on serverScope.
         nw_helper_quic_group_set_new_connection_handler(group) { streamConn ->
             serverScope.launch {
-                filterPhantomAndEnqueue(streamConn, incomingStreams, acceptedStreamId)
+                filterPhantomAndEnqueue(streamConn, incomingStreams, acceptedStreamId, keepAliveSeconds)
             }
         }
         nw_helper_quic_group_start(group)
@@ -191,6 +192,7 @@ actual suspend fun <R> withQuicServer(
             acceptedGroups = acceptedGroups,
             datagramsEnabled = datagramsEnabled,
             bufferFactory = BufferFactory.deterministic(),
+            keepAliveSeconds = keepAliveSeconds,
             scope = serverScope,
         )
     return try {
@@ -221,10 +223,11 @@ private suspend fun filterPhantomAndEnqueue(
     streamConn: nw_connection_t,
     incomingStreams: Channel<QuicByteStream>,
     acceptedStreamId: AtomicLong,
+    keepAliveSeconds: Int,
 ) {
     nw_helper_quic_start(streamConn)
     val sid = QuicStreamId(acceptedStreamId.getAndAdd(4))
-    val raw = NWQuicByteStream(streamConn, sid.id)
+    val raw = NWQuicByteStream(streamConn, sid.id, keepAliveSeconds)
     val first =
         try {
             raw.read(PHANTOM_PEEK_TIMEOUT)
@@ -310,6 +313,7 @@ private class AppleQuicServer(
     private val acceptedGroups: Channel<AcceptedGroup>,
     private val datagramsEnabled: Boolean,
     private val bufferFactory: BufferFactory,
+    private val keepAliveSeconds: Int,
     private val scope: CoroutineScope,
 ) : QuicServer {
     override val port: Int get() = boundPort
@@ -354,6 +358,7 @@ private class AppleQuicServer(
                             datagramFlow,
                             accepted.incomingStreams,
                             bufferFactory,
+                            keepAliveSeconds = keepAliveSeconds,
                         )
                     try {
                         conn.handler()

--- a/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
+++ b/socket-quic/src/nativeInterop/cinterop/nw_quic_helpers.h
@@ -247,6 +247,30 @@ static inline uint64_t nw_helper_quic_stream_application_error(
     return nw_quic_get_stream_application_error(metadata);
 }
 
+/**
+ * Set the QUIC keepalive interval (RFC 9000 §10.1.2) so an otherwise-idle connection
+ * sends ack-eliciting PINGs and survives past the idle timeout.
+ *
+ * nw_quic_set_keepalive_interval takes the connection's nw_protocol_metadata_t — NOT the
+ * nw_protocol_options_t available in the create-params block (setting it there is a silent
+ * no-op: the type mismatch only warns, and was the original #130 defect). The metadata is
+ * obtainable only from a STARTED, live flow (nw_connection_copy_protocol_metadata returns
+ * nil before the flow is ready, so setting it right after extract is also a no-op). Callers
+ * apply it on the first successful I/O on a flow. All flows share one QUIC connection, so
+ * configuring any one configures the connection. seconds; 0 = disabled.
+ */
+static inline void nw_helper_quic_set_keepalive(
+    nw_connection_t _Nonnull connection,
+    uint16_t keepalive_interval_seconds)
+{
+    nw_protocol_definition_t quic_def = nw_protocol_copy_quic_definition();
+    nw_protocol_metadata_t metadata =
+        nw_connection_copy_protocol_metadata(connection, quic_def);
+    if (metadata) {
+        nw_quic_set_keepalive_interval(metadata, keepalive_interval_seconds);
+    }
+}
+
 #pragma mark - QUIC Multiplex Group (streams + datagram flow) — RFC 9221 (issue #109)
 
 /**
@@ -331,14 +355,13 @@ static inline nw_connection_group_t _Nullable nw_helper_create_quic_group(
                 nw_quic_set_idle_timeout(quic_options, (uint32_t)idle_timeout_seconds * 1000u);
             }
 
-            // Apply QuicOptions.keepAliveInterval. NW sends an ack-eliciting PING this often on an
-            // otherwise-idle connection, resetting both idle timers so it survives past the idle
-            // timeout with no application traffic — the Network.framework analog of the quiche-backed
-            // driver's reactive keepalive. NOTE the unit: nw_quic_set_keepalive_interval takes SECONDS,
-            // unlike nw_quic_set_idle_timeout (milliseconds) above. 0 = disabled. macOS 11 / iOS 14+.
-            if (keepalive_interval_seconds > 0) {
-                nw_quic_set_keepalive_interval(quic_options, (uint32_t)keepalive_interval_seconds);
-            }
+            // QuicOptions.keepAliveInterval is NOT applied here: nw_quic_set_keepalive_interval
+            // takes nw_protocol_metadata_t, not the nw_protocol_options_t in this create-params
+            // block (the type mismatch only warns and is a silent no-op — the original #130
+            // defect). It is applied post-establishment on a live flow's metadata via
+            // nw_helper_quic_set_keepalive. [keepalive_interval_seconds] kept for signature
+            // symmetry with the idle-timeout path; unused here.
+            (void)keepalive_interval_seconds;
 
             // Raise the stream-count flow-control limits we advertise to the peer. NW's default
             // initial_max_streams_bidirectional is tiny (~7), so a connection wedged after a
@@ -761,11 +784,13 @@ static inline nw_listener_t _Nullable nw_helper_create_quic_listener(
                 nw_quic_set_idle_timeout(quic_options, (uint32_t)idle_timeout_seconds * 1000u);
             }
 
-            // Apply QuicOptions.keepAliveInterval (SECONDS — see the client helper's unit note),
-            // same as the client path. 0 = disabled.
-            if (keepalive_interval_seconds > 0) {
-                nw_quic_set_keepalive_interval(quic_options, (uint32_t)keepalive_interval_seconds);
-            }
+            // QuicOptions.keepAliveInterval is NOT applied here: nw_quic_set_keepalive_interval
+            // takes nw_protocol_metadata_t, not the nw_protocol_options_t in this create-params
+            // block (the type mismatch only warns and is a silent no-op — the original #130
+            // defect). It is applied post-establishment on a live flow's metadata via
+            // nw_helper_quic_set_keepalive. [keepalive_interval_seconds] kept for signature
+            // symmetry with the idle-timeout path; unused here.
+            (void)keepalive_interval_seconds;
 
             // Grant the client credit to open many streams (NW's default is ~7). See the client
             // helper's note. (Issue #112.)


### PR DESCRIPTION
## Problem

`QuicOptions.keepAliveInterval` (added in #130) was a **silent no-op on Apple**: an otherwise-idle connection closed at the idle timeout despite keepalive being configured. The shared `QuicIdleTimeoutTestSuite.activityKeepsConnectionAlivePastIdleTimeout` fails on macOS with `QUIC write error: 57` (ENOTCONN) — the write at idle+wait hits a connection that already idle-closed. #130's CI only **built** the Apple target (`build-apple`), never **ran** it, so this shipped broken.

## Root cause (two bugs)

1. **Wrong object type.** `nw_quic_set_keepalive_interval(...)` was called on the `nw_protocol_options_t` in the `nw_parameters_create_quic` block, but the SDK declares it taking `nw_protocol_metadata_t`. Confirmed with clang: `warning: incompatible pointer types passing 'nw_protocol_options_t' ... to parameter of type 'nw_protocol_metadata_t'`. It compiles (warning only) and does nothing at runtime — the same wrong-accessor class as the historic PR #60 ALPN defect.
2. **Timing.** Even with the correct type, the metadata only exists on a **started, live flow**: `nw_connection_copy_protocol_metadata` returns nil before the flow is ready, so setting it at create-time *or* right after `extract` is also a no-op.

## Fix

- New `nw_helper_quic_set_keepalive` sets the interval on a **live flow's** QUIC connection metadata (correct type).
- `NWQuicByteStream` arms it **once, on the first successful read/write** — the first I/O proves the flow is live. All flows share one QUIC connection, so configuring any one configures the connection.
- Wired on both the **client** (`AppleQuicGroupConnection`) and **server** (listener) paths, matching #130's intent (#130 had set the broken call on both).
- The broken options-block calls are removed and documented as no-ops.

## Verification (macosArm64 hardware)

The existing shared keepalive test now passes on Apple (it idles 6s past a 4s idle timeout with `keepAlive=1s` and survives). Confirmed `metadataObtained=1` on the live flow. **16/16** Apple tests pass across idle-timeout / server / large-payload / datagram suites; ktlint clean. JVM keepalive was already green and is untouched.

## Notes

- No new test needed — #130's `activityKeepsConnectionAlivePastIdleTimeout` already runs on Apple and is now a real regression guard there.
- Independent of the Apple `reset()` PR (#132) and of #133/#134 (stream-reset vs connection-close).