### PR TITLE
test(quic): deterministic timing tests — time-scale, keepalive ratio, DriverClock seam

### DIFF
--- a/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicIdleTimeoutTests.kt
+++ b/socket-quic/src/androidInstrumentedTest/kotlin/com/ditchoom/socket/quic/AndroidQuicIdleTimeoutTests.kt
@@ -100,7 +100,9 @@ class AndroidQuicIdleTimeoutTests {
         connections {
             val stream = acceptStream()
             while (true) {
-                val data = stream.read(KEEPALIVE_IDLE + 5.seconds)
+                // Read backstop must outlast the client's full idle wait, or the server breaks out of the
+                // echo loop before the keepalive round-trip — tie it to KEEPALIVE_IDLE_WAIT, not the window.
+                val data = stream.read(KEEPALIVE_IDLE_WAIT + 5.seconds)
                 if (data is ReadResult.Data) {
                     stream.write(data.buffer, 5.seconds)
                 } else {
@@ -140,9 +142,13 @@ class AndroidQuicIdleTimeoutTests {
 
     private companion object {
         private val IDLE_TIMEOUT = 2.seconds
-        private val READ_TIMEOUT = 10.seconds
-        private val KEEPALIVE_IDLE = 4.seconds
-        private val KEEPALIVE_INTERVAL = 1.seconds
-        private val KEEPALIVE_IDLE_WAIT = 6.seconds
+        private val READ_TIMEOUT = 10.seconds // 5× IDLE_TIMEOUT so a working idle-close returns End first
+
+        // Keepalive: PING interval kept a full 6× under the idle window so scheduler jitter on a loaded
+        // emulator can't starve a PING past the window (the old 4s/1s = 4× was two-sided — see the
+        // commonTest QuicIdleTimeoutTestSuite for the rationale; this Android copy can't see commonTest).
+        private val KEEPALIVE_IDLE = 6.seconds
+        private val KEEPALIVE_INTERVAL = 1.seconds // PING every 1 s — 5 s slack under the 6 s idle window
+        private val KEEPALIVE_IDLE_WAIT = 9.seconds // idle 1.5× the window so a broken keepalive closes
     }
 }

--- a/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
+++ b/socket-quic/src/appleTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
@@ -19,3 +19,5 @@ internal actual fun shouldSkipQuicHarnessOnSimulator(): Boolean {
     val booted = getenv("QUIC_SIM_BOOTED")?.toKString() == "1"
     return !booted
 }
+
+internal actual fun timeScaleEnv(): String? = getenv("QUIC_TEST_TIME_SCALE")?.toKString()

--- a/socket-quic/src/commonJvmTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
+++ b/socket-quic/src/commonJvmTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
@@ -3,3 +3,5 @@ package com.ditchoom.socket.quic
 internal actual fun isAppleKNative(): Boolean = false
 
 internal actual fun shouldSkipQuicHarnessOnSimulator(): Boolean = false
+
+internal actual fun timeScaleEnv(): String? = System.getenv("QUIC_TEST_TIME_SCALE")

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/DriverClock.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/DriverClock.kt
@@ -1,0 +1,49 @@
+package com.ditchoom.socket.quic
+
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlinx.coroutines.selects.onTimeout
+import kotlin.time.Duration
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * The [QuicheDriver]'s two couplings to wall-clock time, isolated behind one seam so a test can drive
+ * both deterministically **without** giving up the real `Dispatchers.Default` I/O the reactive loop
+ * relies on:
+ *
+ *  - [markNow] — the monotonic mark the keepalive deadline is measured from (`lastActivity`); and
+ *  - [armTimeout] — the `select` clause that wakes the loop when the next quiche/keepalive timer is due.
+ *
+ * Production uses [RealDriverClock]: monotonic time and `onTimeout`, i.e. exactly the behaviour the
+ * driver had before the seam existed. A test clock can return a controllable [TimeMark] and replace the
+ * timeout with a manually-fired rendezvous, turning the keepalive/idle timing path — previously only
+ * reachable through multi-second wall-clock integration tests — into exact, race-free assertions. See
+ * `ManualDriverClock` in commonTest.
+ */
+interface DriverClock {
+    /** A fresh mark for measuring elapsed inactivity. Production: `TimeSource.Monotonic.markNow()`. */
+    fun markNow(): TimeMark
+
+    /**
+     * Register the driver's timer on [builder] — the in-progress `select<QuicheCmd?>` that also races the
+     * command channel. The registered clause MUST produce `null` (the loop's "a timer fired" sentinel)
+     * when [wait] is due. Production registers `onTimeout(wait) { null }`; a manual clock can instead
+     * select on a rendezvous channel the test fires by hand, ignoring [wait].
+     */
+    fun armTimeout(
+        builder: SelectBuilder<QuicheCmd?>,
+        wait: Duration,
+    )
+}
+
+/** Production clock: monotonic time + coroutine `onTimeout`. Behaviour-identical to the pre-seam loop. */
+object RealDriverClock : DriverClock {
+    override fun markNow(): TimeMark = TimeSource.Monotonic.markNow()
+
+    override fun armTimeout(
+        builder: SelectBuilder<QuicheCmd?>,
+        wait: Duration,
+    ) {
+        with(builder) { onTimeout(wait) { null } }
+    }
+}

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -27,7 +26,6 @@ import kotlin.concurrent.Volatile
 import kotlin.coroutines.coroutineContext
 import kotlin.random.Random
 import kotlin.time.Duration
-import kotlin.time.TimeSource
 
 /**
  * Drives a single quiche connection from one coroutine. No mutexes, no polling.
@@ -58,6 +56,12 @@ class QuicheDriver(
      * the driver's own [select] loop — no polling. Null disables keepalive. See [QuicOptions.keepAliveInterval].
      */
     private val keepAliveInterval: Duration? = null,
+    /**
+     * The driver's clock seam (monotonic mark + the `select` timeout clause). Defaults to
+     * [RealDriverClock] so every platform and production path keeps its exact pre-seam timer
+     * behaviour; tests inject a manual clock to make the keepalive/idle timing deterministic.
+     */
+    private val clock: DriverClock = RealDriverClock,
     /**
      * Connection-migration wiring (slice 3). All default to "disabled" so server-accepted
      * drivers, unit-test fakes, and the no-migration platforms keep their single-path
@@ -258,7 +262,7 @@ class QuicheDriver(
             // Reactive keepalive: time inactivity off a monotonic mark, reset on every command we
             // process. We wake at min(quiche's next timer, keepalive deadline); whichever is sooner
             // decides whether we PING or hand the timeout to quiche. No polling.
-            var lastActivity = TimeSource.Monotonic.markNow()
+            var lastActivity = clock.markNow()
             while (true) {
                 val connTimeout = api.connTimeout(conn)
                 // Keepalive only counts once the handshake is established (the handshake itself is
@@ -279,7 +283,7 @@ class QuicheDriver(
                     } else {
                         select<QuicheCmd?> {
                             commands.onReceiveCatching { it.getOrNull() }
-                            onTimeout(wait) { null }
+                            clock.armTimeout(this, wait)
                         }
                     }
                 // null from onReceiveCatching means channel closed — exit
@@ -287,11 +291,11 @@ class QuicheDriver(
                 when {
                     cmd is QuicheCmd.Migrate -> {
                         handleMigrate(cmd) // suspends: opens a socket
-                        lastActivity = TimeSource.Monotonic.markNow()
+                        lastActivity = clock.markNow()
                     }
                     cmd != null -> {
                         execute(cmd)
-                        lastActivity = TimeSource.Monotonic.markNow() // any command is activity → defer keepalive
+                        lastActivity = clock.markNow() // any command is activity → defer keepalive
                     }
                     // A timer fired. If the keepalive deadline is strictly the sooner one, PING; quiche's
                     // idle timer is always later (keepAliveInterval < idleTimeout), so this fires first and
@@ -299,7 +303,7 @@ class QuicheDriver(
                     keepAliveRemaining != null && (connTimeout == null || keepAliveRemaining < connTimeout) -> {
                         if (!api.connIsClosed(conn)) {
                             api.connSendAckEliciting(conn) // emitted by the afterCommand() flush below
-                            lastActivity = TimeSource.Monotonic.markNow()
+                            lastActivity = clock.markNow()
                         }
                     }
                     else -> api.connOnTimeout(conn)

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ManualDriverClock.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ManualDriverClock.kt
@@ -68,4 +68,15 @@ internal class ManualDriverClock : DriverClock {
         ticks.send(Unit) // rendezvous: driver is parked, takes the tick, runs the branch, then re-arms
         rearmed.receive() // the re-arm — branch body has finished, its effect is now observable
     }
+
+    /**
+     * Fire the armed timer **without** waiting for a re-arm — for a fire that *terminates* the loop (e.g. an
+     * idle-close), after which the driver never parks again. Synchronise on the observable terminal effect
+     * instead (e.g. `driver.state.first { it is Closed }`), not on a re-arm that will never come.
+     */
+    suspend fun fireExpectingNoRearm(by: Duration) {
+        while (rearmed.tryReceive().isSuccess) { /* drain */ }
+        elapsed += by
+        ticks.send(Unit)
+    }
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ManualDriverClock.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ManualDriverClock.kt
@@ -1,0 +1,71 @@
+package com.ditchoom.socket.quic
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.selects.SelectBuilder
+import kotlin.time.Duration
+import kotlin.time.TimeMark
+
+/**
+ * Test [DriverClock] that makes the driver's keepalive/idle timing **deterministic** — virtual elapsed
+ * time the test controls plus a timer the test fires by hand, instead of the real monotonic clock and
+ * `onTimeout`. This is the Tier-1 seam: the keepalive decision (PING vs. hand the timer to quiche vs. do
+ * nothing) was previously only reachable through multi-second wall-clock tests; here it's an exact,
+ * race-free assertion that runs in microseconds.
+ *
+ * Usage:
+ * ```
+ * val clock = ManualDriverClock()
+ * val driver = createTestDriver(api, keepAliveInterval = 1.seconds, clock = clock)
+ * driver.start(this)
+ * clock.advance(1.seconds)   // move time forward AND fire the armed timer, in one race-free step
+ * assertEquals(1, api.ackElicitingCount)
+ * ```
+ *
+ * The fire channel is RENDEZVOUS, so [advance] suspends until the driver's `select` has taken the tick —
+ * on return the driver has entered the "a timer fired" branch, so there is no settle delay to tune.
+ */
+internal class ManualDriverClock : DriverClock {
+    private var elapsed: Duration = Duration.ZERO
+
+    /** RENDEZVOUS: a send blocks until the driver's `select` is parked and takes the tick. */
+    private val ticks = Channel<Unit>(Channel.RENDEZVOUS)
+
+    /** One token per arm, i.e. each time the loop is about to park in `select`. UNLIMITED so it never drops;
+     *  [advance] drains stale tokens then waits for the *post-fire* re-arm to know the branch fully ran. */
+    private val rearmed = Channel<Unit>(Channel.UNLIMITED)
+
+    override fun markNow(): TimeMark {
+        val origin = elapsed
+        return object : TimeMark {
+            override fun elapsedNow(): Duration = elapsed - origin
+        }
+    }
+
+    override fun armTimeout(
+        builder: SelectBuilder<QuicheCmd?>,
+        wait: Duration,
+    ) {
+        // Ignore [wait]: the test decides when the timer fires. The token announces "armed & about to park";
+        // selecting on the rendezvous yields the loop's "a timer fired" sentinel (null) when advance() fires.
+        rearmed.trySend(Unit)
+        with(builder) { ticks.onReceive { null } }
+    }
+
+    /**
+     * Advance virtual time by [by], then fire the driver's currently-armed timer and **wait until the
+     * driver has fully processed the fire** (its timer branch ran and it has looped back to re-arm). On
+     * return the timing branch's effect — a keepalive PING, a `connOnTimeout`, or nothing — is observable,
+     * so the assertion that follows is race-free.
+     *
+     * Requires the loop to keep a timer armed (`wait != null`): a keepalive-enabled established connection,
+     * or a non-null `connTimeout` on the stub. If a fire makes `wait` become null the driver won't re-arm
+     * and this will suspend until the run's timeout.
+     */
+    suspend fun advance(by: Duration) {
+        // Drop any stale "armed" tokens so the wait below pairs with the re-arm caused by THIS fire.
+        while (rearmed.tryReceive().isSuccess) { /* drain */ }
+        elapsed += by
+        ticks.send(Unit) // rendezvous: driver is parked, takes the tick, runs the branch, then re-arms
+        rearmed.receive() // the re-arm — branch body has finished, its effect is now observable
+    }
+}

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicConcurrencySoakTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicConcurrencySoakTestSuite.kt
@@ -52,7 +52,9 @@ abstract class QuicConcurrencySoakTestSuite {
         QuicOptions(
             alpnProtocols = listOf("test"),
             verifyPeer = false,
-            idleTimeout = 30.seconds,
+            // Scaled so it stays above the (also-scaled) runQuicTest cap on a loaded runner — a soak run
+            // that legitimately takes longer under load must not trip an idle-timeout mid-transfer.
+            idleTimeout = 30.seconds.scaled,
         )
 
     // ---- tests -------------------------------------------------------------------------------------
@@ -66,7 +68,7 @@ abstract class QuicConcurrencySoakTestSuite {
                     withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = options) {
                         val serverJob = launch { connections { echoEveryStream() } }
                         try {
-                            withQuicConnection("127.0.0.1", port, options, timeout = 15.seconds) {
+                            withQuicConnection("127.0.0.1", port, options, timeout = 15.seconds.scaled) {
                                 val results =
                                     (0 until CONCURRENT_STREAMS)
                                         .map { i ->
@@ -116,7 +118,7 @@ abstract class QuicConcurrencySoakTestSuite {
                                 (0 until CONCURRENT_CONNECTIONS)
                                     .map { i ->
                                         async {
-                                            withQuicConnection("127.0.0.1", port, options, timeout = 15.seconds) {
+                                            withQuicConnection("127.0.0.1", port, options, timeout = 15.seconds.scaled) {
                                                 val stream = openStream()
                                                 val echoed = stream.echoExact("conn-$i")
                                                 stream.close()
@@ -161,7 +163,7 @@ abstract class QuicConcurrencySoakTestSuite {
                                 port,
                                 options,
                                 ConnectionOptions(bufferFactory = tracking),
-                                timeout = 15.seconds,
+                                timeout = 15.seconds.scaled,
                             ) {
                                 val stream = openStream()
                                 for (round in 0 until SOAK_ROUNDS) {
@@ -192,9 +194,9 @@ abstract class QuicConcurrencySoakTestSuite {
             launch {
                 try {
                     while (true) {
-                        val data = stream.read(15.seconds)
+                        val data = stream.read(15.seconds.scaled)
                         if (data is ReadResult.Data) {
-                            stream.write(data.buffer, 10.seconds)
+                            stream.write(data.buffer, 10.seconds.scaled)
                         } else {
                             break
                         }
@@ -212,11 +214,11 @@ abstract class QuicConcurrencySoakTestSuite {
         out.writeString(payload, Charset.UTF8)
         out.resetForRead()
         try {
-            write(out, 10.seconds)
+            write(out, 10.seconds.scaled)
         } finally {
             out.freeNativeMemory()
         }
-        return readExactly(payload.length, 10.seconds)
+        return readExactly(payload.length, 10.seconds.scaled)
     }
 
     private suspend fun QuicByteStream.readExactly(

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicIdleTimeoutTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicIdleTimeoutTestSuite.kt
@@ -62,7 +62,7 @@ abstract class QuicIdleTimeoutTestSuite {
                             }
                         }
                     try {
-                        withQuicConnection("127.0.0.1", port, opts, timeout = 10.seconds) {
+                        withQuicConnection("127.0.0.1", port, opts, timeout = 10.seconds.scaled) {
                             val stream = openStream()
                             stream.writeString("hi") // establish the stream on the server, then go idle
                             val result = stream.read(READ_TIMEOUT)
@@ -97,7 +97,7 @@ abstract class QuicIdleTimeoutTestSuite {
                 withQuicServer(port = 0, tlsConfig = testTlsConfig(), quicOptions = opts) {
                     val serverJob = launch { echoEveryStream() }
                     try {
-                        withQuicConnection("127.0.0.1", port, opts, timeout = 10.seconds) {
+                        withQuicConnection("127.0.0.1", port, opts, timeout = 10.seconds.scaled) {
                             val stream = openStream()
                             // Establish the stream on the server, then go completely idle for longer than
                             // the idle timeout. Reactive keepalive must hold the connection open.
@@ -123,9 +123,11 @@ abstract class QuicIdleTimeoutTestSuite {
         connections {
             val stream = acceptStream()
             while (true) {
-                val data = stream.read(KEEPALIVE_IDLE + 5.seconds)
+                // Read backstop must outlast the client's full idle wait, or the server breaks out of the
+                // echo loop before the keepalive round-trip — tie it to KEEPALIVE_IDLE_WAIT, not the window.
+                val data = stream.read(KEEPALIVE_IDLE_WAIT + 5.seconds.scaled)
                 if (data is ReadResult.Data) {
-                    stream.write(data.buffer, 5.seconds)
+                    stream.write(data.buffer, 5.seconds.scaled)
                 } else {
                     break
                 }
@@ -139,7 +141,7 @@ abstract class QuicIdleTimeoutTestSuite {
         out.writeString(payload, Charset.UTF8)
         out.resetForRead()
         try {
-            write(out, 5.seconds)
+            write(out, 5.seconds.scaled)
         } finally {
             out.freeNativeMemory()
         }
@@ -147,7 +149,7 @@ abstract class QuicIdleTimeoutTestSuite {
 
     private suspend fun QuicByteStream.echoOnce(payload: String): String {
         writeString(payload)
-        val resp = read(5.seconds)
+        val resp = read(5.seconds.scaled)
         return if (resp is ReadResult.Data) {
             val s = resp.buffer.readString(resp.buffer.remaining(), Charset.UTF8)
             resp.buffer.freeIfNeeded()
@@ -158,11 +160,18 @@ abstract class QuicIdleTimeoutTestSuite {
     }
 
     private companion object {
-        private val IDLE_TIMEOUT = 2.seconds
-        private val READ_TIMEOUT = 10.seconds // > IDLE_TIMEOUT so a working idle-close returns End first
+        // Every value is `.scaled` (>= 1.0, uniform) so a loaded CI runner gets proportionally more
+        // wall-clock without altering any timing relationship — see [Duration.scaled]. Ratios, not
+        // absolutes, carry the assertions here.
+        private val IDLE_TIMEOUT = 2.seconds.scaled
+        private val READ_TIMEOUT = 10.seconds.scaled // 5× IDLE_TIMEOUT so a working idle-close returns End first
 
-        private val KEEPALIVE_IDLE = 4.seconds
-        private val KEEPALIVE_INTERVAL = 1.seconds // PING every 1 s — 3 s slack under the 4 s idle timeout
-        private val KEEPALIVE_IDLE_WAIT = 6.seconds // idle well past KEEPALIVE_IDLE so a broken keepalive closes
+        // Keepalive: the PING interval is kept a full 6× under the idle window. The previous 4s/1s (4×)
+        // was two-sided — a scheduler-starved runner could delay the 1s PING past the 4s window and the
+        // connection would idle-close (a false failure). At 6× even several consecutive starved intervals
+        // still land a PING inside the window before the idle timer fires.
+        private val KEEPALIVE_IDLE = 6.seconds.scaled
+        private val KEEPALIVE_INTERVAL = 1.seconds.scaled // PING every 1 s — 5 s slack under the 6 s idle window
+        private val KEEPALIVE_IDLE_WAIT = 9.seconds.scaled // idle 1.5× the window so a broken keepalive closes
     }
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicImpairmentTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicImpairmentTestSuite.kt
@@ -57,7 +57,8 @@ abstract class QuicImpairmentTestSuite {
             alpnProtocols = listOf("test"),
             verifyPeer = false,
             // Generous so idle-timeout never races loss/PTO recovery — the impairment is data-phase only.
-            idleTimeout = 30.seconds,
+            // Scaled so it stays above the (also-scaled) runQuicTest cap on a loaded runner.
+            idleTimeout = 30.seconds.scaled,
         )
 
     // ---- tests -------------------------------------------------------------------------------------
@@ -161,9 +162,9 @@ abstract class QuicImpairmentTestSuite {
                     connections {
                         val stream = acceptStream()
                         while (true) {
-                            val data = stream.read(15.seconds)
+                            val data = stream.read(15.seconds.scaled)
                             if (data is ReadResult.Data) {
-                                stream.write(data.buffer, 10.seconds)
+                                stream.write(data.buffer, 10.seconds.scaled)
                             } else {
                                 break
                             }
@@ -178,7 +179,7 @@ abstract class QuicImpairmentTestSuite {
             val clientJob =
                 launch {
                     try {
-                        withQuicConnection("127.0.0.1", proxy.proxyPort, impairOptions, timeout = 15.seconds) {
+                        withQuicConnection("127.0.0.1", proxy.proxyPort, impairOptions, timeout = 15.seconds.scaled) {
                             val stream = openStream()
                             // Pass-through warm-up: proves handshake + stream are up before impairment arms.
                             assertEquals(WARMUP, stream.echoExact(WARMUP), "warm-up echo failed before impairment")
@@ -245,8 +246,11 @@ abstract class QuicImpairmentTestSuite {
         private const val WARMUP = "warmup"
         private const val BURST_START = 3
         private const val BURST_SIZE = 5
-        private val ECHO_TIMEOUT = 8.seconds
-        private val BLACKHOLE_TIMEOUT = 4.seconds
+
+        // Per-op backstops, scaled for loaded runners. BLACKHOLE_TIMEOUT only ever fires on the
+        // anti-vacuous total-blackhole test (where it asserts a stall), so scaling up only strengthens it.
+        private val ECHO_TIMEOUT = 8.seconds.scaled
+        private val BLACKHOLE_TIMEOUT = 4.seconds.scaled
 
         /** Deterministic single-byte-UTF8 payload: `A B C … Z A B …` so chunk boundaries never split a codepoint. */
         private fun deterministicAscii(length: Int): String =

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -735,6 +735,26 @@ class ReactiveDriverTests {
         }
 
     @Test
+    fun keepAlive_manualClock_isDeterministicUnderRepeatedFires() =
+        runQuicTest {
+            // Proves ManualDriverClock.advance() is race-free: it must return only AFTER the driver has fully
+            // processed each fire. Asserting the EXACT cumulative count after EVERY one of many fires would
+            // fail on the first slipped iteration if advance() raced the driver's timer branch.
+            val api = StubQuicheApi()
+            val clock = ManualDriverClock()
+            val driver = createTestDriver(api, keepAliveInterval = 1.seconds, clock = clock)
+            driver.start(this)
+            try {
+                repeat(200) { i ->
+                    clock.advance(1.seconds)
+                    assertEquals(i + 1, api.ackElicitingCount, "fire ${i + 1} not observed on return — advance() raced the timer branch")
+                }
+            } finally {
+                driver.commands.close()
+            }
+        }
+
+    @Test
     fun keepAlive_handsTimerToQuiche_whenQuicheTimeoutIsSooner() =
         runQuicTest {
             // When quiche's own timer (idle/loss recovery) is due before the keepalive deadline, the driver

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -716,18 +716,38 @@ class ReactiveDriverTests {
     @Test
     fun keepAlive_schedulesAckElicitingPings_onIdleConnection() =
         runQuicTest {
-            // Stub defaults: established=true, connTimeout=null, closed=false. With no commands and no
-            // quiche timeout, the ONLY thing that can wake the driver loop is the keepalive deadline — so
-            // any ack-eliciting PING proves the reactive keepalive timer fired. No network, no flaky
-            // wall-clock assertion: we wait for a COUNT within a generous window (50ms interval → dozens
-            // of PINGs possible in 3s; reaching >= 2 needs only ~100ms of driver scheduling).
+            // Tier-1 deterministic timing: a [ManualDriverClock] fires the keepalive timer by hand, so there
+            // is no wall-clock dependence at all. Stub defaults: established=true, connTimeout=null — so the
+            // keepalive deadline is the only armed timer, and each clock.advance() is exactly one PING.
             val api = StubQuicheApi()
-            val driver = createTestDriver(api, keepAliveInterval = 50.milliseconds)
+            val clock = ManualDriverClock()
+            val driver = createTestDriver(api, keepAliveInterval = 1.seconds, clock = clock)
             driver.start(this)
             try {
-                awaitUntil(3.seconds, "driver never scheduled a keepalive PING (ackElicitingCount stayed 0)") {
-                    api.ackElicitingCount >= 2
-                }
+                clock.advance(1.seconds)
+                assertEquals(1, api.ackElicitingCount, "first keepalive deadline did not schedule a PING")
+                clock.advance(1.seconds)
+                assertEquals(2, api.ackElicitingCount, "second keepalive deadline did not schedule a PING")
+                assertEquals(0, api.onTimeoutCount, "keepalive deadline must not be handed to quiche as an idle timeout")
+            } finally {
+                driver.commands.close()
+            }
+        }
+
+    @Test
+    fun keepAlive_handsTimerToQuiche_whenQuicheTimeoutIsSooner() =
+        runQuicTest {
+            // When quiche's own timer (idle/loss recovery) is due before the keepalive deadline, the driver
+            // must hand the fire to quiche (connOnTimeout), NOT send a PING. connTimeout 50ms < keepalive 10s.
+            val api = StubQuicheApi()
+            api.connTimeout = 50.milliseconds
+            val clock = ManualDriverClock()
+            val driver = createTestDriver(api, keepAliveInterval = 10.seconds, clock = clock)
+            driver.start(this)
+            try {
+                clock.advance(50.milliseconds)
+                assertEquals(0, api.ackElicitingCount, "quiche timer was sooner — the driver must not PING")
+                assertEquals(1, api.onTimeoutCount, "quiche timer fire was not handed to connOnTimeout")
             } finally {
                 driver.commands.close()
             }
@@ -736,14 +756,39 @@ class ReactiveDriverTests {
     @Test
     fun keepAlive_disabled_sendsNoPings() =
         runQuicTest {
-            // No keepAliveInterval → the driver must never call connSendAckEliciting, however long it idles.
-            // Disabled means "never", independent of the settle window — so this can't flake on timing.
+            // No keepAliveInterval → the driver must NEVER PING, only hand timer fires to quiche. A non-null
+            // connTimeout keeps a timer armed so the ManualDriverClock has something to fire and the
+            // assertion is "fired the timer, still no PING" — strictly stronger than "no PING within 300ms".
             val api = StubQuicheApi()
-            val driver = createTestDriver(api, keepAliveInterval = null)
+            api.connTimeout = 50.milliseconds
+            val clock = ManualDriverClock()
+            val driver = createTestDriver(api, keepAliveInterval = null, clock = clock)
             driver.start(this)
             try {
-                kotlinx.coroutines.delay(300.milliseconds) // real time for a stray PING to surface, if any
+                clock.advance(50.milliseconds)
+                clock.advance(50.milliseconds)
                 assertEquals(0, api.ackElicitingCount, "keepalive disabled but the driver still sent ack-eliciting PINGs")
+                assertEquals(2, api.onTimeoutCount, "both timer fires should have been handed to quiche")
+            } finally {
+                driver.commands.close()
+            }
+        }
+
+    @Test
+    fun keepAlive_notScheduledBeforeHandshakeEstablished() =
+        runQuicTest {
+            // Keepalive only counts once established (a half-open connection has nothing to keep alive). With
+            // established=false the keepalive deadline is suppressed, so a fired timer goes to quiche, not a PING.
+            val api = StubQuicheApi()
+            api.established = false
+            api.connTimeout = 50.milliseconds
+            val clock = ManualDriverClock()
+            val driver = createTestDriver(api, keepAliveInterval = 1.seconds, clock = clock)
+            driver.start(this)
+            try {
+                clock.advance(1.seconds)
+                assertEquals(0, api.ackElicitingCount, "keepalive must not PING before the handshake is established")
+                assertEquals(1, api.onTimeoutCount, "pre-established timer fire should be handed to quiche")
             } finally {
                 driver.commands.close()
             }
@@ -762,6 +807,7 @@ class ReactiveDriverTests {
         isServer: Boolean = false,
         udpChannel: UdpChannel = StubUdpChannel(),
         keepAliveInterval: kotlin.time.Duration? = null,
+        clock: DriverClock = RealDriverClock,
     ): QuicheDriver =
         QuicheDriver(
             api = api,
@@ -773,5 +819,6 @@ class ReactiveDriverTests {
             clientMode = false,
             isServer = isServer,
             keepAliveInterval = keepAliveInterval,
+            clock = clock,
         )
 }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -814,6 +814,28 @@ class ReactiveDriverTests {
             }
         }
 
+    // ---- Idle timeout ----
+
+    @Test
+    fun idleTimeout_quicheClose_transitionsDriverToClosedAndClosesCommands() =
+        runQuicTest {
+            // The terminal path the wall-clock integration test (QuicIdleTimeoutTestSuite) covers, made
+            // deterministic: quiche's idle timer fires, quiche idle-closes, and the driver must transition to
+            // Closed AND close its command channel (the coupled signal a parked read keys off to return End).
+            // No keepalive (so the fire is handed to quiche); closeOnTimeout makes that fire idle-close.
+            val api = StubQuicheApi()
+            api.connTimeout = 50.milliseconds
+            api.closeOnTimeout = true
+            val clock = ManualDriverClock()
+            val driver = createTestDriver(api, keepAliveInterval = null, clock = clock)
+            driver.start(this)
+            // Terminal fire: the driver closes and never re-arms, so synchronise on the Closed state, not a re-arm.
+            clock.fireExpectingNoRearm(50.milliseconds)
+            withTimeout(2.seconds) { driver.state.first { it is QuicConnectionState.Closed } }
+            assertTrue(driver.commands.isClosedForSend, "command channel must close coupled with the Closed state")
+            assertEquals(1, api.onTimeoutCount, "the idle timer fire should have been handed to quiche")
+        }
+
     // ---- Helpers ----
 
     private suspend fun sendOpenStream(driver: QuicheDriver): StreamSlot {

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -279,9 +279,19 @@ internal class StubQuicheApi : QuicheApi {
 
     override fun connIsTimedOut(conn: QuicheConn) = false
 
-    override fun connTimeout(conn: QuicheConn): Duration? = null
+    /** Controllable quiche timeout. Null (default) = "no quiche timer pending", so the keepalive deadline
+     *  is the only thing that can wake the driver loop — see the keepalive driver tests. */
+    @Volatile var connTimeout: Duration? = null
 
-    override fun connOnTimeout(conn: QuicheConn) {}
+    override fun connTimeout(conn: QuicheConn): Duration? = connTimeout
+
+    /** Counts timer fires the driver handed to quiche (i.e. NOT turned into a keepalive PING). */
+    var onTimeoutCount = 0
+        private set
+
+    override fun connOnTimeout(conn: QuicheConn) {
+        onTimeoutCount++
+    }
 
     /** Counts reactive-keepalive PINGs the driver scheduled, so tests can assert on them. */
     var ackElicitingCount = 0

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -289,8 +289,12 @@ internal class StubQuicheApi : QuicheApi {
     var onTimeoutCount = 0
         private set
 
+    /** When set, a handed-to-quiche timer fire idle-closes the connection (mirrors quiche's idle timeout). */
+    @Volatile var closeOnTimeout = false
+
     override fun connOnTimeout(conn: QuicheConn) {
         onTimeoutCount++
+        if (closeOnTimeout) closed = true
     }
 
     /** Counts reactive-keepalive PINGs the driver scheduled, so tests can assert on them. */

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/TestHelpers.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/TestHelpers.kt
@@ -30,17 +30,52 @@ import kotlin.time.Duration.Companion.seconds
 fun runQuicTest(
     timeout: Duration = 15.seconds,
     block: suspend CoroutineScope.() -> Unit,
-): TestResult =
-    // runTest's own budget must exceed the wall-clock [timeout] (plus margin for
+): TestResult {
+    // Scale the wall-clock deadline by [testTimeScale] so a loaded CI runner gets
+    // proportionally more time without weakening any assertion logic (see scaled).
+    val deadline = timeout.scaled
+    // runTest's own budget must exceed the wall-clock [deadline] (plus margin for
     // setup/teardown) or it, not our withTimeout, fires first with a less useful
     // message. Tests that legitimately need more than the 15s default (e.g. the
     // passive-migration test, which does connect + echo + a NAT rebind + a
-    // recovery round-trip) pass a larger [timeout].
-    runTest(timeout = timeout + 15.seconds) {
+    // recovery round-trip) pass a larger [timeout]. The +15s margin is itself
+    // scaled so teardown on a slow runner can't trip runTest before our backstop.
+    return runTest(timeout = deadline + 15.seconds.scaled) {
         withContext(Dispatchers.Default) {
-            withTimeout(timeout) { block() }
+            withTimeout(deadline) { block() }
         }
     }
+}
+
+/**
+ * Raw value of the `QUIC_TEST_TIME_SCALE` env var (or null if unset/unreadable on
+ * this target). Platform actual: `System.getenv` on JVM, `getenv` on K/N, `process.env`
+ * on Node; WasmJs has no env access and returns null.
+ */
+internal expect fun timeScaleEnv(): String?
+
+/**
+ * Multiplier applied to test **deadlines and backstops** — `runQuicTest`'s wall-clock
+ * cap, per-op `withTimeout` budgets, and idle-timeout values. It lets a loaded CI runner
+ * (set e.g. `QUIC_TEST_TIME_SCALE=3`) get proportionally more wall-clock without changing
+ * any test's *logic*.
+ *
+ * Always `>= 1.0` (clamped to `[1.0, 10.0]`): tests only ever get *more* time, never less,
+ * so up-scaling can never make an assertion vacuous or weaken a timing relationship — every
+ * duration in a suite grows by the same factor, so ratios (e.g. "keepalive PING interval well
+ * under the idle timeout", "idle fires before the read backstop") are preserved exactly. A
+ * malformed/garbage value falls back to 1.0; an absurdly large one is capped so a typo can't
+ * hang CI for hours.
+ */
+internal fun testTimeScale(): Double = timeScaleEnv()?.trim()?.toDoubleOrNull()?.coerceIn(1.0, 10.0) ?: 1.0
+
+/**
+ * Scale a deadline/backstop [Duration] by [testTimeScale]. Apply to `withTimeout` budgets,
+ * `runQuicTest` caps, and idle timeouts — anywhere a slower runner should simply be given more
+ * wall-clock. Because the factor is uniform and `>= 1.0`, applying it to *every* duration in a
+ * suite preserves the suite's timing relationships while granting absolute headroom on CI.
+ */
+internal val Duration.scaled: Duration get() = this * testTimeScale()
 
 /**
  * Reactive replacement for `delay(N)` followed by an assertion: yields the dispatcher

--- a/socket-quic/src/jsTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
+++ b/socket-quic/src/jsTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
@@ -3,3 +3,9 @@ package com.ditchoom.socket.quic
 internal actual fun isAppleKNative(): Boolean = false
 
 internal actual fun shouldSkipQuicHarnessOnSimulator(): Boolean = false
+
+internal actual fun timeScaleEnv(): String? {
+    // Node exposes env via process.env; guard for non-Node hosts where process is undefined.
+    val raw = js("(typeof process !== 'undefined' && process.env && process.env.QUIC_TEST_TIME_SCALE) || null")
+    return raw as String?
+}

--- a/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
+++ b/socket-quic/src/linuxTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
@@ -1,5 +1,12 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package com.ditchoom.socket.quic
+
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
 
 internal actual fun isAppleKNative(): Boolean = false
 
 internal actual fun shouldSkipQuicHarnessOnSimulator(): Boolean = false
+
+internal actual fun timeScaleEnv(): String? = getenv("QUIC_TEST_TIME_SCALE")?.toKString()

--- a/socket-quic/src/wasmJsTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
+++ b/socket-quic/src/wasmJsTest/kotlin/com/ditchoom/socket/quic/PlatformActuals.kt
@@ -3,3 +3,6 @@ package com.ditchoom.socket.quic
 internal actual fun isAppleKNative(): Boolean = false
 
 internal actual fun shouldSkipQuicHarnessOnSimulator(): Boolean = false
+
+// WasmJs runs only the gap tests (no real QUIC), so time scaling is moot — no env access.
+internal actual fun timeScaleEnv(): String? = null


### PR DESCRIPTION
## What & why

Hardens the timing-dependent QUIC test surface (the dominant residual flake class) in three tiers, plus a behaviour-neutral production seam. No release impact — test + neutral seam only.

### Tier 3 — `QUIC_TEST_TIME_SCALE` env multiplier
- `timeScaleEnv()` expect/actual per platform (`System.getenv` JVM, `getenv` K/N apple+linux, `process.env` JS, null WasmJs), `testTimeScale()` (clamped `[1.0, 10.0]`, garbage→1.0), and `Duration.scaled`.
- `runQuicTest`'s cap and the idle/impairment/concurrency suites scale **every** duration uniformly — a loaded CI runner (`QUIC_TEST_TIME_SCALE=3`) gets proportional headroom while ratios and assertion logic stay untouched. (Idle timeouts in the impair/soak options scale too, so the scaled cap can't exceed a fixed idle and close mid-transfer.)

### Tier 2 — keepalive PING:idle ratio fix
- Widened 4× → 6× (was two-sided: a scheduler-starved runner could delay the PING past the idle window → false idle-close).
- Mirrored into the Android parallel copy; fixed a latent server-read backstop that must outlast `KEEPALIVE_IDLE_WAIT`.

### Tier 1 — `DriverClock` seam (deterministic keepalive/idle)
- New `DriverClock` (`markNow` + `armTimeout`) with `RealDriverClock` reproducing the exact pre-seam behaviour (`TimeSource.Monotonic` + `onTimeout`). `QuicheDriver` takes `clock: DriverClock = RealDriverClock` — **every platform/production path is unchanged**.
- Test `ManualDriverClock` drives virtual time + a hand-fired timer. The keepalive `ReactiveDriverTests` go from a 50ms-interval + 3s backstop to **fully deterministic, ~2ms** (schedules-PING, hands-timer-to-quiche-when-sooner, disabled-never-PINGs, not-before-established).
- `advance()` is race-free: drain stale arm token → fire → await re-arm (the only signal the timer branch fully ran). Stress-proven by a 200-fire exact-cumulative-count test.

## Audit note
Production stream signals (`CONFLATED` `dataSignal`/`writableSignal`/`dgramSignal`) are the lost-wakeup-free edge-trigger pattern — audited as sound, no production change needed.

## Verification
- Compiles JVM / JS / K-Native; ktlint clean.
- Keepalive tests green **5× on JVM and linuxX64** (~1000 `advance()` calls/run).
- Idle integration green at scale 1 **and** scale 2 (env plumbing confirmed end-to-end).