### PR TITLE
feat(http3): WebTransport over HTTP/3 (RFC 9220 + RFC 9297 + draft-ietf-webtrans-http3)

### DIFF
--- a/socket-http3/HANDOFF.md
+++ b/socket-http3/HANDOFF.md
@@ -393,8 +393,54 @@ jsNode; the aioquic/lsqpack docker interop (64 evicting requests with a recurrin
 references (budget-bounded), and draining-duplicate. No known QPACK compression gaps remain.
 5. ✅ **maven-publish + Android/wasmJs/linuxArm64 — DONE.** Apple targets are config-only (declared under
    `if (isMacOS)`); verify on a macOS runner / CI. Optionally run Apple/Android *tests* in their CI workflows.
-6. **WebTransport** (Phase 2): RFC 9220 Extended CONNECT (gate on `peerSettings().enableConnectProtocol`)
-   + RFC 9297 HTTP Datagrams + Capsule, over the existing QUIC datagram + stream plumbing.
+6. ✅ **WebTransport — DONE** (Phases 0–4, branch `feat/webtransport-h3`; see below).
+
+## ✅ DONE — WebTransport over HTTP/3 (RFC 9220 + RFC 9297 + draft-ietf-webtrans-http3)
+
+Built as five phases on `feat/webtransport-h3`; all green **jvm + linuxX64** (185 linuxX64 / 183 jvm)
+and the pure codec/settings tests also green on **jsNode**. Hand-rolled (no buffer-codec/declarative),
+mirroring the rest of `:socket-http3`. Opt-in: pass `WebTransportOptions` to `withHttp3Connection` /
+`withHttp3Server`; datagrams additionally need `QuicOptions(datagrams = DatagramOptions())`.
+
+- **Phase 0 — SETTINGS + capability view.** `Http3SettingId.{H3_DATAGRAM=0x33, WEBTRANSPORT_MAX_SESSIONS,
+  ENABLE_WEBTRANSPORT}`; `Http3Settings.{h3DatagramEnabled, wtMaxSessions, webTransportSupported}`;
+  `webTransportSettings()` advertises Extended CONNECT + H3_DATAGRAM + (legacy) ENABLE_WEBTRANSPORT +
+  WEBTRANSPORT_MAX_SESSIONS on both control streams. `WebTransportSettingsTests` (pure).
+- **Phase 1 — Extended CONNECT session establishment (RFC 9220).** `Http3Connection.connectWebTransport`
+  (gates on `webTransportSupported`, opens a CONNECT bidi stream with `:protocol=webtransport`, reads the
+  2xx), server `onWebTransport` handler with `WebTransportServerExchange.accept()/reject(status)` (limit =
+  `maxSessions`, else 429/501/404). Session id = CONNECT stream id.
+- **Phase 2 — WebTransport streams (draft §4.1/§4.2).** `WebTransportSession.{openBidiStream, openUniStream,
+  incomingBidiStreams, incomingUniStreams}` → `WebTransportStream` / `WebTransportSendStream` /
+  `WebTransportReceiveStream`. Wire: uni stream type `0x54` + Session ID; bidi signal frame `0x41` + Session
+  ID; then raw bytes. Demux added to **both** routers — `Http3StreamReader.peekVarInt` (new, non-consuming)
+  lets the server distinguish a `0x41` WT bidi stream from a HEADERS request before frame parsing; the client
+  router now accepts peer-opened WT bidi/uni streams it previously discarded. Any bytes packed after the
+  header are copied out as the stream's first `read()`.
+- **Phase 3 — datagrams (draft §4.4, RFC 9297).** `WebTransportSession.{sendDatagram, datagrams}` over QUIC
+  DATAGRAM, framed as `Quarter Stream ID (= sessionId/4)` + payload. One receive pump per connection
+  (`WebTransportMux.startDatagramLoop`) demuxes to the owning session's bounded **DROP_OLDEST** channel
+  (unreliable semantics; frees dropped buffers). `sendDatagram` throws `WebTransportException` if QUIC
+  datagrams aren't enabled.
+- **Phase 4 — graceful close via the Capsule Protocol (draft §6, RFC 9297).** Capsules ride **inside HTTP/3
+  DATA frames** on the CONNECT stream (verified against RFC 9297 §3.1). `WebTransportSession.close(code,
+  reason)` sends a `WT_CLOSE_SESSION` (0x2843) capsule + FIN; the per-session capsule loop (`runCapsuleLoop`,
+  replacing the Phase-1 drain) reassembles DATA payloads, parses capsules, and surfaces the peer's code +
+  reason via `awaitClosed()` / `closeInfo`. `WT_DRAIN_SESSION` (0x78ae) + unknown capsules are skipped.
+
+**Shared engine: `WebTransportMux`** (one per connection, used verbatim by client + server) owns the session
+table, stream-open + demux, the datagram pump, and the capsule protocol — so the two roles share all WT logic.
+Sessions are tabled the instant their CONNECT stream id is known (client tables *before* reading the 2xx) so a
+peer that opens a WT stream/datagram immediately after the handshake never races registration.
+
+Tests: `WebTransportCapsuleTests` (capsule codec, pure), `WebTransportSettingsTests` (pure), and 10 in-process
+loopback E2E tests in `Http3LoopbackTestSuite` (establish/reject/no-support/two-sessions + bidi-echo + client
+uni + server uni + datagram round-trip + client-close-observed-by-server + server-close-observed-by-client),
+all jvm + linuxX64. The loopback `QuicOptions` now enable `DatagramOptions()`.
+
+*Not done (future):* sending `WT_DRAIN_SESSION` (we only receive/skip it); Apple `reset()` parity carries over
+from the existing follow-up (a WT stream `reset()` on Apple still degrades to `close()` — see the step-2 Apple
+note); third-party WT interop (no aioquic/lsqpack WT sidecar yet — the docker interop covers QPACK only).
 
 ## (historical) step 4b/5 plan — now DONE, see above
 

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
@@ -47,6 +47,22 @@ data class Http3Settings(
     val qpackBlockedStreams: Long get() = value(Http3SettingId.QPACK_BLOCKED_STREAMS) ?: 0L
     val maxFieldSectionSize: Long? get() = value(Http3SettingId.MAX_FIELD_SECTION_SIZE)
     val enableConnectProtocol: Boolean get() = value(Http3SettingId.ENABLE_CONNECT_PROTOCOL) == 1L
+
+    /** RFC 9297 — the peer enabled HTTP Datagrams (`H3_DATAGRAM = 1`). Required for WebTransport. */
+    val h3DatagramEnabled: Boolean get() = value(Http3SettingId.H3_DATAGRAM) == 1L
+
+    /**
+     * draft-ietf-webtrans-http3 — the number of concurrent WebTransport sessions the peer will
+     * accept (`WEBTRANSPORT_MAX_SESSIONS`); 0 / absent means it accepts none.
+     */
+    val wtMaxSessions: Long get() = value(Http3SettingId.WEBTRANSPORT_MAX_SESSIONS) ?: 0L
+
+    /**
+     * The peer can accept WebTransport sessions we initiate: it advertised Extended CONNECT
+     * (RFC 9220), HTTP Datagrams (RFC 9297), and a non-zero session limit. Gate
+     * `connectWebTransport` on this.
+     */
+    val webTransportSupported: Boolean get() = enableConnectProtocol && h3DatagramEnabled && wtMaxSessions > 0
 }
 
 /**
@@ -84,6 +100,10 @@ class Http3Connection private constructor(
     // ids 0..maxPushId; when -1 no MAX_PUSH_ID is sent and any PUSH_PROMISE / push stream is an
     // H3_ID_ERROR connection violation (RFC 9114 §7.2.5 / §4.6).
     private val maxPushId: Long,
+    // WebTransport participation (RFC 9220 + RFC 9297). Null disables it: no WT SETTINGS are
+    // advertised, so neither role establishes WebTransport sessions. Non-null advertises the WT
+    // SETTINGS at bootstrap; [WebTransportOptions.maxSessions] is the inbound accept limit.
+    private val webTransport: WebTransportOptions?,
 ) {
     private val peerSettingsDeferred = CompletableDeferred<Http3Settings>()
     private val _goAway = MutableStateFlow<Long?>(null)
@@ -98,6 +118,12 @@ class Http3Connection private constructor(
     private val pushEntries = mutableMapOf<Long, PushEntry>()
     private val pushChannel = Channel<Http3ServerPush>(Channel.UNLIMITED)
     private val controlStreamWriteMutex = Mutex()
+
+    // --- WebTransport (RFC 9220 + draft-ietf-webtrans-http3) ---
+    // The per-connection WebTransport engine: session table, stream/datagram demux, capsule protocol.
+    // Null when WebTransport was not enabled at bootstrap (no WT SETTINGS advertised).
+    private val webTransportMux: WebTransportMux? =
+        if (webTransport != null) WebTransportMux(scope, pool, options) else null
 
     // The live push-id limit (RFC 9114 §7.2.7). Starts at the advertised maxPushId and is re-issued
     // upward (never down) as pushes are observed, so the server keeps a rolling window of credit
@@ -209,6 +235,125 @@ class Http3Connection private constructor(
         return readResponse(stream)
     }
 
+    /**
+     * Open a WebTransport session (RFC 9220 Extended CONNECT) to [authority]/[path] over this HTTP/3
+     * connection, returning once the server's 2xx response confirms it. Multiple sessions may share
+     * the connection (each on its own CONNECT stream); the session id is the CONNECT stream id.
+     *
+     * Requires that this connection was bootstrapped with a [WebTransportOptions] (so we advertised
+     * Extended CONNECT + HTTP Datagrams) and that the peer advertised WebTransport support — this
+     * suspends on [peerSettings] to check [Http3Settings.webTransportSupported] first.
+     *
+     * @throws WebTransportException if WebTransport isn't enabled locally, the peer doesn't support
+     *   it, or the server rejects the CONNECT (any non-2xx status).
+     */
+    suspend fun connectWebTransport(
+        authority: String,
+        path: String,
+        headers: List<QpackHeaderField> = emptyList(),
+    ): WebTransportSession {
+        val mux =
+            webTransportMux ?: throw WebTransportException(
+                "WebTransport is not enabled on this connection — pass WebTransportOptions to withHttp3Connection()/bootstrap()",
+            )
+        if (!peerSettings().webTransportSupported) {
+            throw WebTransportException("the peer did not advertise WebTransport support (Extended CONNECT + H3_DATAGRAM + sessions)")
+        }
+        val stream = openExtendedConnectStream(WEBTRANSPORT_PROTOCOL, authority, path, headers)
+        // Table the session by its CONNECT stream id immediately, so a WebTransport stream/datagram the
+        // server sends the instant it accepts can't race ahead of registration. Abandoned if rejected.
+        val session = mux.preRegister(stream)
+        val reader = Http3StreamReader.create(stream, pool)
+        val status =
+            try {
+                readConnectStatus(stream, reader)
+            } catch (t: Throwable) {
+                reader.release()
+                mux.abandon(session)
+                resetStreamQuietly(stream, Http3ErrorCode.REQUEST_CANCELLED)
+                throw t
+            }
+        if (status !in 200..299) {
+            reader.release()
+            mux.abandon(session)
+            resetStreamQuietly(stream, Http3ErrorCode.REQUEST_CANCELLED)
+            throw WebTransportException("WebTransport CONNECT to $authority$path was rejected with status $status")
+        }
+        // Confirmed: hand the CONNECT-stream reader to the session's capsule loop.
+        mux.activate(session, reader)
+        return session
+    }
+
+    /** Open a client bidi stream and write an Extended CONNECT HEADERS frame (`:protocol` included). */
+    private suspend fun openExtendedConnectStream(
+        protocol: String,
+        authority: String,
+        path: String,
+        headers: List<QpackHeaderField>,
+    ): QuicByteStream {
+        val stream = scope.openStream()
+        // Extended CONNECT (RFC 9220 §4): :method=CONNECT, :protocol, plus :scheme/:authority/:path.
+        val fields =
+            buildList {
+                add(QpackHeaderField(":method", "CONNECT"))
+                add(QpackHeaderField(":protocol", protocol))
+                add(QpackHeaderField(":scheme", "https"))
+                add(QpackHeaderField(":authority", authority))
+                add(QpackHeaderField(":path", path))
+                addAll(headers)
+            }
+        writeHeadersFrame(stream, fields)
+        return stream
+    }
+
+    /** Read frames off the CONNECT [reader] until the response HEADERS, returning its :status. */
+    private suspend fun readConnectStatus(
+        stream: QuicByteStream,
+        reader: Http3StreamReader,
+    ): Int {
+        while (true) {
+            when (val frame = reader.nextFrame(options.readTimeout)) {
+                null ->
+                    throw Http3StreamException(
+                        "CONNECT stream ended before a response HEADERS frame",
+                        Http3ErrorCode.REQUEST_INCOMPLETE,
+                    )
+                is Http3Frame.Headers ->
+                    return parseStatus(decoder.decodeSection(frame.encodedFieldSection, stream.streamId.id, pool))
+                // Unknown/reserved frames are ignored (RFC 9114 §9); anything else before HEADERS is invalid.
+                is Http3Frame.Unknown -> {}
+                else ->
+                    throw Http3StreamException(
+                        "unexpected ${frame::class.simpleName} before the CONNECT response HEADERS",
+                        Http3ErrorCode.FRAME_UNEXPECTED,
+                    )
+            }
+        }
+    }
+
+    /** Encode [fields] as a HEADERS field section (dynamic encoder when available) and write the frame. */
+    private suspend fun writeHeadersFrame(
+        stream: QuicByteStream,
+        fields: List<QpackHeaderField>,
+    ) {
+        val activeEncoder = encoder
+        val sectionBuffer =
+            if (activeEncoder != null) {
+                activeEncoder.encodeSection(fields, stream.streamId.id, pool)
+            } else {
+                val sectionSize = (QpackFieldSectionCodec.wireSize(fields, EncodeContext.Empty) as WireSize.Exact).bytes
+                pool.allocate(sectionSize).also {
+                    QpackFieldSectionCodec.encode(it, fields, EncodeContext.Empty)
+                    it.resetForRead()
+                }
+            }
+        try {
+            writeFrame(stream, Http3Frame.Headers(sectionBuffer))
+        } finally {
+            sectionBuffer.freeIfNeeded()
+        }
+    }
+
     /** Open a client bidi stream and write the request HEADERS frame (pseudo-headers first). */
     private suspend fun openRequestStream(
         method: String,
@@ -226,25 +371,7 @@ class Http3Connection private constructor(
                 add(QpackHeaderField(":path", path))
                 addAll(headers)
             }
-        val activeEncoder = encoder
-        val sectionBuffer =
-            if (activeEncoder != null) {
-                // Dynamic QPACK: the encoder may emit inserts on the encoder stream and reference
-                // acknowledged dynamic entries; it returns the section payload as an owned buffer.
-                activeEncoder.encodeSection(fields, stream.streamId.id, pool)
-            } else {
-                // Static-only (no peer dynamic table, or SETTINGS not yet seen): the original path.
-                val sectionSize = (QpackFieldSectionCodec.wireSize(fields, EncodeContext.Empty) as WireSize.Exact).bytes
-                pool.allocate(sectionSize).also {
-                    QpackFieldSectionCodec.encode(it, fields, EncodeContext.Empty)
-                    it.resetForRead()
-                }
-            }
-        try {
-            writeFrame(stream, Http3Frame.Headers(sectionBuffer))
-        } finally {
-            sectionBuffer.freeIfNeeded()
-        }
+        writeHeadersFrame(stream, fields)
         return stream
     }
 
@@ -429,6 +556,8 @@ class Http3Connection private constructor(
         if (maxPushId >= 0) writeControlFrame(Http3Frame.MaxPushId(maxPushId))
         startRouter()
         startEncoderSetup()
+        // WebTransport datagram demux (RFC 9297): a no-op when QUIC datagrams aren't enabled.
+        webTransportMux?.startDatagramLoop()
     }
 
     /** Write a frame on the client control stream after its header (MAX_PUSH_ID / CANCEL_PUSH). */
@@ -462,13 +591,13 @@ class Http3Connection private constructor(
 
     /** Control stream: the type prefix `0x00` immediately followed by the SETTINGS frame. */
     private suspend fun writeControlStreamHeader() {
-        val settings =
-            Http3Frame.Settings(
-                listOf(
-                    Http3Setting(Http3SettingId.QPACK_MAX_TABLE_CAPACITY, QPACK_MAX_TABLE_CAPACITY),
-                    Http3Setting(Http3SettingId.QPACK_BLOCKED_STREAMS, QPACK_BLOCKED_STREAMS),
-                ),
+        val entries =
+            mutableListOf(
+                Http3Setting(Http3SettingId.QPACK_MAX_TABLE_CAPACITY, QPACK_MAX_TABLE_CAPACITY),
+                Http3Setting(Http3SettingId.QPACK_BLOCKED_STREAMS, QPACK_BLOCKED_STREAMS),
             )
+        webTransport?.let { entries += webTransportSettings(it) }
+        val settings = Http3Frame.Settings(entries)
         val frameSize = (Http3FrameCodec.wireSize(settings, EncodeContext.Empty) as WireSize.Exact).bytes
         val buffer = pool.allocate(VarIntCodec.encodedLength(Http3StreamType.CONTROL) + frameSize)
         try {
@@ -526,18 +655,25 @@ class Http3Connection private constructor(
      * connection scope — and the control handler resolves [peerSettings] on its own error path.
      */
     private suspend fun route(stream: QuicByteStream) {
-        if (!stream.streamId.isUnidirectional) {
-            // Peer-initiated bidirectional streams aren't used by this client; discard.
-            stream.close()
-            return
-        }
         // One processor, shared so bytes buffered while reading the type prefix carry into the
         // control/QPACK handler that continues on the same stream.
         val processor = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
-        // A push stream outlives this router call — its handler owns the processor + stream lifetime
-        // (the pushed response streams its body lazily), so the generic finally must not touch them.
+        // A push stream or an accepted WebTransport stream outlives this router call — the handler/mux
+        // owns the processor + stream lifetime, so the generic finally must not touch them.
         var handlerOwnsStream = false
         try {
+            if (!stream.streamId.isUnidirectional) {
+                // The only peer-initiated bidirectional stream this client expects is a WebTransport
+                // bidirectional stream (draft-ietf-webtrans-http3 §4.2); anything else is discarded.
+                val mux = webTransportMux
+                if (mux != null &&
+                    Http3StreamReader(stream, processor).peekVarInt(options.readTimeout) == WebTransportWire.WT_BIDI_STREAM_SIGNAL
+                ) {
+                    handlerOwnsStream = true
+                    mux.acceptIncomingBidi(stream, processor)
+                }
+                return
+            }
             when (Http3StreamReader(stream, processor).nextVarInt()) {
                 Http3StreamType.CONTROL -> handleControl(Http3StreamReader(stream, processor))
                 // The peer's QPACK encoder stream drives our decoder's dynamic table (RFC 9204 §4.3).
@@ -550,6 +686,13 @@ class Http3Connection private constructor(
                     handlerOwnsStream = true
                     handlePushStream(stream, processor)
                 }
+                // A peer-initiated unidirectional WebTransport stream (draft-ietf-webtrans-http3 §4.1):
+                // the mux reads the Session ID and routes it to the owning session.
+                WebTransportWire.WT_UNI_STREAM_TYPE ->
+                    webTransportMux?.let {
+                        handlerOwnsStream = true
+                        it.acceptIncomingUni(stream, processor)
+                    } ?: drain(stream)
                 // Reserved/GREASE streams carry data we ignore; drain to keep flow control flowing.
                 else -> drain(stream)
             }
@@ -893,13 +1036,15 @@ class Http3Connection private constructor(
             scope: QuicScope,
             options: ConnectionOptions = ConnectionOptions(),
             maxPushId: Long = -1,
+            webTransport: WebTransportOptions? = null,
         ): Http3Connection {
             // MultiThreaded: the router's per-stream coroutines allocate from this pool concurrently.
             val pool = BufferPool(threadingMode = ThreadingMode.MultiThreaded, factory = options.bufferFactory)
             val control = scope.openUniStream()
             val qpackEncoder = scope.openUniStream()
             val qpackDecoder = scope.openUniStream()
-            return Http3Connection(scope, options, pool, control, qpackEncoder, qpackDecoder, maxPushId).also { it.start() }
+            return Http3Connection(scope, options, pool, control, qpackEncoder, qpackDecoder, maxPushId, webTransport)
+                .also { it.start() }
         }
     }
 }

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Frame.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Frame.kt
@@ -122,6 +122,22 @@ object Http3SettingId {
 
     /** RFC 9220 — required by the Extended CONNECT used for WebTransport. */
     const val ENABLE_CONNECT_PROTOCOL: Long = 0x08
+
+    /** RFC 9297 — HTTP Datagrams. Value 1 enables them; required by WebTransport. */
+    const val H3_DATAGRAM: Long = 0x33
+
+    /**
+     * draft-ietf-webtrans-http3 — the maximum number of concurrent WebTransport sessions the
+     * endpoint is willing to accept. A non-zero value (together with [ENABLE_CONNECT_PROTOCOL]
+     * and [H3_DATAGRAM]) signals WebTransport support; 0 / absent means the peer accepts none.
+     */
+    const val WEBTRANSPORT_MAX_SESSIONS: Long = 0xc671706a
+
+    /**
+     * Legacy WebTransport toggle from draft-02 (`SETTINGS_ENABLE_WEBTRANSPORT`). Superseded by
+     * [WEBTRANSPORT_MAX_SESSIONS] but advertised alongside it for interop with older peers.
+     */
+    const val ENABLE_WEBTRANSPORT: Long = 0x2b603742
 }
 
 /**

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -43,9 +43,20 @@ class Http3ServerConnection internal constructor(
     private val options: ConnectionOptions,
     private val qpackCapacity: Long,
     private val onRequest: suspend Http3ServerExchange.() -> Unit,
+    // WebTransport participation (RFC 9220 + RFC 9297). Null disables it; non-null advertises the WT
+    // SETTINGS on the server control stream so clients see [Http3Settings.webTransportSupported].
+    private val webTransport: WebTransportOptions? = null,
+    // Handles incoming Extended CONNECT (`:protocol=webtransport`) requests when [webTransport] is
+    // enabled — accept() or reject() the session inside. Null ⇒ every WebTransport CONNECT is refused.
+    private val onWebTransport: (suspend WebTransportServerExchange.() -> Unit)? = null,
 ) {
     // MultiThreaded: per-stream handler coroutines allocate from this pool concurrently.
     private val pool = BufferPool(threadingMode = ThreadingMode.MultiThreaded, factory = options.bufferFactory)
+
+    // The per-connection WebTransport engine (session table, stream/datagram demux, capsule protocol).
+    // Null when WebTransport was not enabled for this server.
+    private val webTransportMux: WebTransportMux? =
+        if (webTransport != null) WebTransportMux(scope, pool, options) else null
 
     private val serverDecoder: QpackDecoder? =
         if (qpackCapacity > 0) QpackDecoder(qpackCapacity) { writeQpackDecoderInstruction(it) } else null
@@ -72,6 +83,8 @@ class Http3ServerConnection internal constructor(
             qpackEncoderStream = scope.openUniStream().also { writeStreamType(it, Http3StreamType.QPACK_ENCODER) }
             qpackDecoderStream = scope.openUniStream().also { writeStreamType(it, Http3StreamType.QPACK_DECODER) }
         }
+        // WebTransport datagram demux (RFC 9297): a no-op when QUIC datagrams aren't enabled.
+        webTransportMux?.startDatagramLoop()
         scope.streams().collect { stream ->
             scope.launch {
                 try {
@@ -88,6 +101,9 @@ class Http3ServerConnection internal constructor(
 
     private suspend fun handleUniStream(stream: QuicByteStream) {
         val processor = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        // A peer-initiated unidirectional WebTransport stream outlives this call — the mux owns the
+        // processor + stream lifetime, so the generic finally must not release the processor.
+        var muxOwnsStream = false
         try {
             when (Http3StreamReader(stream, processor).nextVarInt()) {
                 Http3StreamType.CONTROL -> handleControl(Http3StreamReader(stream, processor))
@@ -103,10 +119,16 @@ class Http3ServerConnection internal constructor(
                     } else {
                         drain(stream)
                     }
+                // A peer-initiated unidirectional WebTransport stream (draft-ietf-webtrans-http3 §4.1).
+                WebTransportWire.WT_UNI_STREAM_TYPE ->
+                    webTransportMux?.let {
+                        muxOwnsStream = true
+                        it.acceptIncomingUni(stream, processor)
+                    } ?: drain(stream)
                 else -> drain(stream)
             }
         } finally {
-            processor.release()
+            if (!muxOwnsStream) processor.release()
         }
     }
 
@@ -132,8 +154,24 @@ class Http3ServerConnection internal constructor(
 
     /** Read one request off a client bidi [stream], run [onRequest], then drain the body + FIN. */
     private suspend fun handleRequest(stream: QuicByteStream) {
-        val reader = Http3StreamReader.create(stream, pool)
+        // Explicit processor so a WebTransport bidirectional stream's buffered prefix can be handed to
+        // the mux (Http3StreamReader.create would hide the processor).
+        val processor = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        val reader = Http3StreamReader(stream, processor)
+        // An accepted WebTransport session (CONNECT stream) or a demultiplexed WebTransport bidirectional
+        // stream keeps the reader/processor alive past this call, so the generic finally must not release it.
+        var handlerOwnsReader = false
         try {
+            // A peer-initiated WebTransport bidirectional stream (draft-ietf-webtrans-http3 §4.2) starts
+            // with the 0x41 signal, not a HEADERS frame — demultiplex it before request parsing.
+            val mux = webTransportMux
+            if (mux != null &&
+                reader.peekVarInt(options.readTimeout) == WebTransportWire.WT_BIDI_STREAM_SIGNAL
+            ) {
+                handlerOwnsReader = true
+                mux.acceptIncomingBidi(stream, processor)
+                return
+            }
             val first =
                 reader.nextFrame(options.readTimeout)
                     ?: throw Http3StreamException("request stream ended before a HEADERS frame", Http3ErrorCode.REQUEST_INCOMPLETE)
@@ -145,6 +183,12 @@ class Http3ServerConnection internal constructor(
             }
             val streamId = stream.streamId.id
             val fields = decodeSection(first.encodedFieldSection, streamId)
+            // Extended CONNECT (RFC 9220): a CONNECT carrying `:protocol` is routed to WebTransport,
+            // not the normal request handler.
+            if (pseudoOrNull(fields, ":method") == "CONNECT" && pseudoOrNull(fields, ":protocol") != null) {
+                handlerOwnsReader = handleWebTransport(stream, reader, fields)
+                return
+            }
             val request =
                 Http3ServerRequest(
                     method = pseudo(fields, ":method"),
@@ -173,8 +217,84 @@ class Http3ServerConnection internal constructor(
             reactToRequestError(stream, e)
             throw e
         } finally {
-            reader.release()
+            if (!handlerOwnsReader) reader.release()
         }
+    }
+
+    /**
+     * Handle an Extended CONNECT for WebTransport (RFC 9220): refuse unless WebTransport is enabled,
+     * the registered [onWebTransport] handler accepts it, and the session limit isn't exceeded.
+     * Returns true if a session was accepted (the caller must keep the stream reader alive); false
+     * if the CONNECT was rejected (a response was sent and the reader can be released).
+     */
+    private suspend fun handleWebTransport(
+        stream: QuicByteStream,
+        reader: Http3StreamReader,
+        fields: List<QpackHeaderField>,
+    ): Boolean {
+        val handler = onWebTransport
+        val limit = webTransport?.maxSessions ?: 0L
+        if (handler == null || limit <= 0 || pseudoOrNull(fields, ":protocol") != WEBTRANSPORT_PROTOCOL) {
+            sendWebTransportResponse(stream, 501, fin = true)
+            return false
+        }
+        if ((webTransportMux?.activeCount()?.toLong() ?: 0L) >= limit) {
+            // RFC 9220: refuse beyond the advertised WEBTRANSPORT_MAX_SESSIONS.
+            sendWebTransportResponse(stream, 429, fin = true)
+            return false
+        }
+        var acceptedSession: WebTransportSession? = null
+        var decided = false
+        val exchange =
+            WebTransportServerExchange(
+                authority = pseudoOrNull(fields, ":authority") ?: "",
+                path = pseudoOrNull(fields, ":path") ?: "",
+                headers = fields.filterNot { it.name.startsWith(":") },
+                doAccept = {
+                    decided = true
+                    acceptWebTransport(stream, reader).also { acceptedSession = it }
+                },
+                doReject = { status ->
+                    decided = true
+                    sendWebTransportResponse(stream, status, fin = true)
+                },
+            )
+        try {
+            handler.invoke(exchange)
+        } finally {
+            // A handler that returns without deciding implicitly rejects.
+            if (!decided) runCatching { sendWebTransportResponse(stream, 404, fin = true) }
+        }
+        return acceptedSession != null
+    }
+
+    /** Accept a WebTransport session: send 200 (no FIN — the CONNECT stream stays open), register it. */
+    private suspend fun acceptWebTransport(
+        stream: QuicByteStream,
+        reader: Http3StreamReader,
+    ): WebTransportSession {
+        sendWebTransportResponse(stream, 200, fin = false)
+        val mux = webTransportMux ?: error("WebTransport accepted without an enabled mux")
+        val session = mux.preRegister(stream)
+        // The CONNECT stream stays open; its capsule loop owns the reader and ends the session on FIN
+        // or a WT_CLOSE_SESSION capsule.
+        mux.activate(session, reader)
+        return session
+    }
+
+    /** Send a CONNECT response carrying just `:status`; [fin] half-closes the send side (reject path). */
+    private suspend fun sendWebTransportResponse(
+        stream: QuicByteStream,
+        status: Int,
+        fin: Boolean,
+    ) {
+        val section = encodeSection(listOf(QpackHeaderField(":status", status.toString())), stream.streamId.id)
+        try {
+            writeFrame(stream, Http3Frame.Headers(section))
+        } finally {
+            section.freeIfNeeded()
+        }
+        if (fin) stream.shutdownSend()
     }
 
     /**
@@ -326,13 +446,13 @@ class Http3ServerConnection internal constructor(
 
     /** Control stream: the type prefix `0x00` immediately followed by the SETTINGS frame. */
     private suspend fun writeControlStreamHeader(control: QuicByteStream) {
-        val settings =
-            Http3Frame.Settings(
-                listOf(
-                    Http3Setting(Http3SettingId.QPACK_MAX_TABLE_CAPACITY, qpackCapacity),
-                    Http3Setting(Http3SettingId.QPACK_BLOCKED_STREAMS, if (qpackCapacity > 0) BLOCKED_STREAMS else 0L),
-                ),
+        val entries =
+            mutableListOf(
+                Http3Setting(Http3SettingId.QPACK_MAX_TABLE_CAPACITY, qpackCapacity),
+                Http3Setting(Http3SettingId.QPACK_BLOCKED_STREAMS, if (qpackCapacity > 0) BLOCKED_STREAMS else 0L),
             )
+        webTransport?.let { entries += webTransportSettings(it) }
+        val settings = Http3Frame.Settings(entries)
         val frameSize = (Http3FrameCodec.wireSize(settings, EncodeContext.Empty) as WireSize.Exact).bytes
         val buffer = pool.allocate(VarIntCodec.encodedLength(Http3StreamType.CONTROL) + frameSize)
         try {
@@ -405,6 +525,12 @@ class Http3ServerConnection internal constructor(
     ): String =
         fields.firstOrNull { it.name == name }?.value
             ?: throw Http3StreamException("request HEADERS missing the $name pseudo-header", Http3ErrorCode.MESSAGE_ERROR)
+
+    /** Like [pseudo] but returns null instead of throwing when the pseudo-header is absent. */
+    private fun pseudoOrNull(
+        fields: List<QpackHeaderField>,
+        name: String,
+    ): String? = fields.firstOrNull { it.name == name }?.value
 
     companion object {
         /** Blocked-streams we permit the client's encoder to create when dynamic QPACK is on. */

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3StreamReader.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3StreamReader.kt
@@ -99,6 +99,42 @@ class Http3StreamReader(
         }
     }
 
+    /**
+     * Peek the value of the next QUIC varint **without consuming it**, reading from the stream until a
+     * full varint is buffered. Returns null at a clean end-of-stream with no buffered bytes (lets a
+     * caller distinguish an empty stream from one carrying data). Throws [Http3StreamException] if the
+     * stream ends mid-varint or is reset.
+     *
+     * Used to demultiplex a stream's leading varint (e.g. a WebTransport bidirectional-stream signal,
+     * draft-ietf-webtrans-http3 §4.2) before deciding whether to keep reading it as HTTP/3 frames.
+     */
+    suspend fun peekVarInt(timeout: Duration = Duration.INFINITE): Long? {
+        while (true) {
+            val peek = VarIntCodec.peekFrameSize(processor, 0)
+            if (peek is PeekResult.Complete && processor.available() >= peek.bytes) {
+                val first = processor.peekByte(0).toInt() and 0xFF
+                val length = VarIntCodec.lengthFromPrefix(first)
+                var value = (first and 0x3F).toLong()
+                for (i in 1 until length) {
+                    value = (value shl 8) or (processor.peekByte(i).toLong() and 0xFF)
+                }
+                return value
+            }
+            if (ended) {
+                if (processor.available() == 0) return null
+                throw Http3StreamException("stream ended before a complete varint", Http3ErrorCode.FRAME_ERROR)
+            }
+            when (val result = stream.read(timeout)) {
+                is ReadResult.Data -> processor.append(result.buffer)
+                ReadResult.End -> ended = true
+                ReadResult.Reset -> {
+                    ended = true
+                    throw Http3StreamException("stream was reset by the peer")
+                }
+            }
+        }
+    }
+
     /** Return the processor's buffers to the pool. Call once the stream is fully consumed. */
     fun release() = processor.release()
 

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportMux.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportMux.kt
@@ -1,0 +1,384 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.codec.EncodeContext
+import com.ditchoom.buffer.codec.WireSize
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.buffer.stream.StreamProcessor
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.QuicByteStream
+import com.ditchoom.socket.quic.QuicScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.Duration
+
+/**
+ * The per-connection WebTransport engine (draft-ietf-webtrans-http3), shared verbatim by the client
+ * ([Http3Connection]) and server ([Http3ServerConnection]) roles. Owns the session table and the
+ * WebTransport-specific framings that sit on top of the HTTP/3 QUIC connection:
+ *
+ *  - **opening** WebTransport streams ([openBidi]/[openUni]) — a fresh QUIC stream prefixed with the
+ *    WebTransport signal/type + Session ID,
+ *  - **demultiplexing** peer-opened WebTransport streams ([acceptIncomingBidi]/[acceptIncomingUni])
+ *    onto the owning session's incoming-stream flows,
+ *  - **datagrams** ([sendDatagram] + the [startDatagramLoop] receive pump) using the RFC 9297 Quarter
+ *    Stream ID framing, and
+ *  - the **Capsule Protocol** on each session's CONNECT stream ([runCapsuleLoop]) — reading
+ *    DATA-framed capsules to surface a peer's graceful close, and [sendCloseCapsule] to send our own.
+ *
+ * Stream/datagram demux looks a session up by id; an unknown or already-closed session means the frame
+ * is dropped (the stream reset). Sessions are registered the moment their CONNECT stream id is known
+ * (before the 2xx is even read on the client), so a peer that opens a WebTransport stream immediately
+ * after the handshake never races ahead of registration.
+ */
+internal class WebTransportMux(
+    private val scope: QuicScope,
+    private val pool: BufferPool,
+    private val options: ConnectionOptions,
+) {
+    private val sessions = mutableMapOf<Long, WebTransportSession>()
+    private val mutex = Mutex()
+
+    /**
+     * Create a session for a CONNECT stream and table it immediately by id, before the handshake
+     * completes. [abandon] removes it if the CONNECT is rejected; [activate] starts its capsule loop
+     * once it is confirmed.
+     */
+    suspend fun preRegister(connectStream: QuicByteStream): WebTransportSession {
+        val session = WebTransportSession(connectStream.streamId.id, connectStream, this)
+        mutex.withLock { sessions[session.sessionId] = session }
+        return session
+    }
+
+    /** Start [session]'s CONNECT-stream capsule loop (call once the session is confirmed established). */
+    fun activate(
+        session: WebTransportSession,
+        reader: Http3StreamReader,
+    ) {
+        scope.launch { runCapsuleLoop(session, reader) }
+    }
+
+    /** Drop a session whose CONNECT was rejected/aborted before it was activated. */
+    suspend fun abandon(session: WebTransportSession) {
+        mutex.withLock { sessions.remove(session.sessionId) }
+    }
+
+    /** Connection-level deregistration, called from [WebTransportSession.close]/peer-close. */
+    suspend fun deregister(sessionId: Long) {
+        mutex.withLock { sessions.remove(sessionId) }
+    }
+
+    private suspend fun session(sessionId: Long): WebTransportSession? = mutex.withLock { sessions[sessionId] }
+
+    /** Number of sessions currently in the table — the server gates inbound accepts on this. */
+    suspend fun activeCount(): Int = mutex.withLock { sessions.size }
+
+    // --- Opening WebTransport streams (draft-ietf-webtrans-http3 §4.1 / §4.2) ---
+
+    /** Open a bidirectional WebTransport stream: a QUIC bidi stream prefixed with `0x41` + Session ID. */
+    suspend fun openBidi(sessionId: Long): WebTransportStream {
+        val stream = scope.openStream()
+        writeStreamHeader(stream, WebTransportWire.WT_BIDI_STREAM_SIGNAL, sessionId)
+        return WebTransportStream(sessionId, stream, pending = null, Duration.INFINITE, options.writeTimeout)
+    }
+
+    /** Open a unidirectional WebTransport stream: a QUIC uni stream prefixed with `0x54` + Session ID. */
+    suspend fun openUni(sessionId: Long): WebTransportSendStream {
+        val stream = scope.openUniStream()
+        writeStreamHeader(stream, WebTransportWire.WT_UNI_STREAM_TYPE, sessionId)
+        return WebTransportSendStream(sessionId, stream, options.writeTimeout)
+    }
+
+    private suspend fun writeStreamHeader(
+        stream: QuicByteStream,
+        prefix: Long,
+        sessionId: Long,
+    ) {
+        val buffer = pool.allocate(VarIntCodec.encodedLength(prefix) + VarIntCodec.encodedLength(sessionId))
+        try {
+            VarIntCodec.encode(buffer, prefix, EncodeContext.Empty)
+            VarIntCodec.encode(buffer, sessionId, EncodeContext.Empty)
+            buffer.resetForRead()
+            stream.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    // --- Demultiplexing peer-opened WebTransport streams ---
+
+    /**
+     * Take ownership of a peer-opened **bidirectional** stream whose leading `0x41` signal was just
+     * observed: read the Session ID, hand the stream (with any bytes already buffered after the header)
+     * to the owning session's [WebTransportSession.incomingBidiStreams], or reset it if no live session
+     * owns it. Always consumes [processor]; the caller must not touch [stream]/[processor] afterward.
+     */
+    suspend fun acceptIncomingBidi(
+        stream: QuicByteStream,
+        processor: StreamProcessor,
+    ) {
+        val reader = Http3StreamReader(stream, processor)
+        reader.nextVarInt(options.readTimeout) // the 0x41 signal (already peeked by the router)
+        val sessionId = reader.nextVarInt(options.readTimeout)
+        val session = session(sessionId)
+        if (session == null || session.isClosed) {
+            processor.release()
+            resetQuietly(stream)
+            return
+        }
+        val pending = drainBuffered(processor)
+        processor.release()
+        val wt = WebTransportStream(sessionId, stream, pending, Duration.INFINITE, options.writeTimeout)
+        session.deliverIncomingBidi(wt)
+    }
+
+    /**
+     * Take ownership of a peer-opened **unidirectional** stream whose `0x54` type prefix was just
+     * consumed: read the Session ID, hand the receive stream to the owning session's
+     * [WebTransportSession.incomingUniStreams], or reset it if no live session owns it. Always consumes
+     * [processor].
+     */
+    suspend fun acceptIncomingUni(
+        stream: QuicByteStream,
+        processor: StreamProcessor,
+    ) {
+        val reader = Http3StreamReader(stream, processor)
+        val sessionId = reader.nextVarInt(options.readTimeout)
+        val session = session(sessionId)
+        if (session == null || session.isClosed) {
+            processor.release()
+            resetQuietly(stream)
+            return
+        }
+        val pending = drainBuffered(processor)
+        processor.release()
+        val wt = WebTransportReceiveStream(sessionId, stream, pending, Duration.INFINITE)
+        session.deliverIncomingUni(wt)
+    }
+
+    /** Copy whatever bytes the [processor] still holds into an owned buffer (or null when empty). */
+    private fun drainBuffered(processor: StreamProcessor): ReadBuffer? {
+        val n = processor.available()
+        if (n == 0) return null
+        val copy = pool.allocate(n)
+        copy.write(processor.readBuffer(n))
+        copy.resetForRead()
+        return copy
+    }
+
+    // --- Datagrams (RFC 9297 §2.1 Quarter Stream ID framing) ---
+
+    /**
+     * Send a WebTransport datagram for [sessionId]: a QUIC DATAGRAM of `Quarter Stream ID` followed by
+     * [payload]'s bytes (draft-ietf-webtrans-http3 §4.4). Throws [WebTransportException] if the
+     * underlying QUIC connection has no datagram support enabled.
+     */
+    suspend fun sendDatagram(
+        sessionId: Long,
+        payload: ReadBuffer,
+    ) {
+        val quarter = WebTransportWire.quarterStreamId(sessionId)
+        val out = pool.allocate(VarIntCodec.encodedLength(quarter) + payload.remaining())
+        try {
+            VarIntCodec.encode(out, quarter, EncodeContext.Empty)
+            if (payload.remaining() > 0) out.write(payload)
+            out.resetForRead()
+            try {
+                scope.sendDatagram(out)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                throw WebTransportException("QUIC datagrams are not enabled on this connection: ${e.message}")
+            }
+        } finally {
+            out.freeIfNeeded()
+        }
+    }
+
+    /**
+     * Pump inbound QUIC datagrams to their session's [WebTransportSession.datagrams] flow, keyed by the
+     * Quarter Stream ID. A datagram for an unknown/closed session is dropped. Collecting
+     * [QuicScope.datagrams] completes immediately (does nothing) when datagrams are not enabled, so this
+     * is safe to launch unconditionally for a WebTransport-enabled connection.
+     */
+    fun startDatagramLoop() {
+        scope.launch {
+            try {
+                scope.datagrams().collect { buffer ->
+                    val sessionId =
+                        try {
+                            VarIntCodec.decode(buffer, DecodeContext.Empty) * 4
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Throwable) {
+                            buffer.freeIfNeeded() // malformed Quarter Stream ID
+                            return@collect
+                        }
+                    val session = session(sessionId)
+                    if (session != null && !session.isClosed) {
+                        session.deliverDatagram(buffer) // takes ownership (frees on overflow)
+                    } else {
+                        buffer.freeIfNeeded()
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                // Connection closed / datagram source ended — nothing more to demux.
+            }
+        }
+    }
+
+    // --- Capsule Protocol on the CONNECT stream (RFC 9297, carried in HTTP/3 DATA frames) ---
+
+    /**
+     * Read the session's CONNECT stream as a Capsule Protocol byte-stream (the concatenation of its
+     * DATA-frame payloads, RFC 9297 §3.1) until the stream ends or a WT_CLOSE_SESSION capsule arrives,
+     * then end the session. A WT_CLOSE_SESSION carries the peer's application close code + reason; a
+     * bare FIN (or any error) ends the session with the default close info. Owns [reader]'s release.
+     */
+    private suspend fun runCapsuleLoop(
+        session: WebTransportSession,
+        reader: Http3StreamReader,
+    ) {
+        val capsules = StreamProcessor.create(pool, ByteOrder.BIG_ENDIAN)
+        try {
+            loop@ while (true) {
+                val frame = reader.nextFrame(Duration.INFINITE) ?: break
+                if (frame is Http3Frame.Data) {
+                    appendCopy(capsules, frame.payload)
+                    if (parseCapsules(capsules, session)) break@loop // a close capsule was seen
+                }
+                // Non-DATA frames on a CONNECT/Capsule stream are ignored (RFC 9297 treats the content as
+                // the capsule byte-stream; HTTP/3 reserved frames are skipped per RFC 9114 §9).
+            }
+        } catch (_: Throwable) {
+            // Stream error / reset / connection close — the session is gone.
+        } finally {
+            capsules.release()
+            reader.release()
+            session.onPeerClosed(session.closeInfo ?: WebTransportCloseInfo())
+            deregister(session.sessionId)
+        }
+    }
+
+    /** Append a copy of [payload]'s remaining bytes to [capsules] (the borrowed frame buffer is transient). */
+    private fun appendCopy(
+        capsules: StreamProcessor,
+        payload: ReadBuffer,
+    ) {
+        val n = payload.remaining()
+        if (n == 0) return
+        val copy = pool.allocate(n)
+        copy.write(payload)
+        copy.resetForRead()
+        capsules.append(copy)
+    }
+
+    /**
+     * Parse and act on every whole capsule currently buffered in [capsules]. Returns true if a
+     * WT_CLOSE_SESSION capsule was processed (the caller should stop reading). Unknown capsule types
+     * are skipped (their length is honoured so parsing stays aligned).
+     */
+    private suspend fun parseCapsules(
+        capsules: StreamProcessor,
+        session: WebTransportSession,
+    ): Boolean {
+        while (true) {
+            if (capsules.available() < 1) return false
+            val typeFirst = capsules.peekByte(0).toInt() and 0xFF
+            val typeLen = VarIntCodec.lengthFromPrefix(typeFirst)
+            if (capsules.available() < typeLen + 1) return false
+            val lenFirst = capsules.peekByte(typeLen).toInt() and 0xFF
+            val lenLen = VarIntCodec.lengthFromPrefix(lenFirst)
+            if (capsules.available() < typeLen + lenLen) return false
+            val length = peekVarIntAt(capsules, typeLen).toInt()
+            val total = typeLen + lenLen + length
+            if (capsules.available() < total) return false
+
+            val capsule = capsules.readBuffer(total)
+            val type = VarIntCodec.decode(capsule, DecodeContext.Empty)
+            VarIntCodec.decode(capsule, DecodeContext.Empty) // length (already known)
+            when (type) {
+                WebTransportWire.WT_CLOSE_SESSION -> {
+                    val info = WebTransportWire.readCloseSessionValue(capsule, length)
+                    session.onPeerClosed(info)
+                    return true
+                }
+                // WT_DRAIN_SESSION and unknown capsule types: skip the value and continue.
+                else -> {}
+            }
+        }
+    }
+
+    /** Decode the varint at byte [offset] in [processor] (assumes a full varint is buffered there). */
+    private fun peekVarIntAt(
+        processor: StreamProcessor,
+        offset: Int,
+    ): Long {
+        val first = processor.peekByte(offset).toInt() and 0xFF
+        val length = VarIntCodec.lengthFromPrefix(first)
+        var value = (first and 0x3F).toLong()
+        for (i in 1 until length) {
+            value = (value shl 8) or (processor.peekByte(offset + i).toLong() and 0xFF)
+        }
+        return value
+    }
+
+    /**
+     * Send a WT_CLOSE_SESSION capsule (draft-ietf-webtrans-http3 §6) inside a DATA frame on [connectStream]
+     * then FIN it — the graceful WebTransport close. The reason is truncated to 1024 UTF-8 bytes.
+     */
+    suspend fun sendCloseCapsule(
+        connectStream: QuicByteStream,
+        code: Int,
+        reason: String,
+    ) {
+        val reasonBytes = qpackUtf8ByteLength(reason).coerceAtMost(WebTransportWire.MAX_CLOSE_REASON_BYTES)
+        // If truncation would split a multi-byte character, fall back to no reason (the code still carries).
+        val safeReason = if (reasonBytes == qpackUtf8ByteLength(reason)) reason else ""
+        val safeReasonBytes = if (safeReason.isEmpty()) 0 else reasonBytes
+        val capsuleSize = WebTransportWire.closeSessionCapsuleSize(safeReasonBytes)
+        val capsule = pool.allocate(capsuleSize)
+        try {
+            WebTransportWire.writeCloseSessionCapsule(capsule, code, safeReason, safeReasonBytes)
+            capsule.resetForRead()
+            writeDataFrame(connectStream, capsule)
+        } finally {
+            capsule.freeIfNeeded()
+        }
+        connectStream.shutdownSend()
+    }
+
+    /** Wrap [payload] in an HTTP/3 DATA frame and write it whole to [stream]. */
+    private suspend fun writeDataFrame(
+        stream: QuicByteStream,
+        payload: ReadBuffer,
+    ) {
+        val frame = Http3Frame.Data(payload)
+        val size = (Http3FrameCodec.wireSize(frame, EncodeContext.Empty) as WireSize.Exact).bytes
+        val buffer = pool.allocate(size)
+        try {
+            Http3FrameCodec.encode(buffer, frame, EncodeContext.Empty)
+            buffer.resetForRead()
+            stream.write(buffer, options.writeTimeout)
+        } finally {
+            buffer.freeIfNeeded()
+        }
+    }
+
+    private suspend fun resetQuietly(stream: QuicByteStream) {
+        try {
+            stream.reset(0)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // Already gone.
+        }
+    }
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportOptions.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportOptions.kt
@@ -1,0 +1,45 @@
+package com.ditchoom.socket.http3
+
+/** The `:protocol` pseudo-header value identifying a WebTransport Extended CONNECT (RFC 9220). */
+internal const val WEBTRANSPORT_PROTOCOL: String = "webtransport"
+
+/**
+ * WebTransport-over-HTTP/3 participation (RFC 9220 Extended CONNECT + RFC 9297 HTTP Datagrams +
+ * draft-ietf-webtrans-http3).
+ *
+ * Passing a non-null instance to [withHttp3Connection] / [withHttp3Server] makes the endpoint
+ * advertise the WebTransport SETTINGS on its control stream — `ENABLE_CONNECT_PROTOCOL`,
+ * `H3_DATAGRAM`, `WEBTRANSPORT_MAX_SESSIONS` (and the legacy `ENABLE_WEBTRANSPORT` for interop) —
+ * so the peer's [Http3Settings.webTransportSupported] resolves true.
+ *
+ * [maxSessions] is the number of concurrent **peer-initiated** sessions this endpoint accepts and
+ * is the value put on `WEBTRANSPORT_MAX_SESSIONS`. 0 means *initiate-only*: the endpoint still
+ * advertises Extended CONNECT + datagrams so it can open sessions outbound, but accepts none
+ * inbound.
+ *
+ * WebTransport datagrams ride QUIC DATAGRAM frames (RFC 9221/9297), so the underlying
+ * [com.ditchoom.socket.quic.QuicOptions] MUST enable
+ * [com.ditchoom.socket.quic.DatagramOptions] (`datagrams = DatagramOptions()`) — otherwise
+ * sessions still establish but datagrams are unavailable.
+ */
+data class WebTransportOptions(
+    val maxSessions: Long = 1,
+) {
+    init {
+        require(maxSessions >= 0) { "maxSessions must be non-negative" }
+    }
+}
+
+/**
+ * The SETTINGS entries an endpoint advertises to participate in WebTransport (RFC 9220 + RFC 9297 +
+ * draft-ietf-webtrans-http3). Appended to the control-stream SETTINGS by both the client
+ * ([Http3Connection]) and server ([Http3ServerConnection]) roles. [WebTransportOptions.maxSessions]
+ * becomes `WEBTRANSPORT_MAX_SESSIONS`; the legacy `ENABLE_WEBTRANSPORT` is always 1 when enabled.
+ */
+internal fun webTransportSettings(options: WebTransportOptions): List<Http3Setting> =
+    listOf(
+        Http3Setting(Http3SettingId.ENABLE_CONNECT_PROTOCOL, 1L),
+        Http3Setting(Http3SettingId.H3_DATAGRAM, 1L),
+        Http3Setting(Http3SettingId.ENABLE_WEBTRANSPORT, 1L),
+        Http3Setting(Http3SettingId.WEBTRANSPORT_MAX_SESSIONS, options.maxSessions),
+    )

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportServerExchange.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportServerExchange.kt
@@ -1,0 +1,21 @@
+package com.ditchoom.socket.http3
+
+/**
+ * A pending server-side WebTransport session request (an Extended CONNECT, RFC 9220), handed to the
+ * `onWebTransport` handler. Inspect [authority]/[path]/[headers], then either [accept] the session
+ * (returning the live [WebTransportSession]) or [reject] it with an HTTP status. A handler that
+ * returns without deciding implicitly rejects with 404.
+ */
+class WebTransportServerExchange internal constructor(
+    val authority: String,
+    val path: String,
+    val headers: List<QpackHeaderField>,
+    private val doAccept: suspend () -> WebTransportSession,
+    private val doReject: suspend (Int) -> Unit,
+) {
+    /** Accept the session: sends a 200 response and keeps the CONNECT stream open. Call at most once. */
+    suspend fun accept(): WebTransportSession = doAccept()
+
+    /** Reject the session with [status] (default 404), FINishing the CONNECT stream. Call at most once. */
+    suspend fun reject(status: Int = 404): Unit = doReject(status)
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportSession.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportSession.kt
@@ -1,0 +1,155 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.socket.quic.QuicByteStream
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlin.concurrent.Volatile
+
+/** Why a WebTransport session ended: the application error [code] and human-readable [reason]. */
+data class WebTransportCloseInfo(
+    val code: Int = 0,
+    val reason: String = "",
+)
+
+/** A WebTransport-over-HTTP/3 failure (RFC 9220 + draft-ietf-webtrans-http3) that isn't a plain H3 error. */
+class WebTransportException internal constructor(
+    message: String,
+) : Exception(message)
+
+/**
+ * An established WebTransport session (RFC 9220 + draft-ietf-webtrans-http3), shared by the client
+ * ([Http3Connection.connectWebTransport]) and server ([WebTransportServerExchange.accept]) roles.
+ *
+ * A session rides one HTTP/3 Extended CONNECT bidirectional stream — the **CONNECT stream**, whose
+ * id is the [sessionId]. That stream stays open for the session's lifetime; its body carries the
+ * RFC 9297 Capsule Protocol (graceful close, [close]/[awaitClosed]). WebTransport streams and
+ * datagrams are associated with the session by this id.
+ *
+ * Once established a session multiplexes:
+ *  - **streams** — [openBidiStream] / [openUniStream] to initiate, and
+ *    [incomingBidiStreams] / [incomingUniStreams] for peer-initiated ones; and
+ *  - **datagrams** — [sendDatagram] / [datagrams] (require the underlying QUIC connection to have
+ *    datagrams enabled).
+ *
+ * Lifecycle: the session is open until [close]d locally or the peer ends the CONNECT stream;
+ * [awaitClosed] suspends until then and [closeInfo] reports why.
+ */
+class WebTransportSession internal constructor(
+    val sessionId: Long,
+    internal val connectStream: QuicByteStream,
+    private val mux: WebTransportMux,
+) {
+    @Volatile
+    private var _closeInfo: WebTransportCloseInfo? = null
+
+    /** Non-null once the session has ended (locally or by the peer); null while open. */
+    val closeInfo: WebTransportCloseInfo? get() = _closeInfo
+    val isClosed: Boolean get() = _closeInfo != null
+
+    private val closedSignal = CompletableDeferred<WebTransportCloseInfo>()
+
+    // Peer-initiated streams, fed by the connection's router via the mux. UNLIMITED: a burst of
+    // incoming streams must never block the router thread.
+    private val incomingBidi = Channel<WebTransportStream>(Channel.UNLIMITED)
+    private val incomingUni = Channel<WebTransportReceiveStream>(Channel.UNLIMITED)
+
+    // Inbound datagrams are unreliable: a bounded queue that drops the oldest on overflow (and frees the
+    // dropped/undelivered buffer), matching QUIC datagram semantics.
+    private val incomingDatagrams =
+        Channel<ReadBuffer>(
+            capacity = DATAGRAM_QUEUE,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            onUndeliveredElement = { it.freeIfNeeded() },
+        )
+
+    /** Peer-initiated bidirectional WebTransport streams (draft-ietf-webtrans-http3 §4.2). */
+    val incomingBidiStreams: Flow<WebTransportStream> get() = incomingBidi.receiveAsFlow()
+
+    /** Peer-initiated unidirectional WebTransport streams (draft-ietf-webtrans-http3 §4.1). */
+    val incomingUniStreams: Flow<WebTransportReceiveStream> get() = incomingUni.receiveAsFlow()
+
+    /**
+     * Inbound WebTransport datagrams (draft-ietf-webtrans-http3 §4.4). Each emitted buffer is owned by
+     * the collector (release via `freeIfNeeded()`). Empty unless QUIC datagrams are enabled on the
+     * connection; unreliable — the oldest queued datagram is dropped under pressure.
+     */
+    val datagrams: Flow<ReadBuffer> get() = incomingDatagrams.receiveAsFlow()
+
+    /** Suspends until the session ends, returning why. */
+    suspend fun awaitClosed(): WebTransportCloseInfo = closedSignal.await()
+
+    /** Open a bidirectional WebTransport stream on this session. */
+    suspend fun openBidiStream(): WebTransportStream {
+        check(!isClosed) { "session $sessionId is closed" }
+        return mux.openBidi(sessionId)
+    }
+
+    /** Open a unidirectional (send-only) WebTransport stream on this session. */
+    suspend fun openUniStream(): WebTransportSendStream {
+        check(!isClosed) { "session $sessionId is closed" }
+        return mux.openUni(sessionId)
+    }
+
+    /**
+     * Send a WebTransport datagram (draft-ietf-webtrans-http3 §4.4) carrying [payload]'s remaining
+     * bytes. Requires QUIC datagrams to be enabled on the connection (else [WebTransportException]).
+     */
+    suspend fun sendDatagram(payload: ReadBuffer) {
+        check(!isClosed) { "session $sessionId is closed" }
+        mux.sendDatagram(sessionId, payload)
+    }
+
+    /**
+     * Close the session gracefully with an application [code] + [reason] (draft-ietf-webtrans-http3
+     * §6): send a WT_CLOSE_SESSION capsule on the CONNECT stream and FIN it. Idempotent. The [reason]
+     * is truncated to 1024 UTF-8 bytes.
+     */
+    suspend fun close(
+        code: Int = 0,
+        reason: String = "",
+    ) {
+        if (isClosed) return
+        try {
+            mux.sendCloseCapsule(connectStream, code, reason)
+        } catch (_: Throwable) {
+            // Connection/stream already gone — fall through to local teardown.
+        }
+        finish(WebTransportCloseInfo(code, reason))
+    }
+
+    // --- Internal: driven by the connection's router + the mux's capsule loop ---
+
+    internal fun deliverIncomingBidi(stream: WebTransportStream) {
+        incomingBidi.trySend(stream)
+    }
+
+    internal fun deliverIncomingUni(stream: WebTransportReceiveStream) {
+        incomingUni.trySend(stream)
+    }
+
+    internal fun deliverDatagram(buffer: ReadBuffer) {
+        incomingDatagrams.trySend(buffer) // DROP_OLDEST: always accepted; the dropped buffer is freed
+    }
+
+    /** Called by the mux's capsule loop when the peer ends the CONNECT stream (FIN or close capsule). */
+    internal suspend fun onPeerClosed(info: WebTransportCloseInfo) = finish(info)
+
+    private suspend fun finish(info: WebTransportCloseInfo) {
+        if (!closedSignal.complete(info)) return // already closed
+        _closeInfo = info
+        incomingBidi.close()
+        incomingUni.close()
+        incomingDatagrams.close()
+        mux.deregister(sessionId)
+    }
+
+    private companion object {
+        /** Inbound datagram queue depth before the oldest is dropped. */
+        const val DATAGRAM_QUEUE = 256
+    }
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportStreams.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportStreams.kt
@@ -1,0 +1,120 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.flow.BytesWritten
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.socket.quic.QuicByteStream
+import kotlin.time.Duration
+
+/**
+ * A bidirectional WebTransport stream (draft-ietf-webtrans-http3 §4.2). Rides one QUIC bidirectional
+ * stream whose first bytes are the `0x41` signal + the Session ID; everything after is the raw
+ * application payload this stream carries (no HTTP/3 framing).
+ *
+ * Obtained from [WebTransportSession.openBidiStream] (locally opened) or
+ * [WebTransportSession.incomingBidiStreams] (peer-opened). For a peer-opened stream the header was
+ * already stripped by the connection's router; any bytes the peer packed into the same QUIC packet as
+ * the header are returned first by [read] before live stream reads.
+ */
+class WebTransportStream internal constructor(
+    val sessionId: Long,
+    private val stream: QuicByteStream,
+    // Bytes buffered after the WT header when this stream was demultiplexed (peer-opened streams only);
+    // returned by the first read(s) before the underlying QUIC stream is read directly. Null when none.
+    private var pending: ReadBuffer?,
+    private val readTimeout: Duration,
+    private val writeTimeout: Duration,
+) {
+    /** The underlying QUIC stream id (RFC 9000 §2.1). */
+    val streamId: Long get() = stream.streamId.id
+
+    /** Read the next chunk of stream data; [ReadResult.End] at the peer's FIN, [ReadResult.Reset] on reset. */
+    suspend fun read(timeout: Duration = readTimeout): ReadResult = readWithPending(stream, { pending }, { pending = it }, timeout)
+
+    /** Write [buffer]'s remaining bytes to the stream (zero-copy; the caller retains ownership). */
+    suspend fun write(
+        buffer: ReadBuffer,
+        timeout: Duration = writeTimeout,
+    ): BytesWritten = stream.write(buffer, timeout)
+
+    /** Half-close the send side (FIN) while keeping the read side open for the peer's data. */
+    suspend fun shutdownSend() = stream.shutdownSend()
+
+    /** Abort the stream in both directions with [errorCode] (RESET_STREAM + STOP_SENDING). */
+    suspend fun reset(errorCode: Long = 0) = stream.reset(errorCode)
+
+    /** Gracefully close the stream (FIN both directions) and release any buffered prefix. */
+    suspend fun close() {
+        pending?.freeIfNeeded()
+        pending = null
+        stream.close()
+    }
+}
+
+/**
+ * The send half of a unidirectional WebTransport stream (draft-ietf-webtrans-http3 §4.1) we opened —
+ * a QUIC unidirectional stream prefixed with the `0x54` type + Session ID. Write-only; obtained from
+ * [WebTransportSession.openUniStream].
+ */
+class WebTransportSendStream internal constructor(
+    val sessionId: Long,
+    private val stream: QuicByteStream,
+    private val writeTimeout: Duration,
+) {
+    val streamId: Long get() = stream.streamId.id
+
+    suspend fun write(
+        buffer: ReadBuffer,
+        timeout: Duration = writeTimeout,
+    ): BytesWritten = stream.write(buffer, timeout)
+
+    /** Finish the stream cleanly (FIN). */
+    suspend fun close() = stream.close()
+
+    /** Abort the stream with [errorCode] (RESET_STREAM). */
+    suspend fun reset(errorCode: Long = 0) = stream.reset(errorCode)
+}
+
+/**
+ * The receive half of a peer-opened unidirectional WebTransport stream
+ * (draft-ietf-webtrans-http3 §4.1). Read-only; obtained from [WebTransportSession.incomingUniStreams].
+ * The `0x54` type + Session ID header was stripped by the router; [read] returns any bytes buffered
+ * alongside the header before reading the underlying QUIC stream directly.
+ */
+class WebTransportReceiveStream internal constructor(
+    val sessionId: Long,
+    private val stream: QuicByteStream,
+    private var pending: ReadBuffer?,
+    private val readTimeout: Duration,
+) {
+    val streamId: Long get() = stream.streamId.id
+
+    suspend fun read(timeout: Duration = readTimeout): ReadResult = readWithPending(stream, { pending }, { pending = it }, timeout)
+
+    /** Ask the peer to stop sending (STOP_SENDING with [errorCode]) and release any buffered prefix. */
+    suspend fun cancel(errorCode: Long = 0) {
+        pending?.freeIfNeeded()
+        pending = null
+        stream.reset(errorCode)
+    }
+}
+
+/** Drain a one-shot buffered prefix before delegating to the live stream — shared by the read streams. */
+private suspend fun readWithPending(
+    stream: QuicByteStream,
+    getPending: () -> ReadBuffer?,
+    setPending: (ReadBuffer?) -> Unit,
+    timeout: Duration,
+): ReadResult {
+    val buffered = getPending()
+    if (buffered != null) {
+        if (buffered.remaining() > 0) {
+            setPending(null)
+            return ReadResult.Data(buffered)
+        }
+        buffered.freeIfNeeded()
+        setPending(null)
+    }
+    return stream.read(timeout)
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportWire.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportWire.kt
@@ -1,0 +1,93 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.WriteBuffer
+import com.ditchoom.buffer.codec.EncodeContext
+
+/**
+ * Wire constants and codecs for WebTransport over HTTP/3 (draft-ietf-webtrans-http3 §4 / §6,
+ * RFC 9297 Capsule Protocol). Shared by the client ([Http3Connection]) and server
+ * ([Http3ServerConnection]) roles via [WebTransportMux].
+ *
+ * The three byte-level framings WebTransport adds on top of HTTP/3 are:
+ *  - **Unidirectional streams** (§4.1): the stream's first varint is [WT_UNI_STREAM_TYPE], then the
+ *    Session ID varint, then raw application bytes (no HTTP/3 framing).
+ *  - **Bidirectional streams** (§4.2): the stream's first varint is the [WT_BIDI_STREAM_SIGNAL]
+ *    frame type, then the Session ID varint, then raw application bytes.
+ *  - **Datagrams** (§4.4): the QUIC DATAGRAM payload is `Quarter Stream ID (= sessionId / 4)` then the
+ *    application datagram payload, unmodified.
+ *
+ * Session control rides the CONNECT stream as RFC 9297 capsules **inside HTTP/3 DATA frames** —
+ * [WT_CLOSE_SESSION] (graceful close with an application code + reason) and [WT_DRAIN_SESSION].
+ */
+internal object WebTransportWire {
+    /** Unidirectional WebTransport stream type prefix (draft-ietf-webtrans-http3 §4.1). */
+    const val WT_UNI_STREAM_TYPE: Long = 0x54
+
+    /** Bidirectional WebTransport stream signal frame type (draft-ietf-webtrans-http3 §4.2). */
+    const val WT_BIDI_STREAM_SIGNAL: Long = 0x41
+
+    /** WT_CLOSE_SESSION capsule type (draft-ietf-webtrans-http3 §6): graceful session close. */
+    const val WT_CLOSE_SESSION: Long = 0x2843
+
+    /** WT_DRAIN_SESSION capsule type (draft-ietf-webtrans-http3 §4.6): graceful drain request. */
+    const val WT_DRAIN_SESSION: Long = 0x78ae
+
+    /** draft-ietf-webtrans-http3 §6: the application error message is capped at 1024 UTF-8 bytes. */
+    const val MAX_CLOSE_REASON_BYTES: Int = 1024
+
+    /**
+     * The Quarter Stream ID (RFC 9297 §2.1) that identifies datagrams for the session whose CONNECT
+     * stream is [sessionId]. The CONNECT stream is always a client-initiated bidirectional stream, so
+     * its id is a multiple of four and the division is exact.
+     */
+    fun quarterStreamId(sessionId: Long): Long = sessionId / 4
+
+    /** Encoded byte length of a WT_CLOSE_SESSION capsule for [code] + [reason] (truncated to 1024 bytes). */
+    fun closeSessionCapsuleSize(reasonUtf8Bytes: Int): Int {
+        val valueLen = 4 + reasonUtf8Bytes // u32 error code + reason bytes
+        return VarIntCodec.encodedLength(WT_CLOSE_SESSION) + VarIntCodec.encodedLength(valueLen.toLong()) + valueLen
+    }
+
+    /**
+     * Write a WT_CLOSE_SESSION capsule (Type, Length, `Application Error Code (32)`,
+     * `Application Error Message`) to [buffer]. The 32-bit code is written network order via explicit
+     * bytes so it does not depend on the buffer's [com.ditchoom.buffer.ByteOrder].
+     */
+    fun writeCloseSessionCapsule(
+        buffer: WriteBuffer,
+        code: Int,
+        reason: String,
+        reasonUtf8Bytes: Int,
+    ) {
+        val valueLen = 4 + reasonUtf8Bytes
+        VarIntCodec.encode(buffer, WT_CLOSE_SESSION, EncodeContext.Empty)
+        VarIntCodec.encode(buffer, valueLen.toLong(), EncodeContext.Empty)
+        buffer.writeByte((code ushr 24).toByte())
+        buffer.writeByte((code ushr 16).toByte())
+        buffer.writeByte((code ushr 8).toByte())
+        buffer.writeByte(code.toByte())
+        if (reasonUtf8Bytes > 0) buffer.writeString(reason, Charset.UTF8)
+    }
+
+    /**
+     * Decode a WT_CLOSE_SESSION capsule **value** (the bytes after Type+Length) of [valueLength] bytes
+     * from [buffer], positioned at the start of the value. Returns the application error code + reason.
+     * A value shorter than the 4-byte code is malformed (draft-ietf-webtrans-http3 §6).
+     */
+    fun readCloseSessionValue(
+        buffer: ReadBuffer,
+        valueLength: Int,
+    ): WebTransportCloseInfo {
+        if (valueLength < 4) throw Http3StreamException("WT_CLOSE_SESSION capsule shorter than its 4-byte error code")
+        val code =
+            ((buffer.readByte().toInt() and 0xFF) shl 24) or
+                ((buffer.readByte().toInt() and 0xFF) shl 16) or
+                ((buffer.readByte().toInt() and 0xFF) shl 8) or
+                (buffer.readByte().toInt() and 0xFF)
+        val reasonBytes = valueLength - 4
+        val reason = if (reasonBytes > 0) buffer.readString(reasonBytes, Charset.UTF8) else ""
+        return WebTransportCloseInfo(code, reason)
+    }
+}

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WithHttp3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WithHttp3Connection.kt
@@ -35,8 +35,9 @@ suspend fun <R> withHttp3Connection(
     connectionOptions: ConnectionOptions = ConnectionOptions(),
     timeout: Duration = 15.seconds,
     maxPushId: Long = -1,
+    webTransport: WebTransportOptions? = null,
     block: suspend Http3Connection.() -> R,
 ): R =
     withQuicConnection(hostname, port, quicOptions, connectionOptions, timeout) {
-        Http3Connection.bootstrap(this, connectionOptions, maxPushId).block()
+        Http3Connection.bootstrap(this, connectionOptions, maxPushId, webTransport).block()
     }

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WithHttp3Server.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WithHttp3Server.kt
@@ -42,6 +42,8 @@ suspend fun <R> withHttp3Server(
     connectionOptions: ConnectionOptions = ConnectionOptions(),
     qpackCapacity: Long = 0,
     timeout: Duration = 15.seconds,
+    webTransport: WebTransportOptions? = null,
+    onWebTransport: (suspend WebTransportServerExchange.() -> Unit)? = null,
     onRequest: suspend Http3ServerExchange.() -> Unit,
     block: suspend Http3Server.() -> R,
 ): R =
@@ -51,7 +53,8 @@ suspend fun <R> withHttp3Server(
             val acceptJob =
                 launch {
                     connections {
-                        Http3ServerConnection(this, connectionOptions, qpackCapacity, onRequest).serve()
+                        Http3ServerConnection(this, connectionOptions, qpackCapacity, onRequest, webTransport, onWebTransport)
+                            .serve()
                     }
                 }
             try {

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3FrameCodecTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3FrameCodecTests.kt
@@ -129,6 +129,24 @@ class Http3FrameCodecTests {
     }
 
     @Test
+    fun settings_webTransport_roundTrip() {
+        // The WebTransport SETTINGS use large code points (0x33, and 4-byte varints for
+        // WEBTRANSPORT_MAX_SESSIONS / ENABLE_WEBTRANSPORT) — exercise the codec on those ids.
+        val settings = Http3Frame.Settings(webTransportSettings(WebTransportOptions(maxSessions = 17)))
+        val bytes = encodeFrame(settings)
+        val decoded = Http3FrameCodec.decode(bufferOf(*bytes.toIntArray()), DecodeContext.Empty)
+        assertEquals(settings, decoded)
+        assertEquals(bytes.size, wireSizeOf(settings))
+
+        // The decoded peer view reports WebTransport support.
+        val peer = Http3Settings((decoded as Http3Frame.Settings).entries)
+        assertTrue(peer.enableConnectProtocol)
+        assertTrue(peer.h3DatagramEnabled)
+        assertEquals(17L, peer.wtMaxSessions)
+        assertTrue(peer.webTransportSupported)
+    }
+
+    @Test
     fun settings_truncatedPair_failsCleanly() {
         // 04 01 05 : SETTINGS, length 1 — identifier 0x05 with no room for a value.
         // Must throw rather than read the value varint past the frame boundary.

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -4,14 +4,18 @@ import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
 import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.DatagramOptions
 import com.ditchoom.socket.quic.QuicOptions
 import com.ditchoom.socket.quic.QuicTlsConfig
 import com.ditchoom.socket.quic.withQuicServer
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -25,6 +29,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
@@ -59,11 +65,14 @@ abstract class Http3LoopbackTestSuite {
     /** Skip-on-missing-native-lib hook; JVM overrides to translate `UnsatisfiedLinkError` to a skip. */
     protected open suspend fun wrapTestBody(block: suspend () -> Unit): Unit = block()
 
+    // Datagrams enabled so the WebTransport datagram tests (RFC 9297) work; harmless for the others
+    // (it only advertises max_datagram_frame_size in the QUIC handshake).
     private val serverQuicOptions =
         QuicOptions(
             alpnProtocols = listOf(HTTP3_ALPN),
             verifyPeer = false,
             idleTimeout = 10.seconds,
+            datagrams = DatagramOptions(),
         )
 
     private val clientQuicOptions =
@@ -71,6 +80,7 @@ abstract class Http3LoopbackTestSuite {
             alpnProtocols = listOf(HTTP3_ALPN),
             verifyPeer = false,
             idleTimeout = 10.seconds,
+            datagrams = DatagramOptions(),
         )
 
     // QUIC stream I/O is zero-copy: it reads each buffer's native address. On Kotlin/Native,
@@ -790,6 +800,410 @@ abstract class Http3LoopbackTestSuite {
                 }
             }
         }
+
+    // --- WebTransport (RFC 9220 Extended CONNECT) — Phase 1: session establishment ---
+
+    @Test
+    fun webTransport_establishSession_happyPath() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // A real withHttp3Server accepting an Extended CONNECT, and a real withHttp3Connection
+                // opening a WebTransport session: the client's session id must equal the id the server
+                // saw, proving the CONNECT stream id is the shared session id (draft-ietf-webtrans-http3).
+                val serverSawSession = CompletableDeferred<Long>()
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        assertEquals("localhost", authority)
+                        assertEquals("/wt", path)
+                        serverSawSession.complete(accept().sessionId)
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val clientSessionId =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            assertFalse(session.isClosed)
+                            session.sessionId
+                        }
+                    // Awaited OUTSIDE the client block (never block on a server signal from inside it).
+                    val serverId = withTimeout(5.seconds) { serverSawSession.await() }
+                    assertEquals(clientSessionId, serverId)
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_serverRejects_throwsWithStatus() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = { reject(403) },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 4),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        val ex =
+                            assertFailsWith<WebTransportException> {
+                                connectWebTransport(authority = "localhost", path = "/nope")
+                            }
+                        assertTrue(ex.message!!.contains("403"), "message should carry the reject status: ${ex.message}")
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_peerWithoutSupport_throwsBeforeOpening() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // Server does NOT advertise WebTransport (no webTransport option) — the client must
+                // fail the gate on peerSettings().webTransportSupported before opening a CONNECT stream.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 1),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        assertFailsWith<WebTransportException> {
+                            connectWebTransport(authority = "localhost", path = "/x")
+                        }
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_twoConcurrentSessions_getDistinctIds() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                val serverIds = Channel<Long>(Channel.UNLIMITED)
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = { serverIds.trySend(accept().sessionId) },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val (a, b) =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val s1 = connectWebTransport(authority = "localhost", path = "/a")
+                            val s2 = connectWebTransport(authority = "localhost", path = "/b")
+                            s1.sessionId to s2.sessionId
+                        }
+                    assertNotEquals(a, b, "two sessions on one connection must have distinct ids")
+                    val seen = withTimeout(5.seconds) { setOf(serverIds.receive(), serverIds.receive()) }
+                    assertEquals(setOf(a, b), seen)
+                }
+            }
+        }
+
+    // --- WebTransport Phase 2: streams (draft-ietf-webtrans-http3 §4.1 / §4.2) ---
+
+    @Test
+    fun webTransport_clientOpensBidiStream_serverEchoes() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        // Echo the first peer-opened bidirectional stream back with a prefix, then FIN.
+                        val stream = session.incomingBidiStreams.first()
+                        val msg = stream.readUtf8()
+                        stream.write(textBuffer("echo:$msg"))
+                        stream.close()
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val reply =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            val stream = session.openBidiStream()
+                            stream.write(textBuffer("hello"))
+                            stream.shutdownSend()
+                            withTimeout(5.seconds) { stream.readUtf8() }
+                        }
+                    assertEquals("echo:hello", reply)
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_clientOpensUniStream_serverReceives() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                val serverGot = CompletableDeferred<String>()
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        val stream = session.incomingUniStreams.first()
+                        serverGot.complete(stream.readUtf8())
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 4),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        val session = connectWebTransport(authority = "localhost", path = "/wt")
+                        val stream = session.openUniStream()
+                        stream.write(textBuffer("uni-payload"))
+                        stream.close()
+                    }
+                    assertEquals("uni-payload", withTimeout(5.seconds) { serverGot.await() })
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_serverOpensUniStream_clientReceives() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        // Server-initiated unidirectional stream toward the client.
+                        val stream = session.openUniStream()
+                        stream.write(textBuffer("from-server"))
+                        stream.close()
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val got =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            val stream = withTimeout(5.seconds) { session.incomingUniStreams.first() }
+                            withTimeout(5.seconds) { stream.readUtf8() }
+                        }
+                    assertEquals("from-server", got)
+                }
+            }
+        }
+
+    // --- WebTransport Phase 3: datagrams (draft-ietf-webtrans-http3 §4.4, RFC 9297) ---
+
+    @Test
+    fun webTransport_datagramRoundTrip() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        val datagram = session.datagrams.first()
+                        val text = datagram.readString(datagram.remaining(), Charset.UTF8)
+                        datagram.freeIfNeeded()
+                        session.sendDatagram(textBuffer("pong:$text"))
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val reply =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            session.sendDatagram(textBuffer("ping"))
+                            val datagram = withTimeout(5.seconds) { session.datagrams.first() }
+                            val text = datagram.readString(datagram.remaining(), Charset.UTF8)
+                            datagram.freeIfNeeded()
+                            text
+                        }
+                    assertEquals("pong:ping", reply)
+                }
+            }
+        }
+
+    // --- WebTransport Phase 4: graceful close via WT_CLOSE_SESSION capsule (draft §6) ---
+
+    @Test
+    fun webTransport_clientCloses_serverObservesCodeAndReason() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                val serverClose = CompletableDeferred<WebTransportCloseInfo>()
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        serverClose.complete(session.awaitClosed())
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 4),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        val session = connectWebTransport(authority = "localhost", path = "/wt")
+                        session.close(code = 42, reason = "all done")
+                        assertTrue(session.isClosed)
+                        delay(300) // let the WT_CLOSE_SESSION capsule + FIN flush before teardown
+                    }
+                    assertEquals(WebTransportCloseInfo(42, "all done"), withTimeout(5.seconds) { serverClose.await() })
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_serverCloses_clientObservesCodeAndReason() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        session.close(code = 7, reason = "server bye")
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val info =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            // The client observes the peer's close reactively via its own session signal.
+                            withTimeout(5.seconds) { session.awaitClosed() }
+                        }
+                    assertEquals(WebTransportCloseInfo(7, "server bye"), info)
+                }
+            }
+        }
+}
+
+/** Read a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */
+private suspend fun WebTransportStream.readUtf8(): String = drainUtf8 { read() }
+
+/** Read a unidirectional (receive) WebTransport stream to end-of-stream as a UTF-8 string. */
+private suspend fun WebTransportReceiveStream.readUtf8(): String = drainUtf8 { read() }
+
+private suspend fun drainUtf8(read: suspend () -> ReadResult): String {
+    val sb = StringBuilder()
+    while (true) {
+        when (val result = read()) {
+            is ReadResult.Data -> {
+                sb.append(result.buffer.readString(result.buffer.remaining(), Charset.UTF8))
+                result.buffer.freeIfNeeded()
+            }
+            ReadResult.End, ReadResult.Reset -> return sb.toString()
+        }
+    }
 }
 
 /** Result holder for the production server-role test (the block returns GET + POST results). */

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportCapsuleTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportCapsuleTests.kt
@@ -1,0 +1,84 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.PlatformBuffer
+import com.ditchoom.buffer.codec.DecodeContext
+import com.ditchoom.buffer.deterministic
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Pure, deterministic tests for the WebTransport wire constants + WT_CLOSE_SESSION capsule codec
+ * (draft-ietf-webtrans-http3 §6, RFC 9297 Capsule Protocol) — no I/O, so they run on every platform.
+ */
+class WebTransportCapsuleTests {
+    private fun roundTripCloseCapsule(
+        code: Int,
+        reason: String,
+    ): WebTransportCloseInfo {
+        val reasonBytes = qpackUtf8ByteLength(reason)
+        val size = WebTransportWire.closeSessionCapsuleSize(reasonBytes)
+        val buffer: PlatformBuffer = BufferFactory.deterministic().allocate(size.coerceAtLeast(1))
+        WebTransportWire.writeCloseSessionCapsule(buffer, code, reason, reasonBytes)
+        assertEquals(size, buffer.position(), "writer must emit exactly closeSessionCapsuleSize bytes")
+        buffer.resetForRead()
+
+        // Parse it back the way the capsule loop does: Type, Length, then the value.
+        val type = VarIntCodec.decode(buffer, DecodeContext.Empty)
+        assertEquals(WebTransportWire.WT_CLOSE_SESSION, type)
+        val length = VarIntCodec.decode(buffer, DecodeContext.Empty).toInt()
+        assertEquals(4 + reasonBytes, length)
+        return WebTransportWire.readCloseSessionValue(buffer, length)
+    }
+
+    @Test
+    fun closeCapsule_roundTrips_codeAndReason() {
+        assertEquals(WebTransportCloseInfo(42, "going away"), roundTripCloseCapsule(42, "going away"))
+    }
+
+    @Test
+    fun closeCapsule_roundTrips_zeroCodeEmptyReason() {
+        assertEquals(WebTransportCloseInfo(0, ""), roundTripCloseCapsule(0, ""))
+    }
+
+    @Test
+    fun closeCapsule_roundTrips_largeCode() {
+        // A full 32-bit code must survive the explicit network-order byte packing.
+        val code = -0x0F0E0D0C // 0xF0F1F2F4 as a signed Int
+        assertEquals(WebTransportCloseInfo(code, "x"), roundTripCloseCapsule(code, "x"))
+    }
+
+    @Test
+    fun closeCapsule_roundTrips_multiByteUtf8Reason() {
+        val reason = "résumé — 完了"
+        val info = roundTripCloseCapsule(7, reason)
+        assertEquals(WebTransportCloseInfo(7, reason), info)
+    }
+
+    @Test
+    fun readCloseSessionValue_rejectsTooShortValue() {
+        // A value of fewer than the 4 code bytes is malformed.
+        val buffer = BufferFactory.deterministic().allocate(4)
+        buffer.writeByte(0)
+        buffer.writeByte(0)
+        buffer.resetForRead()
+        assertFailsWith<Http3StreamException> { WebTransportWire.readCloseSessionValue(buffer, 2) }
+    }
+
+    @Test
+    fun quarterStreamId_dividesByFour() {
+        // CONNECT streams are client-initiated bidirectional (id % 4 == 0), so the division is exact.
+        assertEquals(0L, WebTransportWire.quarterStreamId(0))
+        assertEquals(1L, WebTransportWire.quarterStreamId(4))
+        assertEquals(15L, WebTransportWire.quarterStreamId(60))
+    }
+
+    @Test
+    fun streamTypeConstants_matchDraft() {
+        assertEquals(0x54L, WebTransportWire.WT_UNI_STREAM_TYPE)
+        assertEquals(0x41L, WebTransportWire.WT_BIDI_STREAM_SIGNAL)
+        assertEquals(0x2843L, WebTransportWire.WT_CLOSE_SESSION)
+        assertEquals(0x78aeL, WebTransportWire.WT_DRAIN_SESSION)
+    }
+}

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportSettingsTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportSettingsTests.kt
@@ -1,0 +1,104 @@
+package com.ditchoom.socket.http3
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Phase 0 — pure, deterministic tests for WebTransport SETTINGS (no I/O): the [Http3Settings]
+ * capability accessors and the [webTransportSettings] advertisement builder.
+ */
+class WebTransportSettingsTests {
+    private fun settings(vararg pairs: Pair<Long, Long>): Http3Settings = Http3Settings(pairs.map { Http3Setting(it.first, it.second) })
+
+    @Test
+    fun accessors_readEachSetting() {
+        val s =
+            settings(
+                Http3SettingId.ENABLE_CONNECT_PROTOCOL to 1L,
+                Http3SettingId.H3_DATAGRAM to 1L,
+                Http3SettingId.WEBTRANSPORT_MAX_SESSIONS to 42L,
+            )
+        assertTrue(s.enableConnectProtocol)
+        assertTrue(s.h3DatagramEnabled)
+        assertEquals(42L, s.wtMaxSessions)
+    }
+
+    @Test
+    fun defaults_whenAbsent() {
+        val s = Http3Settings(emptyList())
+        assertFalse(s.enableConnectProtocol)
+        assertFalse(s.h3DatagramEnabled)
+        assertEquals(0L, s.wtMaxSessions)
+        assertFalse(s.webTransportSupported)
+    }
+
+    @Test
+    fun webTransportSupported_requiresAllThree() {
+        // All three present and positive ⇒ supported.
+        assertTrue(
+            settings(
+                Http3SettingId.ENABLE_CONNECT_PROTOCOL to 1L,
+                Http3SettingId.H3_DATAGRAM to 1L,
+                Http3SettingId.WEBTRANSPORT_MAX_SESSIONS to 1L,
+            ).webTransportSupported,
+        )
+        // Missing Extended CONNECT.
+        assertFalse(
+            settings(
+                Http3SettingId.H3_DATAGRAM to 1L,
+                Http3SettingId.WEBTRANSPORT_MAX_SESSIONS to 1L,
+            ).webTransportSupported,
+        )
+        // Missing H3 datagrams.
+        assertFalse(
+            settings(
+                Http3SettingId.ENABLE_CONNECT_PROTOCOL to 1L,
+                Http3SettingId.WEBTRANSPORT_MAX_SESSIONS to 1L,
+            ).webTransportSupported,
+        )
+        // Connect + datagrams but a zero session limit ⇒ peer accepts no sessions.
+        assertFalse(
+            settings(
+                Http3SettingId.ENABLE_CONNECT_PROTOCOL to 1L,
+                Http3SettingId.H3_DATAGRAM to 1L,
+                Http3SettingId.WEBTRANSPORT_MAX_SESSIONS to 0L,
+            ).webTransportSupported,
+        )
+    }
+
+    @Test
+    fun webTransportSettings_advertisesTheFourEntries() {
+        val entries = webTransportSettings(WebTransportOptions(maxSessions = 5))
+        assertEquals(
+            mapOf(
+                Http3SettingId.ENABLE_CONNECT_PROTOCOL to 1L,
+                Http3SettingId.H3_DATAGRAM to 1L,
+                Http3SettingId.ENABLE_WEBTRANSPORT to 1L,
+                Http3SettingId.WEBTRANSPORT_MAX_SESSIONS to 5L,
+            ),
+            entries.associate { it.identifier to it.value },
+        )
+    }
+
+    @Test
+    fun webTransportSettings_initiateOnly_advertisesZeroSessionsButStaysCapable() {
+        // maxSessions = 0 (initiate-only) still advertises connect-protocol + datagrams, so the
+        // peer can open sessions toward us even though we accept none inbound.
+        val entries = webTransportSettings(WebTransportOptions(maxSessions = 0))
+        val peer = Http3Settings(entries)
+        assertTrue(peer.enableConnectProtocol)
+        assertTrue(peer.h3DatagramEnabled)
+        assertEquals(0L, peer.wtMaxSessions)
+        // Our own webTransportSupported view of *that* peer is false (it accepts no sessions),
+        // which is the correct gate for whether we may initiate toward it.
+        assertFalse(peer.webTransportSupported)
+    }
+
+    @Test
+    fun webTransportOptions_rejectsNegativeMaxSessions() {
+        assertFailsWith<IllegalArgumentException> { WebTransportOptions(maxSessions = -1) }
+    }
+}


