### PR TITLE
fix(webtransport): register session before sending CONNECT 200 (server demux race)

### DIFF
--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3ServerConnection.kt
@@ -268,14 +268,23 @@ class Http3ServerConnection internal constructor(
         return acceptedSession != null
     }
 
-    /** Accept a WebTransport session: send 200 (no FIN — the CONNECT stream stays open), register it. */
+    /** Accept a WebTransport session: register it, then send 200 (no FIN — the CONNECT stream stays open). */
     private suspend fun acceptWebTransport(
         stream: QuicByteStream,
         reader: Http3StreamReader,
     ): WebTransportSession {
-        sendWebTransportResponse(stream, 200, fin = false)
         val mux = webTransportMux ?: error("WebTransport accepted without an enabled mux")
+        // Table the session BEFORE the 200 can be observed by the client. The client may open a
+        // WebTransport stream the instant it sees the 200 (draft-ietf-webtrans-http3 §4.2); if that
+        // stream reaches our demux before the session is registered, the demux treats it as orphaned and
+        // resets it. Registering first makes the session visible no later than the response itself.
         val session = mux.preRegister(stream)
+        try {
+            sendWebTransportResponse(stream, 200, fin = false)
+        } catch (e: Throwable) {
+            mux.abandon(session) // CONNECT response never reached the peer — untable the half-open session.
+            throw e
+        }
         // The CONNECT stream stays open; its capsule loop owns the reader and ends the session on FIN
         // or a WT_CLOSE_SESSION capsule.
         mux.activate(session, reader)


### PR DESCRIPTION
## Problem

`webTransport_clientOpensBidiStream_serverEchoes` (the `:socket-http3` loopback echo) is an intermittent timeout flake on WebTransport PRs — it flaked once during #146 CI and cleared on rerun. Root cause is a real server-side race, not test timing.

## Root cause

`Http3ServerConnection.acceptWebTransport` sent the Extended CONNECT **200 before** tabling the session in `WebTransportMux`:

```kotlin
sendWebTransportResponse(stream, 200, fin = false)  // 200 sent first
val session = mux.preRegister(stream)               // registered after
```

The client returns from `connectWebTransport` the moment it sees the 200 and may immediately open a WebTransport stream (draft-ietf-webtrans-http3 §4.2). If that stream reaches the server's demux before `preRegister` ran, `session(sessionId)` returns null and the stream is **reset as orphaned** → the client's `readUtf8()` hangs to the 5s timeout.

This is an asymmetry: the **client** path (`Http3Connection.connectWebTransport`) already preRegisters *before* reading the CONNECT status, with abandon-on-failure, precisely to avoid the mirror race. The server didn't.

## Fix

Reorder to **preRegister → send 200**, with `abandon` on write failure to untable a half-open session. The session is now visible no later than the response itself, closing the window. Pure `commonMain` change (applies to all platforms).

## Verification

- 20/20 green stress runs of the loopback echo test (`--rerun-tasks`)
- Full WebTransport + loopback JVM suite green
- ktlint clean