### PR TITLE
feat(webtransport): map stream reset error codes to/from the HTTP/3 space (draft §4.3)

### DIFF
--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportStreams.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportStreams.kt
@@ -5,7 +5,30 @@ import com.ditchoom.buffer.flow.BytesWritten
 import com.ditchoom.buffer.flow.ReadResult
 import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.socket.quic.QuicByteStream
+import com.ditchoom.socket.quic.QuicStreamException
 import kotlin.time.Duration
+
+/**
+ * A WebTransport stream was aborted by the peer (draft-ietf-webtrans-http3 §4.3): [errorCode] is the
+ * peer's WebTransport application error code, **decoded** back out of the HTTP/3 error-code space (or
+ * null when the backend can't resolve the code — e.g. the JNI quiche binding). Wraps the underlying
+ * [QuicStreamException].
+ */
+class WebTransportStreamException internal constructor(
+    val errorCode: Long?,
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)
+
+/**
+ * Translate a QUIC stream abort into a WebTransport one, decoding the peer's application error code from
+ * the HTTP/3 error-code space (draft-ietf-webtrans-http3 §4.3). The shared reset-observation seam for
+ * the WebTransport stream wrappers below.
+ */
+internal fun QuicStreamException.toWebTransport(): WebTransportStreamException {
+    val wtCode = abort.applicationErrorCode?.let { WebTransportWire.toWebTransportErrorCode(it) }
+    return WebTransportStreamException(wtCode, "WebTransport stream $streamId aborted by peer: ${abort::class.simpleName}", this)
+}
 
 /**
  * A bidirectional WebTransport stream (draft-ietf-webtrans-http3 §4.2). Rides one QUIC bidirectional
@@ -32,17 +55,28 @@ class WebTransportStream internal constructor(
     /** Read the next chunk of stream data; [ReadResult.End] at the peer's FIN, [ReadResult.Reset] on reset. */
     suspend fun read(timeout: Duration = readTimeout): ReadResult = readWithPending(stream, { pending }, { pending = it }, timeout)
 
-    /** Write [buffer]'s remaining bytes to the stream (zero-copy; the caller retains ownership). */
+    /**
+     * Write [buffer]'s remaining bytes to the stream (zero-copy; the caller retains ownership). Throws
+     * [WebTransportStreamException] if the peer has aborted the stream (its WebTransport code decoded).
+     */
     suspend fun write(
         buffer: ReadBuffer,
         timeout: Duration = writeTimeout,
-    ): BytesWritten = stream.write(buffer, timeout)
+    ): BytesWritten =
+        try {
+            stream.write(buffer, timeout)
+        } catch (e: QuicStreamException) {
+            throw e.toWebTransport()
+        }
 
     /** Half-close the send side (FIN) while keeping the read side open for the peer's data. */
     suspend fun shutdownSend() = stream.shutdownSend()
 