### PR DESCRIPTION
## What

Implements **WebTransport over HTTP/3** in `:socket-http3`, layered on the existing QUIC datagram + stream plumbing. Opt-in: pass `WebTransportOptions` to `withHttp3Connection` / `withHttp3Server` (datagrams additionally need `QuicOptions(datagrams = DatagramOptions())`).

Built as five phases; the phase boundaries were pinned by the existing code comments. Every wire detail was verified against the draft + RFC 9297 before coding.

| Phase | Scope | Wire |
|---|---|---|
| **0** | SETTINGS + capability view | `H3_DATAGRAM=0x33`, `WEBTRANSPORT_MAX_SESSIONS`, legacy `ENABLE_WEBTRANSPORT`; `Http3Settings.webTransportSupported` |
| **1** | Extended CONNECT session (RFC 9220) | `connectWebTransport` (client), `onWebTransport` + `accept()/reject(status)` (server); session id = CONNECT stream id |
| **2** | Streams (draft §4.1/§4.2) | uni type `0x54`+SessionID, bidi signal `0x41`+SessionID, then raw bytes |
| **3** | Datagrams (draft §4.4 / RFC 9297) | QUIC DATAGRAM = `QuarterStreamID(=sessionId/4)` + payload |
| **4** | Graceful close (draft §6) | `WT_CLOSE_SESSION` (0x2843) capsule **inside H3 DATA frames** on the CONNECT stream |

