### PR TITLE
feat(webtransport): send WT_DRAIN_SESSION + surface peer drain (draft §5)

### DIFF
--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportMux.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportMux.kt
@@ -310,7 +310,12 @@ internal class WebTransportMux(
                     session.onPeerClosed(info)
                     return true
                 }
-                // WT_DRAIN_SESSION and unknown capsule types: skip the value and continue.
+                WebTransportWire.WT_DRAIN_SESSION -> {
+                    // The peer is winding the session down (draft §5); surface it but keep the session
+                    // open so in-flight streams/datagrams finish. The value is empty (length honoured).
+                    session.onPeerDrain()
+                }
+                // Unknown capsule types: skip the value (already consumed via readBuffer) and continue.
                 else -> {}
             }
         }
@@ -353,6 +358,23 @@ internal class WebTransportMux(
             capsule.freeIfNeeded()
         }
         connectStream.shutdownSend()
+    }
+
+    /**
+     * Send a WT_DRAIN_SESSION capsule (draft-ietf-webtrans-http3 §5) inside a DATA frame on
+     * [connectStream] **without** FIN-ing it: the session stays open so in-flight streams/datagrams can
+     * still finish, while the peer learns we are winding down. Mirrors [sendCloseCapsule] minus the
+     * shutdown.
+     */
+    suspend fun sendDrainCapsule(connectStream: QuicByteStream) {
+        val capsule = pool.allocate(WebTransportWire.drainSessionCapsuleSize())
+        try {
+            WebTransportWire.writeDrainSessionCapsule(capsule)
+            capsule.resetForRead()
+            writeDataFrame(connectStream, capsule)
+        } finally {
+            capsule.freeIfNeeded()
+        }
     }
 
     /** Wrap [payload] in an HTTP/3 DATA frame and write it whole to [stream]. */

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportSession.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportSession.kt
@@ -3,10 +3,12 @@ package com.ditchoom.socket.http3
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.socket.quic.QuicByteStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlin.concurrent.Volatile
 