-    /** Abort the stream in both directions with [errorCode] (RESET_STREAM + STOP_SENDING). */
-    suspend fun reset(errorCode: Long = 0) = stream.reset(errorCode)
+    /**
+     * Abort the stream in both directions with the WebTransport application [errorCode] (RESET_STREAM +
+     * STOP_SENDING). The code is mapped into the HTTP/3 error-code space (draft §4.3) on the wire.
+     */
+    suspend fun reset(errorCode: Long = 0) = stream.reset(WebTransportWire.toHttp3ErrorCode(errorCode))
 
     /** Gracefully close the stream (FIN both directions) and release any buffered prefix. */
     suspend fun close() {
@@ -64,16 +98,25 @@ class WebTransportSendStream internal constructor(
 ) {
     val streamId: Long get() = stream.streamId.id
 
+    /**
+     * Write [buffer]'s remaining bytes. Throws [WebTransportStreamException] if the peer sent
+     * STOP_SENDING (its WebTransport code decoded from the HTTP/3 error-code space, draft §4.3).
+     */
     suspend fun write(
         buffer: ReadBuffer,
         timeout: Duration = writeTimeout,
-    ): BytesWritten = stream.write(buffer, timeout)
+    ): BytesWritten =
+        try {
+            stream.write(buffer, timeout)
+        } catch (e: QuicStreamException) {
+            throw e.toWebTransport()
+        }
 
     /** Finish the stream cleanly (FIN). */
     suspend fun close() = stream.close()
 
-    /** Abort the stream with [errorCode] (RESET_STREAM). */
-    suspend fun reset(errorCode: Long = 0) = stream.reset(errorCode)
+    /** Abort the stream with the WebTransport application [errorCode] (RESET_STREAM), mapped per draft §4.3. */
+    suspend fun reset(errorCode: Long = 0) = stream.reset(WebTransportWire.toHttp3ErrorCode(errorCode))
 }
 
 /**
@@ -92,11 +135,14 @@ class WebTransportReceiveStream internal constructor(
 
     suspend fun read(timeout: Duration = readTimeout): ReadResult = readWithPending(stream, { pending }, { pending = it }, timeout)
 
-    /** Ask the peer to stop sending (STOP_SENDING with [errorCode]) and release any buffered prefix. */
+    /**
+     * Ask the peer to stop sending (STOP_SENDING with the WebTransport application [errorCode], mapped
+     * into the HTTP/3 error-code space per draft §4.3) and release any buffered prefix.
+     */
     suspend fun cancel(errorCode: Long = 0) {
         pending?.freeIfNeeded()
         pending = null
-        stream.reset(errorCode)
+        stream.reset(WebTransportWire.toHttp3ErrorCode(errorCode))
     }
 }
 

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportWire.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportWire.kt
@@ -38,6 +38,41 @@ internal object WebTransportWire {
     const val MAX_CLOSE_REASON_BYTES: Int = 1024
 
     /**
+     * Base of the WebTransport slice of the HTTP/3 error-code space (draft-ietf-webtrans-http3 §4.3).
+     * A WebTransport application error code `n` maps to the HTTP/3 code `BASE + n + floor(n / 0x1e)`.
+     */
+    const val WT_ERROR_BASE: Long = 0x52e4a40fa8db
+
+    /**
+     * Map a 32-bit WebTransport application error code [webTransportCode] to the HTTP/3 / QUIC error
+     * code that carries it on a RESET_STREAM / STOP_SENDING frame (draft-ietf-webtrans-http3 §4.3).
+     *
+     * The HTTP/3 error-code space is shared by every extension, so WebTransport codes are remapped to a
+     * dedicated slice — `BASE + n + floor(n / 0x1e)` — that skips one value out of every 0x1f to dodge
+     * the reserved GREASE codes (`0x1f * N + 0x21`). [webTransportCode] is treated as an unsigned 32-bit
+     * value (the draft's domain is `0 .. 2^32 - 1`).
+     */
+    fun toHttp3ErrorCode(webTransportCode: Long): Long {
+        val n = webTransportCode and 0xFFFFFFFFL
+        return WT_ERROR_BASE + n + n / 0x1e
+    }
+
+    /**
+     * Inverse of [toHttp3ErrorCode]: recover the WebTransport application error code from the HTTP/3 /
+     * QUIC code observed on a peer's RESET_STREAM / STOP_SENDING (draft-ietf-webtrans-http3 §4.3,
+     * `shifted = h - BASE; n = shifted - floor(shifted / 0x1f)`).
+     *
+     * Defined for codes inside the WebTransport slice (`h >= BASE`). A code below the slice, or one that
+     * lands on a skipped GREASE slot, is not a WebTransport code; this still returns the formula's value
+     * (the demux paths only feed it codes a WebTransport peer produced via [toHttp3ErrorCode]).
+     */
+    fun toWebTransportErrorCode(http3Code: Long): Long {
+        val shifted = http3Code - WT_ERROR_BASE
+        if (shifted < 0) return shifted // not a WebTransport-mapped code; surface the raw offset
+        return shifted - shifted / 0x1f
+    }
+
+    /**
      * The Quarter Stream ID (RFC 9297 §2.1) that identifies datagrams for the session whose CONNECT
      * stream is [sessionId]. The CONNECT stream is always a client-initiated bidirectional stream, so
      * its id is a multiple of four and the division is exact.

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -1185,6 +1185,64 @@ abstract class Http3LoopbackTestSuite {
                 }
             }
         }
+
+    // --- WebTransport stream reset error-code mapping (draft-ietf-webtrans-http3 §4.3) ---
+
+    @Test
+    fun webTransport_streamReset_codeRoundTripsThroughHttp3Space() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // A code that straddles a §4.3 skip boundary, so a naive pass-through would not round-trip.
+                val wtCode = 0x1e7L
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        val stream = session.incomingBidiStreams.first()
+                        // Read the opener's first chunk, then abort the stream with a WebTransport code.
+                        // reset() maps it into the HTTP/3 error-code space on the RESET_STREAM/STOP_SENDING.
+                        withTimeout(5.seconds) { stream.read() }
+                        stream.reset(wtCode)
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val observed =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            val stream = session.openBidiStream()
+                            stream.write(textBuffer("hello"))
+                            // Keep writing until the peer's STOP_SENDING surfaces; the WT layer decodes the
+                            // HTTP/3 code back to the original WebTransport application error code.
+                            withTimeout(5.seconds) {
+                                var code: Long? = null
+                                while (code == null) {
+                                    try {
+                                        stream.write(textBuffer("x"))
+                                        delay(25)
+                                    } catch (e: WebTransportStreamException) {
+                                        code = e.errorCode
+                                    }
+                                }
+                                code
+                            }
+                        }
+                    assertEquals(wtCode, observed)
+                }
+            }
+        }
 }
 
 /** Read a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportErrorCodeTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportErrorCodeTests.kt
@@ -1,0 +1,82 @@
+package com.ditchoom.socket.http3
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pure, deterministic tests for the WebTransport ↔ HTTP/3 error-code mapping
+ * (draft-ietf-webtrans-http3 §4.3) — no I/O, so they run on every platform (incl. jsNode).
+ */
+class WebTransportErrorCodeTests {
+    @Test
+    fun mapping_matchesTheDraftWorkedExamples() {
+        // From the draft's worked table: n=0 → BASE, and the skip kicks in at every multiple of 0x1e.
+        assertEquals(WebTransportWire.WT_ERROR_BASE, WebTransportWire.toHttp3ErrorCode(0))
+        assertEquals(WebTransportWire.WT_ERROR_BASE + 1, WebTransportWire.toHttp3ErrorCode(1))
+        // n=0x1d (last before the first skip): no skip yet.
+        assertEquals(WebTransportWire.WT_ERROR_BASE + 0x1d, WebTransportWire.toHttp3ErrorCode(0x1d))
+        // n=0x1e: floor(0x1e/0x1e)=1 → one value is skipped.
+        assertEquals(WebTransportWire.WT_ERROR_BASE + 0x1e + 1, WebTransportWire.toHttp3ErrorCode(0x1e))
+        // n=0x3b (0x1e..0x3b share skip=1); n=0x3c bumps skip to 2.
+        assertEquals(WebTransportWire.WT_ERROR_BASE + 0x3b + 1, WebTransportWire.toHttp3ErrorCode(0x3b))
+        assertEquals(WebTransportWire.WT_ERROR_BASE + 0x3c + 2, WebTransportWire.toHttp3ErrorCode(0x3c))
+    }
+
+    @Test
+    fun roundTrip_acrossBoundariesAndFullU32Range() {
+        val samples =
+            listOf(
+                0L,
+                1L,
+                0x1dL,
+                0x1eL,
+                0x1fL,
+                0x3bL,
+                0x3cL,
+                0x3dL,
+                30L,
+                31L,
+                60L,
+                100L,
+                1000L,
+                65535L,
+                0x7FFFFFFFL, // 2^31 - 1
+                0x80000000L, // 2^31
+                0xFFFFFFFEL,
+                0xFFFFFFFFL, // 2^32 - 1, the max WebTransport application error code
+            )
+        for (n in samples) {
+            val h3 = WebTransportWire.toHttp3ErrorCode(n)
+            assertTrue(h3 >= WebTransportWire.WT_ERROR_BASE, "h3 code must land in the WT slice for n=$n")
+            assertEquals(n, WebTransportWire.toWebTransportErrorCode(h3), "round-trip must recover n=$n")
+        }
+    }
+
+    @Test
+    fun roundTrip_isExhaustiveOverASlidingDenseWindow() {
+        // Every value straddling several skip boundaries must round-trip exactly (no off-by-one).
+        for (n in 0L..2000L) {
+            assertEquals(n, WebTransportWire.toWebTransportErrorCode(WebTransportWire.toHttp3ErrorCode(n)))
+        }
+    }
+
+    @Test
+    fun skippedGreaseSlotsAreNeverProducedByTheForwardMap() {
+        // The forward map must never emit a code whose offset-from-base is ≡ 0x1e (mod 0x1f): those are
+        // the reserved slots the remapping exists to dodge.
+        for (n in 0L..5000L) {
+            val shifted = WebTransportWire.toHttp3ErrorCode(n) - WebTransportWire.WT_ERROR_BASE
+            assertTrue(shifted % 0x1f != 0x1eL, "n=$n mapped onto a reserved GREASE slot")
+        }
+    }
+
+    @Test
+    fun upperBitsBeyondU32AreIgnored() {
+        // The reset API carries a Long; only the low 32 bits are the WebTransport code (draft §4.3 domain).
+        assertEquals(
+            WebTransportWire.toHttp3ErrorCode(0x42),
+            WebTransportWire.toHttp3ErrorCode(0xFFFF_FFFF_0000_0042uL.toLong()),
+        )
+    }
+}

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JniQuicheApi.kt
@@ -1,5 +1,8 @@
 package com.ditchoom.socket.quic
 
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.nativeMemoryAccess
 import dalvik.annotation.optimization.FastNative
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
@@ -202,7 +205,32 @@ object JniQuicheApi : QuicheApi {
         buf: Long,
         bufLen: Int,
         fin: Boolean,
-    ): Int = nConnStreamSend(conn.handle, streamId.id, buf, bufLen, fin)
+    ): StreamSendResult {
+        // Hand the C shim an 8-byte native scratch to receive quiche's out_error_code — a buffer address
+        // (FastNative-safe primitive), not a Java array. Per-call rather than reused: JniQuicheApi is a
+        // shared singleton called from every connection's driver thread, so one scratch would race; the
+        // FFM backend likewise allocates a confined Arena per send. quiche fills the code big-endian only
+        // on STREAM_STOPPED / STREAM_RESET (it leaves 0 otherwise).
+        val scratch = BufferFactory.deterministic().allocate(8)
+        return try {
+            val addr = scratch.nativeMemoryAccess!!.nativeAddress.toLong()
+            val result = nConnStreamSend(conn.handle, streamId.id, buf, bufLen, fin, addr)
+            val code =
+                if (result == QuicheDriver.QUICHE_ERR_STREAM_STOPPED || result == QuicheDriver.QUICHE_ERR_STREAM_RESET) {
+                    // The C shim wrote the 8 bytes straight to native memory; it only has the raw address,
+                    // not the buffer object, so it can't (and shouldn't) touch the JVM-side read/write
+                    // cursor. Read them back big-endian by absolute index — no position bookkeeping needed.
+                    var v = 0L
+                    for (i in 0 until 8) v = (v shl 8) or (scratch[i].toLong() and 0xFF)
+                    v
+                } else {
+                    null
+                }
+            StreamSendResult(result, code)
+        } finally {
+            scratch.freeNativeMemory()
+        }
+    }
 
     override fun connStreamShutdown(
         conn: QuicheConn,
@@ -613,6 +641,7 @@ object JniQuicheApi : QuicheApi {
         buf: Long,
         bufLen: Int,
         fin: Boolean,
+        errorOut: Long,
     ): Int
 
     @FastNative

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicStreamException.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicStreamException.kt
@@ -6,8 +6,9 @@ package com.ditchoom.socket.quic
  *
  * Backends populate what they can resolve, which differs:
  * - the quiche driver reports the **direction** ([StopSending] vs [ResetStream], from the
- *   `QUICHE_ERR_STREAM_STOPPED` / `QUICHE_ERR_STREAM_RESET` sentinels) but `quiche_conn_stream_send`
- *   does not surface the peer's application error code, so [applicationErrorCode] is null there;
+ *   `QUICHE_ERR_STREAM_STOPPED` / `QUICHE_ERR_STREAM_RESET` sentinels) and the peer's
+ *   [applicationErrorCode] via `quiche_conn_stream_send`'s `out_error_code` out-parameter — surfaced on
+ *   all three quiche backends (FFM on JDK 21, JNI on JDK < 21 / Android, cinterop on K/N);
  * - Network.framework (Apple) reports the peer's [applicationErrorCode] (via
  *   `nw_quic_get_stream_application_error`) but does not distinguish the direction, so a peer reset
  *   surfacing on our write path is reported as [StopSending] (the peer no longer wants our data)

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheApi.kt
@@ -184,13 +184,17 @@ interface QuicheApi {
         bufLen: Int,
     ): StreamRecvResult
 
