### PR TITLE
docs: QUIC, StreamMux, HTTP/3 & WebTransport guides + examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,45 @@ withQuicServer(port = 4433, tlsConfig = QuicTlsConfig(certChainPath, privKeyPath
 }
 ```
 
-Backed by quiche on JVM/Android (JNI on JDK ≤20, FFM on JDK 21+), quiche cinterop on Linux native, and Network.framework on Apple. JS/wasmJs throw `UnsupportedOperationException` (no raw UDP). Stream multiplexing via `withQuicMux(..., codec) { … }` for codec-typed sessions.
+Backed by quiche on JVM/Android (JNI on JDK ≤20, FFM on JDK 21+), quiche cinterop on Linux native, and Network.framework on Apple. JS/wasmJs throw `UnsupportedOperationException` (no raw UDP).
+
+Each `QuicByteStream` has independent send/receive sides: `write()`/`read()` for bytes, `shutdownSend()` to half-close the send side (FIN) for request/response, and `reset(errorCode)` to abort both directions. `read()` returns a `ReadResult` — `Data` (a buffer), `End` (peer FIN), or `Reset` (peer abort). Unreliable datagrams (RFC 9221) are available via `sendDatagram()`/`receiveDatagram()` when `QuicOptions.datagrams` is set.
+
+#### Typed stream multiplexing
+
+`withQuicMux(..., codec) { … }` layers a `Codec<T>` over the connection so each stream exchanges typed messages instead of raw buffers:
+
+```kotlin
+withQuicMux("localhost", port, quicOptions, StringCodec) {
+    val conn = openBidirectional()
+    conn.send("hello")
+    val reply = conn.receive().first() // "echo: hello"
+    conn.close()
+}
+```
+
+#### HTTP/3 & WebTransport — `socket-http3`
+
+`socket-http3` builds HTTP/3 (RFC 9114, with QPACK + server push) and WebTransport (RFC 9220) on top of `socket-quic`:
+
+```kotlin
+// HTTP/3 client request/response
+withHttp3Connection("example.com", 443) {
+    val response = request(Http3Request(method = "GET", authority = "example.com", path = "/"))
+    val body = response.readFullBody()
+    response.close()
+}
+
+// WebTransport session with its own multiplexed streams + datagrams
+withHttp3Connection("example.com", port, webTransport = WebTransportOptions(maxSessions = 4)) {
+    val session = connectWebTransport(authority = "example.com", path = "/wt")
+    val stream = session.openBidiStream()
+    stream.write(buf); stream.shutdownSend()
+    session.close()
+}
+```
+
+See the [QUIC][quic-docs] and [HTTP/3 & WebTransport][http3-docs] guides for the full API, including server roles, datagrams, and session drain/close.
 
 ## Error Handling
 
@@ -304,3 +342,5 @@ Socket builds on the [buffer v4](https://github.com/DitchOoM/buffer) library for
     limitations under the License.
 
 [docs]: https://ditchoom.github.io/socket/
+[quic-docs]: https://ditchoom.github.io/socket/quic/intro
+[http3-docs]: https://ditchoom.github.io/socket/http3/intro

--- a/docs/docs/http3/intro.md
+++ b/docs/docs/http3/intro.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 1
+title: HTTP/3
+---
+
+# HTTP/3
+
+`socket-http3` implements HTTP/3 (RFC 9114) — including QPACK header compression (RFC 9204), server
+push (§4.6), and the WebTransport extension (RFC 9220) — on top of `socket-quic`. It's a separate
+artifact:
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:socket-http3:<latest-version>")
+}
+```
+
+Like the rest of the stack, everything is scope-based: the connection (or server) lives for the
+duration of your block and tears down on exit. HTTP/3 inherits QUIC's platform support — JVM/Android,
+Linux native, and Apple; JS/wasmJs throw `UnsupportedOperationException`.
+
+## Client: Request / Response
+
+`withHttp3Connection` performs the QUIC handshake with the `h3` ALPN, bootstraps the HTTP/3 control
+and QPACK streams, and hands you an `Http3Connection`:
+
+```kotlin
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.freeIfNeeded
+
+val (status, text) = withHttp3Connection("example.com", port = 443) {
+    val response = request(
+        Http3Request(method = "GET", authority = "example.com", path = "/"),
+    )
+    try {
+        val body = response.readFullBody()        // collect the whole body
+        val text = body.readString(body.remaining(), Charset.UTF8)
+        body.freeIfNeeded()                        // you own the buffer
+        response.status to text
+    } finally {
+        response.close()                           // release the response reader
+    }
+}
+```
+
+For large or streamed responses, pull DATA frames one at a time with `response.nextBodyChunk()`
+(returns `null` at the end) instead of `readFullBody()`. Trailing headers, if any, land in
+`response.trailers`.
+
+### Streaming a request body
+
+To send a body incrementally instead of buffering it, use the lambda form — it hands you an
+`Http3RequestBody` you write DATA frames into:
+
+```kotlin
+val response = request(
+    method = "POST",
+    authority = "example.com",
+    path = "/upload",
+) {
+    // `this` is an Http3RequestBody — each write() sends one DATA frame, in order.
+    write(part1)
+    write(part2)
+}
+```
+
+## Server
+
+`withHttp3Server` binds a QUIC server and routes each request to your `onRequest` handler, which
+receives an `Http3ServerExchange` (its `request` and `response`):
+
+```kotlin
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+
+withHttp3Server(
+    port = 0, // ephemeral; read it back from `port`
+    tlsConfig = QuicTlsConfig(certChainPath = "cert.pem", privKeyPath = "key.pem"),
+    onRequest = {
+        when (request.path) {
+            "/hello" -> {
+                val body = BufferFactory.Default.allocate(64)
+                body.writeString("hello from h3", Charset.UTF8)
+                body.resetForRead()
+                response.send(
+                    status = 200,
+                    headers = listOf(QpackHeaderField("content-type", "text/plain")),
+                    body = body,
+                )
+            }
+            else -> response.send(404)
+        }
+    },
+) {
+    // `this` is the Http3Server; serve until this block is cancelled.
+    awaitCancellation()
+}
+```
+
+`response.send(...)` is the buffered convenience (headers + optional body + finish). For streamed
+responses, call `sendHeaders(status, headers)`, then `writeBody(chunk)` per DATA frame, and finally
+`sendTrailers(...)` if needed. Read a request body with `request.readFullBody()` or
+`request.nextBodyChunk()`.
+
+### Server push (RFC 9114 §4.6)
+
+From inside a handler, `push(...)` promises and sends an extra response the client didn't ask for
+(enable it client-side with `maxPushId >= 0` on `withHttp3Connection`, and collect `connection.pushes`):
+
+```kotlin
+onRequest = {
+    response.send(200, body = indexHtml)
+    push(path = "/style.css") {
+        send(200, body = css) // `this` is the pushed Http3ServerResponse
+    }
+}
+```
+
+## Next Steps
+
+- [WebTransport](./webtransport) — bidirectional sessions, streams, and datagrams over HTTP/3
+- [QUIC Overview](../quic/intro) — the transport HTTP/3 is built on

--- a/docs/docs/http3/webtransport.md
+++ b/docs/docs/http3/webtransport.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 2
+title: WebTransport
+---
+
+# WebTransport
+
+WebTransport (RFC 9220 + draft-ietf-webtrans-http3) runs bidirectional sessions over an HTTP/3
+connection. A session is established with an Extended CONNECT and then multiplexes its own streams
+and datagrams — think of it as a browser-friendly, multiplexed alternative to WebSocket built on
+QUIC.
+
+Enable it on both ends by passing `WebTransportOptions`. `maxSessions` is how many peer-initiated
+sessions you'll accept:
+
+```kotlin
+data class WebTransportOptions(val maxSessions: Long = 1)
+```
+
+## Establishing a Session
+
+The **client** calls `connectWebTransport` after confirming the peer advertised support (via
+`peerSettings()`):
+
+```kotlin
+withHttp3Connection(
+    "example.com", port,
+    webTransport = WebTransportOptions(maxSessions = 4),
+) {
+    check(peerSettings().webTransportSupported)
+    val session = connectWebTransport(authority = "example.com", path = "/wt")
+    // …use the session…
+    session.close()
+}
+```
+
+The **server** supplies an `onWebTransport` handler; call `accept()` to establish the session (or
+`reject(status)` to refuse):
+
+```kotlin
+withHttp3Server(
+    port = 0,
+    tlsConfig = QuicTlsConfig("cert.pem", "key.pem"),
+    webTransport = WebTransportOptions(maxSessions = 4),
+    onWebTransport = {
+        // `this` is a WebTransportServerExchange — inspect path/headers, then decide.
+        if (path == "/wt") {
+            val session = accept()
+            // …use the session…
+        } else {
+            reject(404)
+        }
+    },
+    onRequest = { response.send(404) }, // non-WebTransport requests
+) {
+    awaitCancellation()
+}
+```
+
+## Streams
+
+A session opens streams just like raw QUIC, but scoped to the session. Bidirectional streams are
+`WebTransportStream` (read + write); unidirectional ones split into `WebTransportSendStream` and
+`WebTransportReceiveStream`. They use the same `read(): ReadResult` / `write(buffer)` surface as
+`QuicByteStream`.
+
+```kotlin
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.flow.ReadResult
+
+// Client: open a bidi stream, send, half-close, read the reply.
+val stream = session.openBidiStream()
+
+val out = BufferFactory.Default.allocate(5)
+out.writeString("hello", Charset.UTF8)
+out.resetForRead()
+stream.write(out)
+out.freeIfNeeded()
+stream.shutdownSend()
+
+val reply = when (val r = stream.read()) {
+    is ReadResult.Data -> {
+        val s = r.buffer.readString(r.buffer.remaining(), Charset.UTF8)
+        r.buffer.freeIfNeeded()
+        s
+    }
+    ReadResult.End, ReadResult.Reset -> ""
+}
+stream.close()
+```
+
+The peer receives opened streams through flows on its session:
+
+```kotlin
+// Server: echo the first peer-opened bidirectional stream back with a prefix.
+val stream = session.incomingBidiStreams.first()
+val msg = when (val r = stream.read()) {
+    is ReadResult.Data -> r.buffer.readString(r.buffer.remaining(), Charset.UTF8).also { r.buffer.freeIfNeeded() }
+    ReadResult.End, ReadResult.Reset -> ""
+}
+val out = BufferFactory.Default.allocate(64)
+out.writeString("echo:$msg", Charset.UTF8)
+out.resetForRead()
+stream.write(out)
+out.freeIfNeeded()
+stream.close()
+```
+
+`incomingUniStreams: Flow<WebTransportReceiveStream>` is the unidirectional counterpart. To abort a
+stream, `reset(errorCode)` (bidi/send) or `cancel(errorCode)` (receive) — the WebTransport
+application code is mapped into the HTTP/3 error-code space per draft §4.3.
+
+## Datagrams
+
+A session sends and receives unreliable datagrams (RFC 9297), provided QUIC datagrams are enabled on
+the underlying connection:
+
+```kotlin
+// Send.
+val dgram = BufferFactory.Default.allocate(4)
+dgram.writeString("ping", Charset.UTF8)
+dgram.resetForRead()
+session.sendDatagram(dgram)
+dgram.freeIfNeeded()
+
+// Receive — you own each emitted buffer.
+val incoming = session.datagrams.first()
+incoming.freeIfNeeded()
+```
+
+## Draining and Closing
+
+Two distinct lifecycle signals:
+
+- **Drain** (`drain()`, draft §5) asks the peer to *stop opening new streams* while keeping the
+  session open so in-flight work finishes. The peer observes it via `isDrainRequested` or the
+  `drained: Flow<Unit>` (which emits once, or completes silently if the session closes first).
+- **Close** (`close(code, reason)`) ends the session with an application code + reason
+  (WT_CLOSE_SESSION capsule + FIN). It's idempotent, and `awaitClosed()` suspends until the session
+  ends, returning the `WebTransportCloseInfo`.
+
+```kotlin
+// Graceful wind-down: tell the peer to stop opening streams, drain in-flight work, then close.
+session.drain()
+// …finish outstanding streams/datagrams…
+session.close(code = 0, reason = "done")
+```
+
+On the peer:
+
+```kotlin
+session.drained.collect { /* stop opening new streams */ }
+val info = session.awaitClosed() // info.code, info.reason
+```
+
+## Next Steps
+
+- [HTTP/3](./intro) — the request/response and server-push layer beneath WebTransport
+- [QUIC: Connections & Streams](../quic/connection) — the stream model WebTransport streams inherit

--- a/docs/docs/quic/connection.md
+++ b/docs/docs/quic/connection.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 2
+title: Connections & Streams
+---
+
+# Connections & Streams
+
+A QUIC connection is a multiplexing fabric: you open as many streams as you need over it, and each
+stream is an independent, ordered, reliable byte channel (`QuicByteStream`). The connection also
+carries unreliable datagrams.
+
+## Client
+
+`withQuicConnection` opens a connection, runs your block with a `QuicScope` receiver, and closes the
+connection on exit:
+
+```kotlin
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.flow.ReadResult
+import kotlin.time.Duration.Companion.seconds
+
+val reply = withQuicConnection(
+    hostname = "example.com",
+    port = 443,
+    quicOptions = QuicOptions(alpnProtocols = listOf("h3")),
+    timeout = 15.seconds,
+) {
+    val stream = openStream()
+
+    // Write — buffers are written zero-copy; reset for read before handing them off.
+    val out = BufferFactory.Default.allocate(11)
+    out.writeString("hello quic!", Charset.UTF8)
+    out.resetForRead()
+    stream.write(out, 5.seconds)
+    out.freeIfNeeded()
+
+    // The peer is done sending us nothing more on the write side — half-close it (FIN).
+    stream.shutdownSend()
+
+    // Read the response.
+    val text = when (val r = stream.read(5.seconds)) {
+        is ReadResult.Data -> {
+            val s = r.buffer.readString(r.buffer.remaining(), Charset.UTF8)
+            r.buffer.freeIfNeeded()
+            s
+        }
+        ReadResult.End, ReadResult.Reset -> ""
+    }
+    stream.close()
+    text
+}
+```
+
+## Server
+
+`withQuicServer` binds a UDP socket and dispatches each accepted connection to a handler running on
+its own `QuicScope`. Pass `port = 0` for an OS-assigned ephemeral port (read it back from `port`).
+
+```kotlin
+withQuicServer(
+    port = 4433,
+    tlsConfig = QuicTlsConfig(certChainPath = "cert.pem", privKeyPath = "key.pem"),
+    quicOptions = QuicOptions(alpnProtocols = listOf("h3")),
+) {
+    connections {
+        // `this` is the per-connection QuicScope. Accept a peer-opened stream and echo it.
+        val stream = acceptStream()
+        when (val r = stream.read(5.seconds)) {
+            is ReadResult.Data -> stream.write(r.buffer, 5.seconds) // echo (zero-copy)
+            ReadResult.End, ReadResult.Reset -> {}
+        }
+        stream.close()
+    }
+}
+```
+
+`connections { … }` handles multiple connections concurrently — each invocation is a fresh scope.
+You can also collect `streams(): Flow<QuicByteStream>` to react to every peer-opened stream.
+
+## The `QuicByteStream` Lifecycle
+
+A stream has independent send and receive sides. The methods map directly onto QUIC frames:
+
+| Call | Effect |
+|------|--------|
+| `write(buffer, timeout)` | Send bytes (zero-copy; you retain ownership of `buffer`). |
+| `read(timeout): ReadResult` | Receive the next chunk. `Data` carries a buffer; `End` is the peer's FIN; `Reset` is a peer abort. |
+| `shutdownSend()` | Half-close the **send** side only (FIN). The read side stays open — this is the request/response pattern. Idempotent. |
+| `reset(errorCode)` | Abort **both** directions (`RESET_STREAM` + `STOP_SENDING`) with an application error code. Idempotent. |
+| `close()` | Graceful close (FIN). Idempotent. |
+
+`writeGathered(buffers, timeout)` does a scatter-gather write of several buffers as one operation.
+
+Each stream carries a `streamId: QuicStreamId` whose bits tell you `isClientInitiated` /
+`isServerInitiated` and `isBidirectional` / `isUnidirectional` (RFC 9000 §2.1).
+
+### Unidirectional streams
+
+`openUniStream()` opens a send-only stream. By convention you write a stream-type prefix as the
+first bytes, then `close()` sends the FIN. (Not all platforms support locally-opened uni streams;
+unsupported ones throw `UnsupportedOperationException`.)
+
+## Datagrams (RFC 9221)
+
+Unreliable datagrams are off by default — enable them by setting `QuicOptions.datagrams`. Each whole
+buffer is one datagram; there is no retransmission, and oversized buffers are rejected.
+
+```kotlin
+val opts = QuicOptions(alpnProtocols = listOf("h3"), datagrams = DatagramOptions())
+
+withQuicConnection("example.com", 443, opts) {
+    // Send.
+    val dgram = BufferFactory.Default.allocate(4)
+    dgram.writeString("ping", Charset.UTF8)
+    dgram.resetForRead()
+    sendDatagram(dgram)
+    dgram.freeIfNeeded()
+
+    // Receive — the buffer's ownership transfers to you.
+    when (val r = receiveDatagram()) {
+        is DatagramReceiveResult.Received -> r.buffer.freeIfNeeded()
+        is DatagramReceiveResult.ConnectionClosed -> { /* r.error: QuicError */ }
+    }
+}
+```
+
+`maxDatagramSize()` reports the current sendable size (`MaxDatagramSize.Bytes(n)` or `Unavailable`),
+and `datagrams(): Flow<ReadBuffer>` is a flow form of the receive loop.
+
+## Error Handling
+
+QUIC errors mirror the core `socket` sealed hierarchy:
+
+- **`QuicCloseException`** (a `SocketClosedException`) — the whole **connection** ended: peer close,
+  idle timeout, handshake failure. Carries a structured `quicError: QuicError`.
+- **`QuicStreamException`** — a single **stream** was aborted by the peer (`STOP_SENDING` or
+  `RESET_STREAM`); the connection stays healthy. Inspect `abort: QuicStreamAbort` for the peer's
+  application error code.
+
+```kotlin
+try {
+    stream.write(buf, 5.seconds)
+} catch (e: QuicStreamException) {
+    // Just this stream died — e.abort.applicationErrorCode tells you why.
+} catch (e: QuicCloseException) {
+    // The connection is gone — e.quicError is the reason.
+}
+```
+
+## Next Steps
+
+- [Typed Stream Multiplexing](./stream-mux) — codec-typed messages instead of raw buffers
+- [HTTP/3 & WebTransport](../http3/intro) — protocols built on this stream model

--- a/docs/docs/quic/intro.md
+++ b/docs/docs/quic/intro.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 1
+title: QUIC Overview
+---
+
+# QUIC
+
+`socket-quic` is a sister artifact that adds a QUIC (RFC 9000) client and server with the same
+scope-based, suspend-based shape as the core `socket` module — and the same zero-copy buffer
+discipline. It lives in a separate dependency so TCP-only consumers don't pay for it.
+
+```kotlin
+dependencies {
+    implementation("com.ditchoom:socket-quic:<latest-version>")
+}
+```
+
+Find the latest version on [Maven Central](https://central.sonatype.com/search?q=com.ditchoom).
+
+## Why QUIC?
+
+- **Multiplexed streams** — many independent bidirectional/unidirectional streams over one
+  connection, with no head-of-line blocking between them.
+- **Always encrypted** — TLS 1.3 is built into the handshake; there is no plaintext QUIC.
+- **Unreliable datagrams** (RFC 9221) — fire-and-forget messages alongside reliable streams.
+- **Connection migration** (RFC 9000 §9) — survive a local address change without a new handshake.
+- **Same API everywhere** — one Kotlin codebase across JVM, Android, Linux native, and Apple.
+
+## Platform Support
+
+| Platform | Backend | Notes |
+|----------|---------|-------|
+| JVM / Android | [quiche](https://github.com/cloudflare/quiche) | FFM on JDK 21+, JNI on JDK ≤20 |
+| Linux (x64/arm64) | quiche cinterop | Static `libquiche.a`, io_uring UDP |
+| Apple (iOS/macOS/…) | [Network.framework](https://developer.apple.com/documentation/network) | Native `NWConnection` QUIC |
+| JS / wasmJs | — | Throws `UnsupportedOperationException` (no raw UDP) |
+
+## The Shape of the API
+
+Everything runs inside a scope that owns the connection's lifetime. The handshake completes before
+your block runs, and the connection closes when the block exits — on normal return, exception, or
+cancellation.
+
+```kotlin
+withQuicConnection("example.com", 443, QuicOptions(alpnProtocols = listOf("h3"))) {
+    // `this` is a QuicScope — open streams, send datagrams, migrate paths…
+    val stream = openStream()
+    // …
+    stream.close()
+} // connection closed here
+```
+
+`QuicOptions.alpnProtocols` is the one required field — QUIC always negotiates an application
+protocol during the TLS handshake.
+
+## Next Steps
+
+- [Connections & Streams](./connection) — client, server, the `QuicByteStream` lifecycle, and datagrams
+- [Typed Stream Multiplexing](./stream-mux) — exchange codec-typed messages with `withQuicMux`
+- [HTTP/3 & WebTransport](../http3/intro) — the `socket-http3` layer built on top of QUIC

--- a/docs/docs/quic/stream-mux.md
+++ b/docs/docs/quic/stream-mux.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 3
+title: Typed Stream Multiplexing
+---
+
+# Typed Stream Multiplexing
+
+Working with raw `QuicByteStream` buffers is fine for byte protocols, but most applications speak in
+*messages*. `StreamMux<T>` layers a [`Codec<T>`](https://central.sonatype.com/search?q=com.ditchoom.buffer-codec)
+over a QUIC connection so each stream sends and receives typed values — framing and buffer management
+happen for you.
+
+## The Entry Point
+
+`withQuicMux` is `withQuicConnection` plus a codec. The block receives a `StreamMux<T>`:
+
+```kotlin
+suspend fun <T, R> withQuicMux(
+    hostname: String,
+    port: Int,
+    quicOptions: QuicOptions,
+    codec: Codec<T>,
+    connectionOptions: ConnectionOptions = ConnectionOptions(),
+    timeout: Duration = 15.seconds,
+    block: suspend StreamMux<T>.() -> R,
+): R
+```
+
+`StreamMux<T>` opens and accepts typed streams:
+
+| Method | Returns | Use |
+|--------|---------|-----|
+| `openBidirectional()` | `Connection<T>` | Open a send+receive typed stream. |
+| `openUnidirectional()` | `Sender<T>` | Open a send-only typed stream. |
+| `acceptBidirectional()` | `Connection<T>` | Accept a peer-opened send+receive stream. |
+| `acceptUnidirectional()` | `Receiver<T>` | Accept a peer-opened send-only stream. |
+
+A `Connection<T>` is `send(value)`, `receive(): Flow<T>`, `close()`, and an `id` (the QUIC stream id).
+
+## Defining a Codec
+
+A `Codec<T>` encodes a value to a buffer, decodes one back, and — because streams are byte streams,
+not message streams — tells the framing layer how big the next frame is so it can be split out of the
+incoming bytes. Here is a length-prefixed UTF-8 string codec:
+
+```kotlin
+object StringCodec : Codec<String> {
+    override fun encode(buffer: WriteBuffer, value: String, context: EncodeContext) {
+        val bytes = value.encodeToByteArray()
+        buffer.writeShort(bytes.size.toShort()) // 2-byte length prefix
+        buffer.writeBytes(bytes)
+    }
+
+    override fun decode(buffer: ReadBuffer, context: DecodeContext): String {
+        val length = buffer.readShort().toInt() and 0xFFFF
+        return buffer.readString(length)
+    }
+
+    override fun wireSize(value: String, context: EncodeContext): WireSize = WireSize.BackPatch
+
+    override fun peekFrameSize(stream: StreamProcessor, baseOffset: Int): PeekResult {
+        // Need at least the 2-byte length to know the frame size.
+        if (stream.available() < baseOffset + 2) return PeekResult.NeedsMoreData
+        val length = stream.peekShort(baseOffset).toInt() and 0xFFFF
+        return PeekResult.Complete(2 + length)
+    }
+}
+```
+
+`peekFrameSize` returns `PeekResult.Complete(n)` once a full frame is buffered, or
+`PeekResult.NeedsMoreData` to wait for more bytes. `wireSize` lets the encoder pre-size its buffer
+(`WireSize.Exact(n)` for fixed sizes, `WireSize.BackPatch` for variable ones).
+
+## Client and Server
+
+The client uses `withQuicMux`. The server gets a raw `QuicScope` from `withQuicServer`, so it wraps
+it in a `QuicStreamMux` directly:
+
+```kotlin
+// --- Server: accept a typed bidi stream and echo with a prefix ---
+withQuicServer(port = 0, tlsConfig = tlsConfig, quicOptions = quicOptions) {
+    connections {
+        val mux = QuicStreamMux(this, StringCodec, ConnectionOptions())
+        val conn = mux.acceptBidirectional()
+        val msg = conn.receive().first()
+        conn.send("echo: $msg")
+        conn.close()
+    }
+}
+
+// --- Client: open a typed bidi stream, send, receive ---
+val response = withQuicMux("localhost", port, quicOptions, StringCodec) {
+    val conn = openBidirectional()
+    conn.send("hello")
+    val reply = conn.receive().first()
+    conn.close()
+    reply
+}
+// response == "echo: hello"
+```
+
+`receive()` is a cold `Flow<T>` — collect it for a stream of messages, or take `.first()` for a
+single request/response exchange as above.
+
+## Next Steps
+
+- [Connections & Streams](./connection) — the raw `QuicByteStream` model underneath the mux
+- [HTTP/3 & WebTransport](../http3/intro) — higher-level protocols on QUIC

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -17,6 +17,23 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'QUIC',
+      items: [
+        'quic/intro',
+        'quic/connection',
+        'quic/stream-mux',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'HTTP/3 & WebTransport',
+      items: [
+        'http3/intro',
+        'http3/webtransport',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Guides',
       items: [
         'guides/building-a-protocol',


### PR DESCRIPTION
## What

The docs site and README covered only the core TCP `socket` module. The `socket-quic` and `socket-http3` layers had **no guide pages** and only a thin README blurb. This adds full coverage of both, with runnable examples.

### Docs site (Docusaurus, served at ditchoom.github.io/socket)
New **QUIC** category:
- **quic/intro** — what QUIC adds, install, platform support, the scope-based shape
- **quic/connection** — client + server, the full `QuicByteStream` lifecycle (`read()→ReadResult`, `write()`, `shutdownSend()` half-close, `reset()`), unidirectional streams, datagrams (RFC 9221), and the `QuicCloseException` vs `QuicStreamException` error model
- **quic/stream-mux** — typed multiplexing: implementing a `Codec<T>` and exchanging messages with `withQuicMux` / `StreamMux<T>`

New **HTTP/3 & WebTransport** category:
- **http3/intro** — client request/response, streaming request bodies, the `withHttp3Server` + `onRequest` server, and server push (§4.6)
- **http3/webtransport** — establishing sessions (client `connectWebTransport`, server `onWebTransport`/`accept`), session-scoped streams, datagrams, and the drain (§5) vs close lifecycle

Both wired into `sidebars.ts`.

### README
Expanded the `socket-quic` section: the `QuicByteStream` send/receive lifecycle, a typed `StreamMux` snippet, and a new **HTTP/3 & WebTransport** subsection that links into the site.

## Accuracy

I extracted the exact public API signatures (three parallel read-only passes over the source) and wrote every example against the **real** surface — `read()→ReadResult`, `write(ReadBuffer)`, `withHttp3Server`/`onRequest`, `connectWebTransport`, `session.openBidiStream()`, etc. Deliberately **not** the test-only helpers (`readUtf8()`, `textBuffer()`, `Http3LoopbackServer`) that appear in the test suites.

## Verification

`docusaurus build` passes — no broken internal links, no frontmatter errors. Docs-only change; no production code touched.