### PR TITLE
test(quic): fix ManualDriverClock initial-arm race (CI keepalive flake)

### DIFF
--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ManualDriverClock.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ManualDriverClock.kt
@@ -31,8 +31,11 @@ internal class ManualDriverClock : DriverClock {
     private val ticks = Channel<Unit>(Channel.RENDEZVOUS)
 
     /** One token per arm, i.e. each time the loop is about to park in `select`. UNLIMITED so it never drops;
-     *  [advance] drains stale tokens then waits for the *post-fire* re-arm to know the branch fully ran. */
+     *  [advance] waits for the *post-fire* re-arm to know the branch fully ran. */
     private val rearmed = Channel<Unit>(Channel.UNLIMITED)
+
+    /** Set once the driver's very first arm token (emitted before any fire) has been consumed. */
+    private var initialArmConsumed = false
 
     override fun markNow(): TimeMark {
         val origin = elapsed
@@ -62,11 +65,26 @@ internal class ManualDriverClock : DriverClock {
      * and this will suspend until the run's timeout.
      */
     suspend fun advance(by: Duration) {
-        // Drop any stale "armed" tokens so the wait below pairs with the re-arm caused by THIS fire.
-        while (rearmed.tryReceive().isSuccess) { /* drain */ }
+        consumeInitialArm()
         elapsed += by
         ticks.send(Unit) // rendezvous: driver is parked, takes the tick, runs the branch, then re-arms
         rearmed.receive() // the re-arm — branch body has finished, its effect is now observable
+    }
+
+    /**
+     * Consume the driver's very first arm token — the one emitted before any fire — exactly once, with a
+     * **blocking** receive rather than a `tryReceive` drain. `armTimeout` does its `rearmed.trySend` *before*
+     * the `select` actually parks, so a `tryReceive` drain on the test thread can run before that send and
+     * miss the token; the stale token then pairs with the *next* fire's re-arm wait, returning before the
+     * timer branch ran. A blocking receive cannot miss it — it simply waits for the trySend — which is what
+     * makes [advance]/[fireExpectingNoRearm] race-free under scheduler pressure. (The driver arms exactly
+     * once before the first fire, so there is never more than this one token to clear.)
+     */
+    private suspend fun consumeInitialArm() {
+        if (!initialArmConsumed) {
+            rearmed.receive()
+            initialArmConsumed = true
+        }
     }
 
     /**
@@ -75,7 +93,7 @@ internal class ManualDriverClock : DriverClock {
      * instead (e.g. `driver.state.first { it is Closed }`), not on a re-arm that will never come.
      */
     suspend fun fireExpectingNoRearm(by: Duration) {
-        while (rearmed.tryReceive().isSuccess) { /* drain */ }
+        consumeInitialArm()
         elapsed += by
         ticks.send(Unit)
     }

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/ReactiveDriverTests.kt
@@ -10,6 +10,7 @@ import com.ditchoom.socket.SocketClosedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -751,6 +752,40 @@ class ReactiveDriverTests {
                 }
             } finally {
                 driver.commands.close()
+            }
+        }
+
+    @Test
+    fun keepAlive_manualClock_stress_manyConcurrentDriversStayDeterministic() =
+        runQuicTest {
+            // Regression guard for the ManualDriverClock initial-arm race (the FFM/JDK17 CI flake): a single
+            // driver rarely loses the advance()-vs-armTimeout-trySend window on a fast box, so fan out many
+            // independent driver+clock pairs advancing concurrently on Dispatchers.Default. Each pair's FIRST
+            // advance is the racy one, so 64 of them per run multiplies the exposure by ~64×. Every fire must
+            // still be observed on return for every driver.
+            val drivers = 64
+            val firesEach = 40
+            coroutineScope {
+                repeat(drivers) { d ->
+                    launch {
+                        val api = StubQuicheApi()
+                        val clock = ManualDriverClock()
+                        val driver = createTestDriver(api, keepAliveInterval = 1.seconds, clock = clock)
+                        driver.start(this)
+                        try {
+                            repeat(firesEach) { i ->
+                                clock.advance(1.seconds)
+                                assertEquals(
+                                    i + 1,
+                                    api.ackElicitingCount,
+                                    "driver $d: fire ${i + 1} not observed on return — advance() raced the timer branch",
+                                )
+                            }
+                        } finally {
+                            driver.commands.close()
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

`ReactiveDriverTests.keepAlive_manualClock_isDeterministicUnderRepeatedFires` intermittently fails on the **FFM** and **JDK 17 / JNI** `:socket-quic:jvmTest` lanes with:

```
fire 1 not observed on return — advance() raced the timer branch  expected:<1> but was:<0>
```

It surfaced on PR #145's CI (an unrelated `:socket-http3` change) and is pre-existing on `main`.

## Root cause — a TOCTOU in `ManualDriverClock`

The driver's `armTimeout` emits the "armed" token **before** the `select` actually parks:

```kotlin
override fun armTimeout(builder, wait) {
    rearmed.trySend(Unit)              // (A) token sent BEFORE the select parks
    with(builder) { ticks.onReceive { null } }  // (B) clause registered, then suspends
}
```

`advance()` started with a non-blocking drain:

```kotlin
while (rearmed.tryReceive().isSuccess) {}   // races (A)
elapsed += by
ticks.send(Unit)                            // fire
rearmed.receive()                           // wait for re-arm
```

On the **first** `advance()`, if the test thread runs its `tryReceive` drain before the driver thread does its `trySend` (legal — different threads), the **initial arm token survives the drain**. Then `rearmed.receive()` pairs the fire with that *stale pre-fire token* and returns **before** `connSendAckEliciting` (the count++) has run, so the count is one behind. It only manifests under scheduler pressure, which is why the loaded FFM/JDK17 CI lanes hit it and a fast dev box (8/8 local) did not.

Steady-state advances were already race-free (each consumes exactly its own post-fire re-arm and leaves the channel empty) — **only the initial token** was the problem.

## Fix

Replace the racy `tryReceive` drain with a one-time **blocking** receive of the initial arm token (`consumeInitialArm()`). A blocking receive cannot miss the token — it simply waits for the `trySend`. The driver arms exactly once before the first fire (all 6 `ManualDriverClock` users do `start` then `advance`/`fire` with no command in between), so there's never more than one token to clear. `fireExpectingNoRearm` gets the same treatment.

## Validation

Added `keepAlive_manualClock_stress_manyConcurrentDriversStayDeterministic` — 64 concurrent driver+clock pairs on `Dispatchers.Default`, multiplying first-`advance()` race exposure ~64×.

| | Result |
|---|---|
| Stress test vs **old** racy drain | **4/15 runs failed** — always on "fire 1", `expected:<1> but was:<0>` |
| Stress test vs **fix** | green (6/6 jvm + 4/4 extra linuxX64) |
| Full `ReactiveDriverTests` | green on **jvm + linuxX64** |
| ktlint | clean |

This unblocks the FFM/JDK17 lanes that have been intermittently failing PR CI. Branched off `main`.