+    /**
+     * Write to a QUIC stream. Returns a [StreamSendResult] carrying the raw quiche return plus the peer's
+     * application error code (when the peer aborted the stream and the backend exposes `out_error_code`).
+     */
     fun connStreamSend(
         conn: QuicheConn,
         streamId: QuicStreamId,
         buf: Long,
         bufLen: Int,
         fin: Boolean,
-    ): Int
+    ): StreamSendResult
 
     /**
      * Shut down one [direction] of [streamId] with application error code [err]

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheCmd.kt
@@ -58,7 +58,7 @@ sealed interface QuicheCmd {
         val addr: Long,
         val bufLen: Int,
         val fin: Boolean,
-        val result: CompletableDeferred<Int>,
+        val result: CompletableDeferred<StreamSendResult>,
     ) : QuicheCmd
 
     /**

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicheDriver.kt
@@ -352,8 +352,8 @@ class QuicheDriver(
             }
 
             is QuicheCmd.StreamSend -> {
-                val written = api.connStreamSend(conn, QuicStreamId(cmd.streamId), cmd.addr, cmd.bufLen, cmd.fin)
-                cmd.result.complete(written)
+                val sent = api.connStreamSend(conn, QuicStreamId(cmd.streamId), cmd.addr, cmd.bufLen, cmd.fin)
+                cmd.result.complete(sent)
             }
 
             is QuicheCmd.StreamShutdown -> {
@@ -777,7 +777,7 @@ class QuicheDriver(
                     QuicCloseException(closeReasonOr(QuicError.NoError), "connection closed"),
                 )
             is QuicheCmd.StreamRecv -> cmd.result.complete(StreamRecvResult.Error(-2))
-            is QuicheCmd.StreamSend -> cmd.result.complete(-1)
+            is QuicheCmd.StreamSend -> cmd.result.complete(StreamSendResult(-1))
             // The stream/connection is gone; the shutdown frame won't go out, which is fine — the
             // peer already sees the connection closing. Complete with a benign 0 (no-op).
             is QuicheCmd.StreamShutdown -> cmd.result.complete(0)
@@ -936,16 +936,17 @@ class DriverStreamAdapter(
         // first; otherwise quiche reads freed/Cleaner-reclaimed memory. (A read-after-free is less likely to
         // corrupt the heap than the read path's write-after-free, but it can still fault on an unmapped page,
         // and the lifetime contract must hold symmetrically.)
-        var inFlight: CompletableDeferred<Int>? = null
+        var inFlight: CompletableDeferred<StreamSendResult>? = null
         return try {
             withTimeout(timeout) {
                 while (true) {
-                    val deferred = CompletableDeferred<Int>()
+                    val deferred = CompletableDeferred<StreamSendResult>()
                     driver.commands.send(QuicheCmd.StreamSend(streamId.id, addr, remaining, false, deferred))
                     // Mark in-flight only AFTER a successful enqueue (see streamRead).
                     inFlight = deferred
-                    val written = deferred.await()
+                    val sent = deferred.await()
                     inFlight = null
+                    val written = sent.result
                     when (written) {
                         // Flow-control blocked (QUICHE_ERR_DONE, or a defensive 0 with bytes still pending):
                         // the stream's window is full. Park on writableSignal until the driver observes the
@@ -964,13 +965,13 @@ class DriverStreamAdapter(
                                 // Peer sent STOP_SENDING / RESET_STREAM on THIS stream (RFC 9000 §19.4-19.5).
                                 // Stream-scoped, not connection loss — surface a stream error the caller can
                                 // catch to abandon just this stream; the connection keeps every other stream.
-                                // quiche reports the direction via the sentinel but not the peer application
-                                // error code, so applicationErrorCode is left null.
+                                // quiche reports the direction via the sentinel and the peer application error
+                                // code via out_error_code (FFM/cinterop surface it; JNI leaves it null).
                                 val abort =
                                     if (written == QuicheDriver.QUICHE_ERR_STREAM_STOPPED) {
-                                        QuicStreamAbort.StopSending()
+                                        QuicStreamAbort.StopSending(sent.errorCode)
                                     } else {
-                                        QuicStreamAbort.ResetStream()
+                                        QuicStreamAbort.ResetStream(sent.errorCode)
                                     }
                                 throw QuicStreamException(
                                     streamId.id,
@@ -1003,7 +1004,7 @@ class DriverStreamAdapter(
 
     override suspend fun streamClose(streamId: QuicStreamId) {
         try {
-            val deferred = CompletableDeferred<Int>()
+            val deferred = CompletableDeferred<StreamSendResult>()
             driver.commands.send(QuicheCmd.StreamSend(streamId.id, 0L, 0, true, deferred))
             deferred.await()
         } catch (_: ClosedSendChannelException) {

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/StreamSendResult.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/StreamSendResult.kt
@@ -1,0 +1,19 @@
+package com.ditchoom.socket.quic
+
+/**
+ * Result of a quiche stream write operation (`quiche_conn_stream_send`).
+ *
+ * [result] keeps the raw quiche return convention the driver switches on: `>= 0` bytes accepted,
+ * [QuicheDriver.QUICHE_ERR_DONE] (window full / backpressure), or a negative quiche error code —
+ * notably [QuicheDriver.QUICHE_ERR_STREAM_STOPPED] / [QuicheDriver.QUICHE_ERR_STREAM_RESET] when the
+ * peer aborted the stream.
+ *
+ * [errorCode] is the peer's QUIC application error code from quiche's `out_error_code` out-parameter,
+ * meaningful only when [result] is `STREAM_STOPPED`/`STREAM_RESET`. It is `null` when the backend does
+ * not surface it (the JNI binding) so callers can tell "code unknown" from a real code of `0` — see
+ * [QuicStreamAbort.applicationErrorCode].
+ */
+class StreamSendResult(
+    val result: Int,
+    val errorCode: Long? = null,
+)

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicServerTestSuite.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicServerTestSuite.kt
@@ -277,17 +277,25 @@ abstract class QuicServerTestSuite {
                             serverReadFirst.await()
 
                             // The peer reset must surface here as a STREAM error, not a connection close.
-                            assertFailsWith<QuicStreamException>(
-                                "a peer stream reset must be a QuicStreamException, not a connection-level QuicCloseException",
-                            ) {
-                                repeat(50) {
-                                    val ping = BufferFactory.deterministic().allocate(4)
-                                    ping.writeString("ping", Charset.UTF8)
-                                    ping.resetForRead()
-                                    s1.write(ping, 5.seconds)
-                                    delay(100)
+                            val streamError =
+                                assertFailsWith<QuicStreamException>(
+                                    "a peer stream reset must be a QuicStreamException, not a connection-level QuicCloseException",
+                                ) {
+                                    repeat(50) {
+                                        val ping = BufferFactory.deterministic().allocate(4)
+                                        ping.writeString("ping", Charset.UTF8)
+                                        ping.resetForRead()
+                                        s1.write(ping, 5.seconds)
+                                        delay(100)
+                                    }
                                 }
-                            }
+                            // The peer's application error code must round-trip via quiche's out_error_code
+                            // on every quiche backend (FFM on JDK 21, JNI on JDK < 21, cinterop on K/N).
+                            assertEquals(
+                                0x10cL,
+                                streamError.abort.applicationErrorCode,
+                                "the peer STOP_SENDING/RESET application error code must be surfaced",
+                            )
 
                             // Connection survived: a fresh stream still round-trips.
                             val s2 = openStream()

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/StubQuicheApi.kt
@@ -210,13 +210,16 @@ internal class StubQuicheApi : QuicheApi {
     /** When set, [connStreamSend] returns this instead of [bufLen] — e.g. -1 (QUICHE_ERR_DONE) or a real error. */
     @Volatile var connStreamSendResult: Int? = null
 
+    /** Peer application error code [connStreamSend] reports alongside a STREAM_STOPPED/RESET result. */
+    @Volatile var connStreamSendErrorCode: Long? = null
+
     override fun connStreamSend(
         conn: QuicheConn,
         streamId: QuicStreamId,
         buf: Long,
         bufLen: Int,
         fin: Boolean,
-    ) = connStreamSendResult ?: bufLen
+    ) = StreamSendResult(connStreamSendResult ?: bufLen, connStreamSendErrorCode)
 
     /** Records each [connStreamShutdown] call as (streamId, direction, errorCode) so tests can assert resets. */
     val streamShutdowns = mutableListOf<Triple<Long, Int, Long>>()

--- a/socket-quic/src/jni/quiche_jni.c
+++ b/socket-quic/src/jni/quiche_jni.c
@@ -206,12 +206,27 @@ JNIEXPORT jlong JNICALL JNI_FN(nConnStreamRecv)(
 
 JNIEXPORT jint JNICALL JNI_FN(nConnStreamSend)(
     JNIEnv *env, jclass cls,
-    jlong conn, jlong stream_id, jlong buf, jint buf_len, jboolean fin) {
+    jlong conn, jlong stream_id, jlong buf, jint buf_len, jboolean fin, jlong error_out) {
     uint64_t error_code = 0;
-    return (jint)quiche_conn_stream_send(
+    jint result = (jint)quiche_conn_stream_send(
         (quiche_conn *)(uintptr_t)conn, (uint64_t)stream_id,
         (const uint8_t *)(uintptr_t)buf, (size_t)buf_len,
         (bool)fin, &error_code);
+    /* error_code is only meaningful on STREAM_STOPPED / STREAM_RESET; quiche leaves it 0 otherwise.
+       Write it big-endian into the caller's 8-byte native scratch (a buffer address, not a Java array —
+       FastNative-safe) so the JVM reads it back order-independently. */
+    if (error_out != 0) {
+        uint8_t *p = (uint8_t *)(uintptr_t)error_out;
+        p[0] = (uint8_t)(error_code >> 56);
+        p[1] = (uint8_t)(error_code >> 48);
+        p[2] = (uint8_t)(error_code >> 40);
+        p[3] = (uint8_t)(error_code >> 32);
+        p[4] = (uint8_t)(error_code >> 24);
+        p[5] = (uint8_t)(error_code >> 16);
+        p[6] = (uint8_t)(error_code >> 8);
+        p[7] = (uint8_t)(error_code);
+    }
+    return result;
 }
 
 /* Shut down one direction of a stream with an application error code:

--- a/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
+++ b/socket-quic/src/jvm21Main/kotlin/com/ditchoom/socket/quic/FfmQuicheApi.kt
@@ -469,10 +469,18 @@ class FfmQuicheApi private constructor(
         buf: Long,
         bufLen: Int,
         fin: Boolean,
-    ): Int =
+    ): StreamSendResult =
         Arena.ofConfined().use { arena ->
             val errOut = arena.allocate(JAVA_LONG)
-            (hStreamSend.invokeExact(seg(conn.handle), streamId.id, seg(buf), bufLen.toLong(), fin, errOut) as Long).toInt()
+            val result = (hStreamSend.invokeExact(seg(conn.handle), streamId.id, seg(buf), bufLen.toLong(), fin, errOut) as Long).toInt()
+            // quiche fills out_error_code only on STREAM_STOPPED / STREAM_RESET.
+            val errorCode =
+                if (result == QuicheDriver.QUICHE_ERR_STREAM_STOPPED || result == QuicheDriver.QUICHE_ERR_STREAM_RESET) {
+                    errOut.get(JAVA_LONG, 0)
+                } else {
+                    null
+                }
+            StreamSendResult(result, errorCode)
         }
 
     override fun connStreamShutdown(

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/CinteropQuicheApi.kt
@@ -320,17 +320,26 @@ internal object CinteropQuicheApi : QuicheApi {
         buf: Long,
         bufLen: Int,
         fin: Boolean,
-    ): Int {
+    ): StreamSendResult {
         memScoped {
             val errorCode = alloc<ULongVar>()
-            return quiche_conn_stream_send(
-                conn.handle.toCPointer()!!,
-                streamId.id.convert(),
-                if (bufLen > 0) buf.toCPointer<UByteVar>() else null,
-                bufLen.convert(),
-                fin,
-                errorCode.ptr,
-            ).toInt()
+            val result =
+                quiche_conn_stream_send(
+                    conn.handle.toCPointer()!!,
+                    streamId.id.convert(),
+                    if (bufLen > 0) buf.toCPointer<UByteVar>() else null,
+                    bufLen.convert(),
+                    fin,
+                    errorCode.ptr,
+                ).toInt()
+            // quiche fills out_error_code only on STREAM_STOPPED / STREAM_RESET.
+            val peerCode =
+                if (result == QuicheDriver.QUICHE_ERR_STREAM_STOPPED || result == QuicheDriver.QUICHE_ERR_STREAM_RESET) {
+                    errorCode.value.toLong()
+                } else {
+                    null
+                }
+            return StreamSendResult(result, peerCode)
         }
     }
 


### PR DESCRIPTION
## What

WebTransport stream resets must remap the 32-bit application error code into the HTTP/3 error-code space (draft-ietf-webtrans-http3 §4.3) so they don't collide with HTTP/3, QUIC, or other-extension codes on `RESET_STREAM` / `STOP_SENDING`. Today `WebTransportStream.reset` / `WebTransportSendStream.reset` / `WebTransportReceiveStream.cancel` pass the raw WebTransport code straight to QUIC; this maps it on send and decodes it back on receive.

## `:socket-http3`

- **`WebTransportWire.toHttp3ErrorCode(n) = BASE + n + n/0x1e`** and the inverse `toWebTransportErrorCode(h)` (`BASE = 0x52e4a40fa8db`), with exhaustive round-trip + GREASE-slot unit tests (jvm/js/linux).
- **Encode on send:** `WebTransportStream.reset` / `WebTransportSendStream.reset` / `WebTransportReceiveStream.cancel` map the code before it reaches QUIC.
- **Decode on receive:** new `WebTransportStreamException(errorCode)`; the WT stream `write()` catches `QuicStreamException` and decodes the peer's code back to the original WebTransport value.
- **Loopback E2E** `webTransport_streamReset_codeRoundTripsThroughHttp3Space` (jvm + linuxX64): server resets an incoming stream, the client's next write observes the decoded WT code.

## `:socket-quic` — surface the peer's application error code on the write path

quiche 0.28's `quiche_conn_stream_send` fills `out_error_code` on `STREAM_STOPPED` / `STREAM_RESET`; it was being allocated-then-discarded. Threaded through a new `StreamSendResult(result, errorCode)` into `QuicStreamAbort.applicationErrorCode` on **all three quiche backends**:

- **FFM / cinterop** read their existing out-var.
- **JNI** gains a `jlong error_out` **native-address** param (a buffer's `nativeAddress`, *not* a Java array — `@FastNative`-safe, mirroring the existing `nConnPathEventNext` out-pointer convention), with a big-endian write in the C shim and an absolute-index readback on the Kotlin side. The JNI C shim rebuilds from source — **no prebuilt-binary change**.
- `QuicServerTestSuite.peerStreamResetSurfacesAsStreamErrorAndConnectionStaysUsable` now asserts the peer code round-trips (jvm-JNI + linuxX64-cinterop).

The **read** path stays code-less by design: quiche maps a recv-side reset to `ReadResult.End`, and `ReadResult.Reset` is a code-less `data object` in the pinned, published `com.ditchoom:buffer` dependency — so receive-side observation is write-path-only.

## Verified locally

- `:socket-http3` jvmTest + jsNodeTest + linuxX64Test (incl. the new codec unit tests + loopback round-trip)
- `:socket-quic` jvmTest (JNI, rebuilt shim) + linuxX64Test + the tightened reset regression guard
- ktlint clean on both modules