### PR TITLE
fix(quic): recv_info must own its sockaddr bytes (intermittent JNI SIGSEGV)

### DIFF
--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -476,14 +476,27 @@ JNIEXPORT void JNICALL JNI_FN(nStreamIterFree)(JNIEnv *env, jclass cls, jlong it
 
 /* --- RecvInfo / SendInfo helpers --- */
 
+/* The struct OWNS its sockaddr bytes: we allocate the quiche_recv_info followed by inline
+ * storage for the `from` and `to` sockaddrs and copy the caller's bytes in, so quiche_conn_recv
+ * dereferences memory this allocation owns — NOT the caller's separately-managed buffers. On the
+ * JVM those `from`/`to` buffers are DirectByteBuffers that the GC's Cleaner (or an explicit free
+ * during cache eviction / connection teardown) can release while a queued packet still references
+ * the recv_info, which made quiche read freed/unmapped memory in std_addr_from_c (intermittent
+ * SIGSEGV under connection churn). from/to are immutable for a given recv_info, so copying once at
+ * creation is sufficient. The struct (32 bytes, 8-aligned) is followed by 4-aligned sockaddr copies
+ * (from_len/to_len are 16 or 28). nRecvInfoFree frees the single allocation. */
 JNIEXPORT jlong JNICALL JNI_FN(nRecvInfoNew)(
     JNIEnv *env, jclass cls,
     jlong from_addr, jint from_len, jlong to_addr, jint to_len) {
-    quiche_recv_info *info = (quiche_recv_info *)calloc(1, sizeof(quiche_recv_info));
+    size_t total = sizeof(quiche_recv_info) + (size_t)from_len + (size_t)to_len;
+    quiche_recv_info *info = (quiche_recv_info *)calloc(1, total);
     if (!info) return 0;
-    info->from = (struct sockaddr *)(uintptr_t)from_addr;
+    unsigned char *storage = (unsigned char *)info + sizeof(quiche_recv_info);
+    memcpy(storage, (const void *)(uintptr_t)from_addr, (size_t)from_len);
+    memcpy(storage + from_len, (const void *)(uintptr_t)to_addr, (size_t)to_len);
+    info->from = (struct sockaddr *)storage;
     info->from_len = (socklen_t)from_len;
-    info->to = (struct sockaddr *)(uintptr_t)to_addr;
+    info->to = (struct sockaddr *)(storage + from_len);
     info->to_len = (socklen_t)to_len;
     return (jlong)(uintptr_t)info;
 }

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -830,10 +830,20 @@ class FfmQuicheApi private constructor(
         toAddr: Long,
         toAddrLen: Int,
     ): QuicheRecvInfo {
-        val info = recvInfoArena.allocate(RECV_INFO_SIZE.toLong(), 8)
-        info.set(ADDRESS, 0, seg(fromAddr)) // from
+        // Make the struct OWN its sockaddr bytes: allocate the 32-byte quiche_recv_info followed by
+        // inline copies of `from` and `to`, and point the struct's pointers inside this segment.
+        // quiche_conn_recv then dereferences memory this allocation owns, NOT the caller's
+        // DirectByteBuffer-backed sockaddrs, which the GC Cleaner or cache eviction can free while a
+        // queued packet still references the recv_info (intermittent SIGSEGV in std_addr_from_c under
+        // connection churn). from/to are immutable per recv_info, so a one-time copy is sufficient.
+        val info = recvInfoArena.allocate(RECV_INFO_SIZE.toLong() + fromAddrLen + toAddrLen, 8)
+        val fromOffset = RECV_INFO_SIZE.toLong() // 32, 8-aligned
+        val toOffset = fromOffset + fromAddrLen // 4-aligned (fromAddrLen is 16 or 28)
+        MemorySegment.copy(seg(fromAddr).reinterpret(fromAddrLen.toLong()), 0L, info, fromOffset, fromAddrLen.toLong())
+        MemorySegment.copy(seg(toAddr).reinterpret(toAddrLen.toLong()), 0L, info, toOffset, toAddrLen.toLong())
+        info.set(ADDRESS, 0, info.asSlice(fromOffset)) // from -> inline copy
         info.set(JAVA_INT, 8, fromAddrLen) // from_len
-        info.set(ADDRESS, 16, seg(toAddr)) // to
+        info.set(ADDRESS, 16, info.asSlice(toOffset)) // to -> inline copy
         info.set(JAVA_INT, 24, toAddrLen) // to_len
         return QuicheRecvInfo(info.address())
     }

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -80,13 +80,16 @@ import kotlinx.cinterop.UByteVar
 import kotlinx.cinterop.UIntVar
 import kotlinx.cinterop.ULongVar
 import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.plus
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.rawValue
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
 import kotlinx.cinterop.toCPointer
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.value
@@ -677,12 +680,25 @@ internal object CinteropQuicheApi : QuicheApi {
         toAddr: Long,
         toAddrLen: Int,
     ): QuicheRecvInfo {
-        val info = kotlinx.cinterop.nativeHeap.alloc<quiche_recv_info>()
-        info.from = fromAddr.toCPointer()!!
+        // Make the struct OWN its sockaddr bytes: one allocation holding the quiche_recv_info
+        // followed by inline copies of `from` and `to`, with the struct's pointers aimed inside it.
+        // quiche_conn_recv then reads memory this allocation owns, not the caller's separately-managed
+        // sockaddr buffers (which cache eviction / teardown can free while a queued packet still holds
+        // the recv_info — the intermittent SIGSEGV in std_addr_from_c). nativeHeap is malloc-backed
+        // (>=8-aligned); from/to are immutable per recv_info so a one-time copy suffices. recvInfoFree
+        // frees the single block (the struct address == the allocation base).
+        val structSize = sizeOf<quiche_recv_info>()
+        val raw = kotlinx.cinterop.nativeHeap.allocArray<ByteVar>(structSize + fromAddrLen + toAddrLen)
+        val fromStorage = (raw + structSize)!!
+        val toStorage = (raw + (structSize + fromAddrLen))!!
+        platform.posix.memcpy(fromStorage, fromAddr.toCPointer<ByteVar>(), fromAddrLen.convert())
+        platform.posix.memcpy(toStorage, toAddr.toCPointer<ByteVar>(), toAddrLen.convert())
+        val info = raw.reinterpret<quiche_recv_info>().pointed
+        info.from = fromStorage.reinterpret()
         info.from_len = fromAddrLen.convert()
-        info.to = toAddr.toCPointer()!!
+        info.to = toStorage.reinterpret()
         info.to_len = toAddrLen.convert()
-        return QuicheRecvInfo(info.ptr.rawValue.toLong())
+        return QuicheRecvInfo(raw.rawValue.toLong())
     }
 
     override fun recvInfoFree(info: QuicheRecvInfo) {


### PR DESCRIPTION
## Root cause (caught in CI with a full stack)

The intermittent JNI native crash we'd been hunting reproduced on the build-linux lane, and the `-XX:+ErrorFileToStderr` diagnostic (from #135) put the hs_err in the live log. It's a **use-after-free**, not a random abort:

```
SIGSEGV / SEGV_MAPERR  in  quiche::ffi::std_addr_from_c
  <- quiche_conn_recv  <- JniQuicheApi.nConnRecv
  <- QuicheDriver.execute(RecvPacket)  <- QuicheDriver.run()
```

`quiche_recv_info` stored **raw pointers** to sockaddr buffers owned by Kotlin (`DirectByteBuffer` / `NativeSockAddr`), and `nRecvInfoFree` freed only the struct. `quiche_conn_recv` dereferences `info->from` / `info->to` during the call — so when the server's per-source recv_info cache evicts an entry (or the GC `Cleaner` reclaims a `DirectByteBuffer`) **while a packet referencing that recv_info is still queued** on the driver's UNLIMITED command channel, quiche reads freed/unmapped memory → SIGSEGV in `std_addr_from_c`. It's the same hazard the `acceptNewConnection` comment (quiche `ffi.rs:2059`) already flagged for the primary recv_info — the in-flight refcount / strong-ref guards narrowed the window but didn't close it.

## Fix

Make `quiche_recv_info` **self-contained**: `recvInfoNew` allocates the struct followed by inline copies of `from` and `to`, and points the struct inside its own allocation. quiche then only ever reads memory the recv_info owns; the Kotlin-side sockaddr buffer lifetime no longer matters for quiche's reads. `from`/`to` are immutable per recv_info, so a one-time copy at creation suffices, and `recvInfoFree` still frees a single block.

Applied across all backends:
- **JNI** (`quiche_jni.c`): `calloc(struct + from_len + to_len)` + `memcpy`.
- **FFM** (`FfmQuicheApi`): arena segment sized struct+from+to, `MemorySegment.copy`, `from`/`to` point at `asSlice()` offsets.
- **cinterop** (`CinteropQuicheApi`, linuxX64): `nativeHeap` byte block + posix `memcpy`.

The existing Kotlin lifetime management (`CachedRecvInfo.inFlight` refcount, `onCleanup` strong refs) is now belt-and-suspenders and left intact.

## Verification

- Full `:socket-quic:jvmTest` green on **JNI** including **`-PquicMallocCheck`** (glibc malloc.check=3 would abort on any double-free / corruption of the new combined allocation).
- Full `:socket-quic:jvmTest` green on **FFM**.
- Full `:socket-quic:linuxX64Test` green (**cinterop**).

The original crash is rare (needs CI scheduling latency) so a local repro isn't expected; this removes the dangling-sockaddr class structurally. `skip-release`.

Refs: `project_ci_backend_coverage` (captured stack), #135 (the diagnostic that caught it).