@@ -53,6 +55,19 @@ class WebTransportSession internal constructor(
 
     private val closedSignal = CompletableDeferred<WebTransportCloseInfo>()
 
+    // true once the peer has requested a drain; false if the session ends with no drain ever seen.
+    // Completing it on close lets the [drained] flow terminate instead of hanging a collector forever.
+    private val drainSignal = CompletableDeferred<Boolean>()
+
+    @Volatile
+    private var _isDrainRequested = false
+
+    @Volatile
+    private var localDrainSent = false
+
+    /** True once the peer has asked this session to drain (WT_DRAIN_SESSION, draft §5). */
+    val isDrainRequested: Boolean get() = _isDrainRequested
+
     // Peer-initiated streams, fed by the connection's router via the mux. UNLIMITED: a burst of
     // incoming streams must never block the router thread.
     private val incomingBidi = Channel<WebTransportStream>(Channel.UNLIMITED)
@@ -80,6 +95,14 @@ class WebTransportSession internal constructor(
      */
     val datagrams: Flow<ReadBuffer> get() = incomingDatagrams.receiveAsFlow()
 
+    /**
+     * Emits exactly once when the peer asks this session to drain (WT_DRAIN_SESSION,
+     * draft-ietf-webtrans-http3 §5): the peer is winding the session down and the application should
+     * stop opening new streams, though in-flight streams and datagrams still finish until [close].
+     * Completes without emitting if the session ends before any drain arrives.
+     */
+    val drained: Flow<Unit> get() = flow { if (drainSignal.await()) emit(Unit) }
+
     /** Suspends until the session ends, returning why. */
     suspend fun awaitClosed(): WebTransportCloseInfo = closedSignal.await()
 
@@ -102,6 +125,24 @@ class WebTransportSession internal constructor(
     suspend fun sendDatagram(payload: ReadBuffer) {
         check(!isClosed) { "session $sessionId is closed" }
         mux.sendDatagram(sessionId, payload)
+    }
+
+    /**
+     * Ask the peer to wind this session down (WT_DRAIN_SESSION, draft-ietf-webtrans-http3 §5) **without**
+     * closing it: send a WT_DRAIN_SESSION capsule on the CONNECT stream so the peer learns it should stop
+     * opening new streams, while in-flight streams and datagrams still finish. The session stays open
+     * until [close]. Idempotent, and a no-op once the session is closed.
+     */
+    suspend fun drain() {
+        if (isClosed || localDrainSent) return
+        localDrainSent = true
+        try {
+            mux.sendDrainCapsule(connectStream)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // Connection/stream already gone — nothing left to wind down.
+        }
     }
 
     /**
@@ -136,12 +177,19 @@ class WebTransportSession internal constructor(
         incomingDatagrams.trySend(buffer) // DROP_OLDEST: always accepted; the dropped buffer is freed
     }
 
+    /** Called by the mux's capsule loop when the peer sends WT_DRAIN_SESSION (draft §5). Idempotent. */
+    internal fun onPeerDrain() {
+        _isDrainRequested = true
+        drainSignal.complete(true)
+    }
+
     /** Called by the mux's capsule loop when the peer ends the CONNECT stream (FIN or close capsule). */
     internal suspend fun onPeerClosed(info: WebTransportCloseInfo) = finish(info)
 
     private suspend fun finish(info: WebTransportCloseInfo) {
         if (!closedSignal.complete(info)) return // already closed
         _closeInfo = info
+        drainSignal.complete(false) // no-op if a drain already arrived; else unblocks [drained] collectors
         incomingBidi.close()
         incomingUni.close()
         incomingDatagrams.close()

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportWire.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportWire.kt
@@ -31,7 +31,7 @@ internal object WebTransportWire {
     /** WT_CLOSE_SESSION capsule type (draft-ietf-webtrans-http3 §6): graceful session close. */
     const val WT_CLOSE_SESSION: Long = 0x2843
 
-    /** WT_DRAIN_SESSION capsule type (draft-ietf-webtrans-http3 §4.6): graceful drain request. */
+    /** WT_DRAIN_SESSION capsule type (draft-ietf-webtrans-http3 §5): graceful drain request. */
     const val WT_DRAIN_SESSION: Long = 0x78ae
 
     /** draft-ietf-webtrans-http3 §6: the application error message is capped at 1024 UTF-8 bytes. */
@@ -83,6 +83,18 @@ internal object WebTransportWire {
     fun closeSessionCapsuleSize(reasonUtf8Bytes: Int): Int {
         val valueLen = 4 + reasonUtf8Bytes // u32 error code + reason bytes
         return VarIntCodec.encodedLength(WT_CLOSE_SESSION) + VarIntCodec.encodedLength(valueLen.toLong()) + valueLen
+    }
+
+    /** Encoded byte length of a WT_DRAIN_SESSION capsule (Type + zero Length, no value). */
+    fun drainSessionCapsuleSize(): Int = VarIntCodec.encodedLength(WT_DRAIN_SESSION) + VarIntCodec.encodedLength(0L)
+
+    /**
+     * Write a WT_DRAIN_SESSION capsule (Type, Length=0; the capsule carries no value) to [buffer]
+     * (draft-ietf-webtrans-http3 §5). Signals that the session is winding down without closing it.
+     */
+    fun writeDrainSessionCapsule(buffer: WriteBuffer) {
+        VarIntCodec.encode(buffer, WT_DRAIN_SESSION, EncodeContext.Empty)
+        VarIntCodec.encode(buffer, 0L, EncodeContext.Empty)
     }
 
     /**

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -1243,6 +1243,55 @@ abstract class Http3LoopbackTestSuite {
                 }
             }
         }
+
+    // --- WebTransport WT_DRAIN_SESSION (draft-ietf-webtrans-http3 §5) ---
+
+    @Test
+    fun webTransport_serverDrains_clientObservesDrainThenBothCloseCleanly() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                val serverClose = CompletableDeferred<WebTransportCloseInfo>()
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        // Wind the session down without closing it, then wait for the client's clean close.
+                        session.drain()
+                        serverClose.complete(session.awaitClosed())
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 4),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        val session = connectWebTransport(authority = "localhost", path = "/wt")
+                        // The peer's drain is surfaced reactively; it must NOT close the session.
+                        withTimeout(5.seconds) { session.drained.first() }
+                        assertTrue(session.isDrainRequested)
+                        assertFalse(session.isClosed, "WT_DRAIN_SESSION must not close the session")
+                        // Now finish cleanly from the client side.
+                        session.close(code = 0, reason = "drained, closing")
+                        assertTrue(session.isClosed)
+                        delay(300) // let the WT_CLOSE_SESSION capsule + FIN flush before teardown
+                    }
+                    assertEquals(
+                        WebTransportCloseInfo(0, "drained, closing"),
+                        withTimeout(5.seconds) { serverClose.await() },
+                    )
+                }
+            }
+        }
 }
 
 /** Read a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -1292,6 +1292,142 @@ abstract class Http3LoopbackTestSuite {
                 }
             }
         }
+
+    @Test
+    fun webTransport_clientDrains_serverObservesDrain() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // The mirror of the server-drain case: drain() and the drained signal are role-agnostic
+                // (the shared mux), so a client-initiated drain must surface on the server while open.
+                val serverObservedWhileOpen = CompletableDeferred<Boolean>()
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        withTimeout(5.seconds) { session.drained.first() }
+                        // Only the drain is in flight here (the client waits for our close before closing),
+                        // so observing it while still open is deterministic. Then we finish the session.
+                        serverObservedWhileOpen.complete(session.isDrainRequested && !session.isClosed)
+                        session.close(code = 0, reason = "server done")
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 4),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        val session = connectWebTransport(authority = "localhost", path = "/wt")
+                        session.drain()
+                        assertFalse(session.isClosed, "draining our own session must not close it")
+                        // Let the server observe our drain and close back; we don't close first.
+                        withTimeout(5.seconds) { session.awaitClosed() }
+                    }
+                    assertTrue(
+                        withTimeout(5.seconds) { serverObservedWhileOpen.await() },
+                        "server must observe the drain while the session is still open",
+                    )
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_drainKeepsTheTransportUsable() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // draft §5: a drain only signals intent — the session stays open and streams keep working.
+                // Enforcement (stop opening new streams) is the application's choice, not the transport's.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        session.drain()
+                        // A stream still flows after the drain is sent.
+                        val stream = session.incomingBidiStreams.first()
+                        val msg = stream.readUtf8()
+                        stream.write(textBuffer("echo:$msg"))
+                        stream.close()
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    val reply =
+                        withHttp3Connection(
+                            "localhost",
+                            port,
+                            clientQuicOptions,
+                            connectionOptions,
+                            15.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 4),
+                        ) {
+                            withTimeout(5.seconds) { peerSettings() }
+                            val session = connectWebTransport(authority = "localhost", path = "/wt")
+                            withTimeout(5.seconds) { session.drained.first() }
+                            assertFalse(session.isClosed, "drain must not close the session")
+                            // Open + round-trip a stream AFTER observing the drain.
+                            val stream = session.openBidiStream()
+                            stream.write(textBuffer("after-drain"))
+                            stream.shutdownSend()
+                            withTimeout(5.seconds) { stream.readUtf8() }
+                        }
+                    assertEquals("echo:after-drain", reply)
+                }
+            }
+        }
+
+    @Test
+    fun webTransport_drainedFlowCompletesWithoutEmitting_whenSessionClosesUndrained() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // The no-hang guarantee: a `drained` collector must terminate (emitting nothing) when the
+                // session ends without ever being drained, rather than awaiting a drain that never comes.
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    webTransport = WebTransportOptions(maxSessions = 4),
+                    onWebTransport = {
+                        val session = accept()
+                        session.close(code = 0, reason = "no drain") // close without ever draining
+                    },
+                    onRequest = { response.send(404) },
+                ) {
+                    delay(100)
+                    withHttp3Connection(
+                        "localhost",
+                        port,
+                        clientQuicOptions,
+                        connectionOptions,
+                        15.seconds,
+                        webTransport = WebTransportOptions(maxSessions = 4),
+                    ) {
+                        withTimeout(5.seconds) { peerSettings() }
+                        val session = connectWebTransport(authority = "localhost", path = "/wt")
+                        withTimeout(5.seconds) { session.awaitClosed() }
+                        // drainSignal completed `false` on close → the flow finishes with no element.
+                        assertTrue(
+                            withTimeout(5.seconds) { session.drained.toList() }.isEmpty(),
+                            "drained must complete without emitting when no drain ever arrived",
+                        )
+                        assertFalse(session.isDrainRequested)
+                    }
+                }
+            }
+        }
 }
 
 /** Read a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportCapsuleTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportCapsuleTests.kt
@@ -67,6 +67,22 @@ class WebTransportCapsuleTests {
     }
 
     @Test
+    fun drainCapsule_encodesTypeAndZeroLength() {
+        val size = WebTransportWire.drainSessionCapsuleSize()
+        val buffer: PlatformBuffer = BufferFactory.deterministic().allocate(size)
+        WebTransportWire.writeDrainSessionCapsule(buffer)
+        assertEquals(size, buffer.position(), "writer must emit exactly drainSessionCapsuleSize bytes")
+        buffer.resetForRead()
+
+        // Parse it the way the capsule loop does: Type, then a zero-length value.
+        val type = VarIntCodec.decode(buffer, DecodeContext.Empty)
+        assertEquals(WebTransportWire.WT_DRAIN_SESSION, type)
+        val length = VarIntCodec.decode(buffer, DecodeContext.Empty).toInt()
+        assertEquals(0, length, "WT_DRAIN_SESSION carries no value")
+        assertEquals(0, buffer.remaining(), "no bytes follow the zero-length value")
+    }
+
+    @Test
     fun quarterStreamId_dividesByFour() {
         // CONNECT streams are client-initiated bidirectional (id % 4 == 0), so the division is exact.
         assertEquals(0L, WebTransportWire.quarterStreamId(0))


### PR DESCRIPTION
## Summary

Today we only **receive and skip** `WT_DRAIN_SESSION` (capsule type `0x78ae`, draft-ietf-webtrans-http3 §5). This adds the ability to **initiate** and **observe** a graceful drain — telling the peer a session is winding down so it stops opening new streams, while in-flight streams and datagrams still finish and the session stays open until a later `close()`.

## Changes

- **`WebTransportWire`** — `drainSessionCapsuleSize()` / `writeDrainSessionCapsule()` encode the zero-value capsule (Type + Length=0), mirroring the `WT_CLOSE_SESSION` codec pair. Also corrected the `WT_DRAIN_SESSION` doc reference (§4.6 → §5).
- **`WebTransportMux`** — `sendDrainCapsule()` emits the capsule inside an HTTP/3 DATA frame **without** FIN-ing the CONNECT stream (mirrors `sendCloseCapsule` minus the shutdown), so the session keeps running. The capsule loop now acts on a received `WT_DRAIN_SESSION` (surfaces it to the session) instead of silently skipping it.
- **`WebTransportSession`** — `drain()` sends the capsule (idempotent; a no-op once closed). The peer's drain is surfaced via a `drained: Flow<Unit>` plus an `isDrainRequested` flag. The internal drain signal also completes on session close, so a `drained` collector never hangs when a session ends without ever draining.

## Tests

- **Pure capsule codec** (`WebTransportCapsuleTests.drainCapsule_encodesTypeAndZeroLength`) — round-trips the Type + zero-length value, asserts exact byte count and no trailing bytes.
- **Loopback E2E** (`Http3LoopbackTestSuite.webTransport_serverDrains_clientObservesDrainThenBothCloseCleanly`) — server `drain()`s; client observes `session.drained.first()`, asserts `isDrainRequested && !isClosed`, then closes cleanly; the server's `awaitClosed()` sees the client's close info.

## Verification

| Target | Result |
|---|---|
| `ktlintCheck` | ✅ |
| `jvmTest` (capsule + E2E) | ✅ |
| `linuxX64Test` (capsule + E2E) | ✅ |
| `jsNodeTest` (capsule) | ✅ |

(The loopback suite has only JVM and linuxX64 subclasses — JS QUIC is unsupported — so the pure capsule test is the JS coverage.)

Branched off `main` (on top of #144).