## Public API

- `WebTransportOptions(maxSessions)` on `withHttp3Connection` / `withHttp3Server` (+ `onWebTransport` handler).
- `Http3Connection.connectWebTransport(authority, path, headers)` → `WebTransportSession`.
- `WebTransportSession`: `openBidiStream` / `openUniStream`, `incomingBidiStreams` / `incomingUniStreams`, `sendDatagram` / `datagrams`, `close(code, reason)` / `awaitClosed()` / `closeInfo`.
- `WebTransportStream` / `WebTransportSendStream` / `WebTransportReceiveStream`, `WebTransportServerExchange`.

## Design notes

- **One shared `WebTransportMux` per connection**, used verbatim by both client (`Http3Connection`) and server (`Http3ServerConnection`) — owns the session table, stream open/demux, the datagram pump, and the capsule protocol, so neither role duplicates WT logic.
- **Server bidi demux needs a non-consuming peek**: a client WT bidi stream starts with `0x41`, not a HEADERS frame, so `handleRequest` must distinguish before frame-parsing. Added `Http3StreamReader.peekVarInt`. The client router now also accepts peer-opened WT bidi/uni streams it previously discarded.
- **Capsules ride inside HTTP/3 DATA frames** on the CONNECT stream (RFC 9297 §3.1 — *not* raw after HEADERS).
- **Registration-race fix**: sessions are tabled the instant the CONNECT stream id is known (client pre-registers *before* reading the 2xx) so a peer opening a WT stream/datagram right after the handshake never races ahead of the table.
- **Idle-session gotcha**: the capsule loop + app-stream reads use `Duration.INFINITE`, not the 15s `readTimeout`, so idle sessions don't die on a read timeout.

## Testing

- `WebTransportCapsuleTests` (capsule codec) + `WebTransportSettingsTests` (pure) — run on **jvm + linuxX64 + jsNode**.
- 10 in-process loopback E2E tests in `Http3LoopbackTestSuite` (establish/reject/no-support/two-sessions, bidi echo, client uni, server uni, datagram round-trip, client-close-observed-by-server, server-close-observed-by-client) — **jvm + linuxX64**.
- android + wasmJs main compile; ktlint clean. Loopback `QuicOptions` now enable `DatagramOptions()`.

## Not done (follow-ups)

- Sending `WT_DRAIN_SESSION` (we receive/skip it).
- Apple WT-stream `reset()` parity (carries over from the existing H3 Apple `reset()` follow-up — needs a Mac).
- Third-party WebTransport interop sidecar (the docker interop covers QPACK only).

## Release label

Tagged **`skip-release`** (no Maven Central publish) since WT is Apple-untested and has no third-party interop yet. Switch to `minor` if you want to cut a release.

Canonical detail: the "DONE — WebTransport over HTTP/3" section in `socket-http3/HANDOFF.md`.