### PR TITLE
fix(apple): peer stream reset must not close the QUIC connection (#134)

### DIFF
--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -195,8 +195,9 @@ private suspend fun <R> connectQuicGroup(
                 // queue, then enqueue it. Runs synchronously inside the block, so the connection
                 // is owned before the block returns.
                 nw_helper_quic_start(streamConn)
+                val sid = QuicStreamId(acceptedStreamId.getAndAdd(4))
                 incomingStreams.trySend(
-                    QuicByteStream(QuicStreamId(acceptedStreamId.getAndAdd(4)), NWQuicByteStream(streamConn)),
+                    QuicByteStream(sid, NWQuicByteStream(streamConn, sid.id)),
                 )
             }
             nw_helper_quic_group_start(group)
@@ -313,7 +314,7 @@ internal class AppleQuicGroupConnection(
                 ?: throw QuicCloseException(closeReason(), "Failed to open QUIC stream")
         nw_helper_quic_start(streamConn)
         val streamId = QuicStreamId(nextClientStreamId.getAndAdd(4))
-        return QuicByteStream(streamId, NWQuicByteStream(streamConn))
+        return QuicByteStream(streamId, NWQuicByteStream(streamConn, streamId.id))
     }
 
     override suspend fun openUniStream(): QuicByteStream {
@@ -328,7 +329,7 @@ internal class AppleQuicGroupConnection(
                 ?: throw QuicCloseException(closeReason(), "Failed to open unidirectional QUIC stream")
         nw_helper_quic_start(streamConn)
         val streamId = QuicStreamId(nextClientUniStreamId.getAndAdd(4))
-        return QuicByteStream(streamId, NWQuicByteStream(streamConn))
+        return QuicByteStream(streamId, NWQuicByteStream(streamConn, streamId.id))
     }
 
     override suspend fun acceptStream(): QuicByteStream {
@@ -446,6 +447,7 @@ internal class AppleQuicGroupConnection(
  */
 internal class NWQuicByteStream(
     private val nwConn: nw_connection_t,
+    private val streamId: Long = -1L,
 ) : HalfCloseableByteStream,
     ResettableByteStream {
     @Volatile
@@ -506,26 +508,17 @@ internal class NWQuicByteStream(
             val nsData = buffer.toNativeData().nsData
 
             suspendCancellableCoroutine { cont ->
-                // NB (stream-vs-connection conflation): the quiche driver maps a peer STOP_SENDING /
-                // RESET_STREAM on one stream to [QuicStreamException] (the connection survives) instead of
-                // [QuicCloseException]. Network.framework does NOT expose a documented per-stream-reset
-                // signal here distinct from a connection error — the send-complete callback surfaces only an
-                // (err_domain, err_code) pair (the helper already passes the domain; this call site ignores
-                // it). A POSIX ECONNRESET-domain code is the likely stream-reset shape, but mapping it to
-                // [QuicStreamException] requires verification on real Apple hardware: mis-classifying a
-                // genuine connection error as a recoverable stream error would mask a dead connection. Until
-                // that is confirmed on a Mac, this path conservatively reports [QuicCloseException]. See
-                // project_quic_stream_stopped_bug.
+                // Stream-vs-connection split (issue #134, mirroring the quiche driver): a peer
+                // STOP_SENDING/RESET_STREAM on ONE stream must raise a stream-scoped
+                // [QuicStreamException] (the connection survives) rather than tearing it down with
+                // [QuicCloseException]. Network.framework gives the same (err_domain, err_code) —
+                // POSIX/57 (ENOTCONN) — for BOTH a peer stream reset AND a real connection close, so
+                // the error code can't discriminate (verified on macOS hardware). The reliable signal
+                // is the QUIC stream application error: nw_quic_get_stream_application_error returns the
+                // peer's reset code on a stream reset, or UINT64_MAX otherwise. (Issue #134.)
                 nw_helper_quic_send(nwConn, nsData, NSNumber(bool = false)) { _, errorCode, _ ->
                     if (errorCode != 0) {
-                        if (cont.isActive) {
-                            cont.resumeWithException(
-                                QuicCloseException(
-                                    QuicError.InternalError("QUIC write error: $errorCode"),
-                                    "QUIC write error: $errorCode",
-                                ),
-                            )
-                        }
+                        if (cont.isActive) cont.resumeWithException(writeError(errorCode))
                     } else {
                         if (cont.isActive) cont.resume(BytesWritten(remaining))
                     }
@@ -557,6 +550,29 @@ internal class NWQuicByteStream(
         // NW stamps the error onto the stream metadata and cancels (no FIN); fire-and-
         // forget, so no send-complete callback to await (unlike sendFin). (Issue #81.)
         nw_helper_quic_reset_stream(nwConn, errorCode.toULong())
+    }
+
+    /**
+     * Classify a non-zero NW send error: a peer stream reset (the stream carries a QUIC
+     * application error code) is a stream-scoped [QuicStreamException] — the connection stays
+     * usable; anything else is a connection-level [QuicCloseException]. A peer reset surfacing
+     * on our write side means the peer no longer wants our data (STOP_SENDING semantics), so the
+     * abort is reported as [QuicStreamAbort.StopSending] carrying the peer's code. (Issue #134.)
+     */
+    private fun writeError(errorCode: Int): Throwable {
+        val appErr = nw_helper_quic_stream_application_error(nwConn)
+        return if (appErr != ULong.MAX_VALUE) {
+            QuicStreamException(
+                streamId,
+                QuicStreamAbort.StopSending(appErr.toLong()),
+                "QUIC stream $streamId reset by peer (application error $appErr)",
+            )
+        } else {
+            QuicCloseException(
+                QuicError.InternalError("QUIC write error: $errorCode"),
+                "QUIC write error: $errorCode",
+            )
+        }
     }
 
     /**

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
@@ -223,7 +223,8 @@ private suspend fun filterPhantomAndEnqueue(
     acceptedStreamId: AtomicLong,
 ) {
     nw_helper_quic_start(streamConn)
-    val raw = NWQuicByteStream(streamConn)
+    val sid = QuicStreamId(acceptedStreamId.getAndAdd(4))
+    val raw = NWQuicByteStream(streamConn, sid.id)
     val first =
         try {
             raw.read(PHANTOM_PEEK_TIMEOUT)
@@ -233,7 +234,7 @@ private suspend fun filterPhantomAndEnqueue(
     when (first) {
         is ReadResult.Data ->
             incomingStreams.trySend(
-                QuicByteStream(QuicStreamId(acceptedStreamId.getAndAdd(4)), PrefixedByteStream(first, raw)),
+                QuicByteStream(sid, PrefixedByteStream(first, raw)),
             )
         else -> nw_helper_quic_cancel(streamConn) // hidden phantom / empty / reset → drop
     }

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicStreamException.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicStreamException.kt
@@ -1,26 +1,57 @@
 package com.ditchoom.socket.quic
 
 /**
+ * Why a single QUIC stream was aborted by the peer while the connection itself stays healthy
+ * (RFC 9000 §19.4-19.5).
+ *
+ * Backends populate what they can resolve, which differs:
+ * - the quiche driver reports the **direction** ([StopSending] vs [ResetStream], from the
+ *   `QUICHE_ERR_STREAM_STOPPED` / `QUICHE_ERR_STREAM_RESET` sentinels) but `quiche_conn_stream_send`
+ *   does not surface the peer's application error code, so [applicationErrorCode] is null there;
+ * - Network.framework (Apple) reports the peer's [applicationErrorCode] (via
+ *   `nw_quic_get_stream_application_error`) but does not distinguish the direction, so a peer reset
+ *   surfacing on our write path is reported as [StopSending] (the peer no longer wants our data)
+ *   carrying the code.
+ */
+sealed interface QuicStreamAbort {
+    /** The peer's QUIC application error code, or null if the backend doesn't expose it. */
+    val applicationErrorCode: Long?
+
+    /** Peer sent STOP_SENDING (RFC 9000 §19.5): it no longer wants what we're sending. */
+    data class StopSending(
+        override val applicationErrorCode: Long? = null,
+    ) : QuicStreamAbort
+
+    /** Peer sent RESET_STREAM (RFC 9000 §19.4): it abruptly ended its send side. */
+    data class ResetStream(
+        override val applicationErrorCode: Long? = null,
+    ) : QuicStreamAbort
+
+    /** The backend signalled a stream abort but couldn't resolve the direction. */
+    data class Unspecified(
+        override val applicationErrorCode: Long? = null,
+    ) : QuicStreamAbort
+}
+
+/**
  * Thrown when a single QUIC stream is aborted by the peer, while the connection itself stays healthy:
  *
- * - **STOP_SENDING** (quiche `QUICHE_ERR_STREAM_STOPPED`, RFC 9000 §19.5) — the peer no longer wants
- *   what we are sending and asked us to stop. A legitimate, routine event: e.g. an HTTP/3 client
- *   cancelling a server PUSH it didn't want (RFC 9114 §7.2.3).
- * - **RESET_STREAM** (quiche `QUICHE_ERR_STREAM_RESET`, RFC 9000 §19.4) — the peer abruptly terminated
- *   the stream it was sending.
+ * - **STOP_SENDING** (RFC 9000 §19.5) — the peer no longer wants what we are sending and asked us to
+ *   stop. A legitimate, routine event: e.g. an HTTP/3 client cancelling a server PUSH it didn't want
+ *   (RFC 9114 §7.2.3).
+ * - **RESET_STREAM** (RFC 9000 §19.4) — the peer abruptly terminated the stream it was sending.
  *
  * This is deliberately **not** a [QuicCloseException] (nor a `SocketClosedException`): a stopped/reset
  * stream says nothing about the connection, which keeps carrying every other stream. Conflating the two
- * — mapping a stream-level quiche error to a connection-close — tears down a perfectly good connection
- * when a peer cancels one stream. Callers should abandon just this stream and continue.
+ * — mapping a stream-level abort to a connection-close — tears down a perfectly good connection when a
+ * peer cancels one stream. Callers should abandon just this stream and continue.
  *
- * [streamId] is the affected stream. [quicheErrorCode] is the raw quiche sentinel
- * ([QuicheDriver.QUICHE_ERR_STREAM_STOPPED] or [QuicheDriver.QUICHE_ERR_STREAM_RESET]) so callers can
- * distinguish STOP_SENDING from RESET_STREAM without parsing the message.
+ * [streamId] is the affected stream. [abort] is the typed reason — match on it to distinguish
+ * STOP_SENDING from RESET_STREAM and read the peer application error code where available.
  */
 class QuicStreamException(
     val streamId: Long,
-    val quicheErrorCode: Int,
+    val abort: QuicStreamAbort,
     message: String,
     cause: Throwable? = null,
 ) : Exception(message, cause)

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -960,9 +960,17 @@ class DriverStreamAdapter(
                                 // Peer sent STOP_SENDING / RESET_STREAM on THIS stream (RFC 9000 §19.4-19.5).
                                 // Stream-scoped, not connection loss — surface a stream error the caller can
                                 // catch to abandon just this stream; the connection keeps every other stream.
+                                // quiche reports the direction via the sentinel but not the peer application
+                                // error code, so applicationErrorCode is left null.
+                                val abort =
+                                    if (written == QuicheDriver.QUICHE_ERR_STREAM_STOPPED) {
+                                        QuicStreamAbort.StopSending()
+                                    } else {
+                                        QuicStreamAbort.ResetStream()
+                                    }
                                 throw QuicStreamException(
                                     streamId.id,
-                                    written,
+                                    abort,
                                     "quiche stream ${streamId.id} aborted by peer (error $written)",
                                 )
                             } else {

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicServerTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicServerTestSuite.kt
@@ -236,6 +236,77 @@ abstract class QuicServerTestSuite {
             }
         }
 
+    /**
+     * A peer resetting ONE stream must surface to a write on that stream as a stream-scoped
+     * [QuicStreamException] (never a connection-level [QuicCloseException]), and the connection
+     * must stay usable — a fresh stream still round-trips. This is the end-to-end contract behind
+     * the quiche driver's STOP_SENDING/RESET split (#133) and its Apple equivalent (#134): the
+     * Apple write path previously mapped every send error to [QuicCloseException], tearing down a
+     * healthy connection when a peer cancelled a single stream.
+     */
+    @Test
+    fun peerStreamResetSurfacesAsStreamErrorAndConnectionStaysUsable() =
+        runQuicTest {
+            wrapTestBody {
+                withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = testQuicOptions) {
+                    val serverReadFirst = CompletableDeferred<Unit>()
+                    val serverJob =
+                        launch {
+                            connections {
+                                // First stream: read the priming byte, then abruptly reset it.
+                                val s1 = acceptStream()
+                                s1.read(5.seconds)
+                                serverReadFirst.complete(Unit)
+                                s1.reset(0x10cL) // HTTP/3 REQUEST_CANCELLED → STOP_SENDING toward the client's writes
+                                // Second stream: prove the connection survived by echoing it.
+                                val s2 = acceptStream()
+                                val d = s2.read(5.seconds)
+                                if (d is ReadResult.Data) s2.write(d.buffer, 5.seconds)
+                                s2.close()
+                            }
+                        }
+                    delay(100)
+
+                    try {
+                        withQuicConnection("localhost", port, testQuicOptions, timeout = 10.seconds) {
+                            val s1 = openStream()
+                            val hello = BufferFactory.deterministic().allocate(5)
+                            hello.writeString("hello", Charset.UTF8)
+                            hello.resetForRead()
+                            s1.write(hello, 5.seconds)
+                            serverReadFirst.await()
+
+                            // The peer reset must surface here as a STREAM error, not a connection close.
+                            assertFailsWith<QuicStreamException>(
+                                "a peer stream reset must be a QuicStreamException, not a connection-level QuicCloseException",
+                            ) {
+                                repeat(50) {
+                                    val ping = BufferFactory.deterministic().allocate(4)
+                                    ping.writeString("ping", Charset.UTF8)
+                                    ping.resetForRead()
+                                    s1.write(ping, 5.seconds)
+                                    delay(100)
+                                }
+                            }
+
+                            // Connection survived: a fresh stream still round-trips.
+                            val s2 = openStream()
+                            val world = BufferFactory.deterministic().allocate(5)
+                            world.writeString("world", Charset.UTF8)
+                            world.resetForRead()
+                            s2.write(world, 5.seconds)
+                            val resp = s2.read(5.seconds)
+                            assertTrue(resp is ReadResult.Data, "fresh stream after a peer stream-reset must round-trip, got $resp")
+                            assertEquals("world", resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8))
+                            s2.close()
+                        }
+                    } finally {
+                        serverJob.cancel()
+                    }
+                }
+            }
+        }
+
     // --- Pinned CA trust (#99) ---
     // QuicOptions.trustedCaCertificatesPem must drive real chain validation on the
     // quiche-backed targets (JVM/Android/Linux), matching the Apple path. Before #99 the

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -474,7 +474,14 @@ class ReactiveDriverTests {
                             withTimeout(2.seconds) { adapter.streamWrite(slot.id, buf, 2.seconds) }
                         }
                     assertEquals(slot.id.id, ex.streamId, "exception must carry the affected stream id")
-                    assertEquals(code, ex.quicheErrorCode, "exception must carry the raw quiche code")
+                    val expectedAbort =
+                        if (code == QuicheDriver.QUICHE_ERR_STREAM_STOPPED) {
+                            QuicStreamAbort.StopSending()
+                        } else {
+                            QuicStreamAbort.ResetStream()
+                        }
+                    assertEquals(expectedAbort, ex.abort, "exception must carry the typed abort for quiche code $code")
+                    assertNull(ex.abort.applicationErrorCode, "quiche does not surface the peer application error code")
                     assertTrue(
                         ex !is SocketClosedException,
                         "a stopped/reset stream is not a closed connection — must not be a SocketClosedException",


### PR DESCRIPTION
Apple-hardware follow-up to **#133** (which fixed the quiche driver). Closes #134.

> **Stacked on #132** (`fix/apple-quic-stream-reset`) — it needs that PR's `nw_helper_quic_stream_application_error` helper and `reset()` (to provoke the regression test). Review/merge #132 first; the base will retarget to `main` once #132 lands. The diff shown here is just the #134 changes.

## Problem

`NWQuicByteStream.write` mapped **every** non-zero Network.framework send error to a connection-level `QuicCloseException`, so a peer resetting **one** stream (STOP_SENDING/RESET_STREAM, RFC 9000 §19.4-19.5) tore down the whole connection — exactly the bug #133 fixed on quiche.

## Hardware finding (macosArm64)

I provoked a peer stream reset (server `stream.reset(0x10c)`) while the client writes, and captured the send-complete callback:

| Scenario | err_domain | err_code | `stream_application_error` |
|---|---|---|---|
| peer **stream reset** (0x10c) | 1 (POSIX) | 57 (ENOTCONN) | **268** (= 0x10c) |
| **connection** idle-close | 1 (POSIX) | 57 (ENOTCONN) | **UINT64_MAX** |

So `(err_domain, err_code)` is identical for both — #134's hypothesized error-code split won't work. The reliable discriminator is `nw_quic_get_stream_application_error` (the helper #132 added for the read path).

## Fix

- **Write path:** on a send error, query the stream application error. Set → stream-scoped `QuicStreamException`; `UINT64_MAX` → `QuicCloseException`. A peer reset surfacing on our write side means the peer no longer wants our data, so it's reported as `StopSending(code)`.
- **Type-safe `QuicStreamException`:** replaces the quiche-specific `quicheErrorCode: Int` (from #133) with a sealed `QuicStreamAbort` (`StopSending` / `ResetStream` / `Unspecified`, each carrying an optional `applicationErrorCode`). quiche reports direction but not the peer app code (null); Apple reports the app code. Quiche driver + `ReactiveDriverTests` updated.
- **`sendFin`:** kept best-effort — `close()` must not throw, and a pre-close reset surfaces on the read/write paths instead.

## Tests

New shared loopback regression in `QuicServerTestSuite`: a peer stream reset surfaces as `QuicStreamException` (not `QuicCloseException`) **and** a fresh stream still round-trips. Verified on **Apple** (11/11 server suite) and **JVM/quiche** (26/26 `ReactiveDriverTests`); ktlint clean.