### PR TITLE
docs: leak-safe buffer lifetime + stream-vs-scope ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ withQuicMux("localhost", port, quicOptions, StringCodec) {
 withHttp3Connection("example.com", 443) {
     val response = request(Http3Request(method = "GET", authority = "example.com", path = "/"))
     val body = response.readFullBody()
+    body.freeIfNeeded() // you own the body buffer
     response.close()
 }
 

--- a/docs/docs/http3/intro.md
+++ b/docs/docs/http3/intro.md
@@ -72,6 +72,7 @@ receives an `Http3ServerExchange` (its `request` and `response`):
 ```kotlin
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.use
 
 withHttp3Server(
     port = 0, // ephemeral; read it back from `port`
@@ -79,14 +80,16 @@ withHttp3Server(
     onRequest = {
         when (request.path) {
             "/hello" -> {
-                val body = BufferFactory.Default.allocate(64)
-                body.writeString("hello from h3", Charset.UTF8)
-                body.resetForRead()
-                response.send(
-                    status = 200,
-                    headers = listOf(QpackHeaderField("content-type", "text/plain")),
-                    body = body,
-                )
+                // `send` writes the body but doesn't take ownership — `use { }` frees it after.
+                BufferFactory.Default.allocate(64).use { body ->
+                    body.writeString("hello from h3", Charset.UTF8)
+                    body.resetForRead()
+                    response.send(
+                        status = 200,
+                        headers = listOf(QpackHeaderField("content-type", "text/plain")),
+                        body = body,
+                    )
+                }
             }
             else -> response.send(404)
         }

--- a/docs/docs/http3/webtransport.md
+++ b/docs/docs/http3/webtransport.md
@@ -68,15 +68,16 @@ A session opens streams just like raw QUIC, but scoped to the session. Bidirecti
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.use
 
 // Client: open a bidi stream, send, half-close, read the reply.
 val stream = session.openBidiStream()
 
-val out = BufferFactory.Default.allocate(5)
-out.writeString("hello", Charset.UTF8)
-out.resetForRead()
-stream.write(out)
-out.freeIfNeeded()
+BufferFactory.Default.allocate(5).use { out ->
+    out.writeString("hello", Charset.UTF8)
+    out.resetForRead()
+    stream.write(out)
+}
 stream.shutdownSend()
 
 val reply = when (val r = stream.read()) {
@@ -99,11 +100,11 @@ val msg = when (val r = stream.read()) {
     is ReadResult.Data -> r.buffer.readString(r.buffer.remaining(), Charset.UTF8).also { r.buffer.freeIfNeeded() }
     ReadResult.End, ReadResult.Reset -> ""
 }
-val out = BufferFactory.Default.allocate(64)
-out.writeString("echo:$msg", Charset.UTF8)
-out.resetForRead()
-stream.write(out)
-out.freeIfNeeded()
+BufferFactory.Default.allocate(64).use { out ->
+    out.writeString("echo:$msg", Charset.UTF8)
+    out.resetForRead()
+    stream.write(out)
+}
 stream.close()
 ```
 
@@ -118,11 +119,11 @@ the underlying connection:
 
 ```kotlin
 // Send.
-val dgram = BufferFactory.Default.allocate(4)
-dgram.writeString("ping", Charset.UTF8)
-dgram.resetForRead()
-session.sendDatagram(dgram)
-dgram.freeIfNeeded()
+BufferFactory.Default.allocate(4).use { dgram ->
+    dgram.writeString("ping", Charset.UTF8)
+    dgram.resetForRead()
+    session.sendDatagram(dgram)
+}
 
 // Receive — you own each emitted buffer.
 val incoming = session.datagrams.first()

--- a/docs/docs/quic/connection.md
+++ b/docs/docs/quic/connection.md
@@ -18,6 +18,7 @@ connection on exit:
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.use
 import kotlin.time.Duration.Companion.seconds
 
 val reply = withQuicConnection(
@@ -28,17 +29,18 @@ val reply = withQuicConnection(
 ) {
     val stream = openStream()
 
-    // Write — buffers are written zero-copy; reset for read before handing them off.
-    val out = BufferFactory.Default.allocate(11)
-    out.writeString("hello quic!", Charset.UTF8)
-    out.resetForRead()
-    stream.write(out, 5.seconds)
-    out.freeIfNeeded()
+    // Write — buffers are written zero-copy; you retain ownership, so free it when done.
+    // `use { }` frees the buffer on the way out, even if write() throws.
+    BufferFactory.Default.allocate(11).use { out ->
+        out.writeString("hello quic!", Charset.UTF8)
+        out.resetForRead()
+        stream.write(out, 5.seconds)
+    }
 
-    // The peer is done sending us nothing more on the write side — half-close it (FIN).
+    // We won't send anything more — half-close the write side (FIN); the read side stays open.
     stream.shutdownSend()
 
-    // Read the response.
+    // Read the response. The buffer in `Data` is yours to free.
     val text = when (val r = stream.read(5.seconds)) {
         is ReadResult.Data -> {
             val s = r.buffer.readString(r.buffer.remaining(), Charset.UTF8)
@@ -47,7 +49,7 @@ val reply = withQuicConnection(
         }
         ReadResult.End, ReadResult.Reset -> ""
     }
-    stream.close()
+    stream.close() // optional here — the scope would reclaim it — but sends a prompt FIN.
     text
 }
 ```
@@ -65,18 +67,32 @@ withQuicServer(
 ) {
     connections {
         // `this` is the per-connection QuicScope. Accept a peer-opened stream and echo it.
+        // A server connection is long-lived and may handle many streams, so release each one as
+        // you finish it — `try/finally` guarantees the close even if the body throws.
         val stream = acceptStream()
-        when (val r = stream.read(5.seconds)) {
-            is ReadResult.Data -> stream.write(r.buffer, 5.seconds) // echo (zero-copy)
-            ReadResult.End, ReadResult.Reset -> {}
+        try {
+            when (val r = stream.read(5.seconds)) {
+                is ReadResult.Data -> {
+                    stream.write(r.buffer, 5.seconds) // echo (zero-copy)
+                    r.buffer.freeIfNeeded()           // you own the read buffer
+                }
+                ReadResult.End, ReadResult.Reset -> {}
+            }
+        } finally {
+            stream.close()
         }
-        stream.close()
     }
 }
 ```
 
 `connections { … }` handles multiple connections concurrently — each invocation is a fresh scope.
 You can also collect `streams(): Flow<QuicByteStream>` to react to every peer-opened stream.
+
+:::tip Streams vs. buffers
+Closing a stream is about *promptness* — the connection scope would reclaim it anyway on exit (see
+[the overview](./intro#who-closes-what)). The thing you must not drop is a **buffer**: it isn't owned
+by the scope. Allocate it inside `use { }`, and free the `ReadBuffer` you get back from `read()`.
+:::
 
 ## The `QuicByteStream` Lifecycle
 
@@ -111,11 +127,11 @@ val opts = QuicOptions(alpnProtocols = listOf("h3"), datagrams = DatagramOptions
 
 withQuicConnection("example.com", 443, opts) {
     // Send.
-    val dgram = BufferFactory.Default.allocate(4)
-    dgram.writeString("ping", Charset.UTF8)
-    dgram.resetForRead()
-    sendDatagram(dgram)
-    dgram.freeIfNeeded()
+    BufferFactory.Default.allocate(4).use { dgram ->
+        dgram.writeString("ping", Charset.UTF8)
+        dgram.resetForRead()
+        sendDatagram(dgram)
+    }
 
     // Receive — the buffer's ownership transfers to you.
     when (val r = receiveDatagram()) {

--- a/docs/docs/quic/intro.md
+++ b/docs/docs/quic/intro.md
@@ -53,6 +53,15 @@ withQuicConnection("example.com", 443, QuicOptions(alpnProtocols = listOf("h3"))
 `QuicOptions.alpnProtocols` is the one required field — QUIC always negotiates an application
 protocol during the TLS handshake.
 
+### Who closes what
+
+The **connection scope is the resource boundary.** When the block exits, the connection — and every
+stream opened on it — is torn down, so a stream you forget to close is reclaimed, not leaked. You
+still call `stream.close()` / `shutdownSend()` to send the peer a prompt FIN, and to release streams
+as you finish them in a **long-lived** connection that opens many. **Buffers are the exception:** they
+are not owned by the scope, so always pair an allocation with `use { }` (or `freeIfNeeded()`) — see
+the examples that follow.
+
 ## Next Steps
 
 - [Connections & Streams](./connection) — client, server, the `QuicByteStream` lifecycle, and datagrams


### PR DESCRIPTION
Follow-up to #148, addressing review feedback that the examples taught a leak-prone habit (lots of manual cleanup).

## What this changes
Verified the actual ownership model before editing:
- The **connection scope is the resource boundary** — `withQuicConnection`/`withHttp3Connection` close the connection on block exit, which cascades to every stream (`QuicheDriver` clears + frees all streams). So a forgotten `stream.close()` is *reclaimed, not leaked*.
- **Buffers are the real risk** — they are **not** owned by the scope. `write()`/`send()` never take ownership (they allocate their own internal frame buffer, copy, and free that). The caller must free.

So the examples now:
- Wrap allocated send buffers in `com.ditchoom.buffer.use { }` — frees on the exception path too. (Kept `freeIfNeeded()` for read-side `ReadBuffer`s from `ReadResult.Data`; `use {}` is a `PlatformBuffer` extension and doesn't apply to them.)
- Fixed a genuine leak: the HTTP/3 server `onRequest` example never freed its response `body`.
- Added a **"Who closes what"** section to the QUIC overview and a tip on the connection page, so the manual `close()` calls read as *prompt FIN / long-lived-connection hygiene*, not *or-you-leak*.
- Showed `try/finally { stream.close() }` in the **server accept loop** — the one place it teaches a real long-lived pattern — rather than blanket-wrapping every one-shot snippet.

## Validation
`cd docs && npm run build` passes (Docusaurus validates internal links **and** anchors, including the new cross-page `./intro#who-closes-what`).