### PR TITLE
feat(quic): BufferFactory.network() + expose bufferFactory on scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Backed by quiche on JVM/Android (JNI on JDK ≤20, FFM on JDK 21+), quiche cinte
 
 Each `QuicByteStream` has independent send/receive sides: `write()`/`read()` for bytes, `shutdownSend()` to half-close the send side (FIN) for request/response, and `reset(errorCode)` to abort both directions. `read()` returns a `ReadResult` — `Data` (a buffer), `End` (peer FIN), or `Reset` (peer abort). Unreliable datagrams (RFC 9221) are available via `sendDatagram()`/`receiveDatagram()` when `QuicOptions.datagrams` is set.
 
+Allocate send buffers from the scope's `bufferFactory` (defaults to `BufferFactory.network()` — the native-memory factory QUIC needs on every backend) and pair them with `use { }`; the connection scope reclaims streams on exit, but buffers are yours to free.
+
 #### Typed stream multiplexing
 
 `withQuicMux(..., codec) { … }` layers a `Codec<T>` over the connection so each stream exchanges typed messages instead of raw buffers:
@@ -91,6 +93,7 @@ withQuicMux("localhost", port, quicOptions, StringCodec) {
 withHttp3Connection("example.com", 443) {
     val response = request(Http3Request(method = "GET", authority = "example.com", path = "/"))
     val body = response.readFullBody()
+    body.freeIfNeeded() // you own the body buffer
     response.close()
 }
 

--- a/docs/docs/http3/intro.md
+++ b/docs/docs/http3/intro.md
@@ -72,6 +72,8 @@ receives an `Http3ServerExchange` (its `request` and `response`):
 ```kotlin
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.use
+import com.ditchoom.socket.quic.network
 
 withHttp3Server(
     port = 0, // ephemeral; read it back from `port`
@@ -79,14 +81,17 @@ withHttp3Server(
     onRequest = {
         when (request.path) {
             "/hello" -> {
-                val body = BufferFactory.Default.allocate(64)
-                body.writeString("hello from h3", Charset.UTF8)
-                body.resetForRead()
-                response.send(
-                    status = 200,
-                    headers = listOf(QpackHeaderField("content-type", "text/plain")),
-                    body = body,
-                )
+                // `send` writes the body but doesn't take ownership — `use { }` frees it after.
+                // QUIC buffers must be native memory; `BufferFactory.network()` guarantees that.
+                BufferFactory.network().allocate(64).use { body ->
+                    body.writeString("hello from h3", Charset.UTF8)
+                    body.resetForRead()
+                    response.send(
+                        status = 200,
+                        headers = listOf(QpackHeaderField("content-type", "text/plain")),
+                        body = body,
+                    )
+                }
             }
             else -> response.send(404)
         }

--- a/docs/docs/http3/webtransport.md
+++ b/docs/docs/http3/webtransport.md
@@ -65,18 +65,19 @@ A session opens streams just like raw QUIC, but scoped to the session. Bidirecti
 `QuicByteStream`.
 
 ```kotlin
-import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.use
 
 // Client: open a bidi stream, send, half-close, read the reply.
 val stream = session.openBidiStream()
 
-val out = BufferFactory.Default.allocate(5)
-out.writeString("hello", Charset.UTF8)
-out.resetForRead()
-stream.write(out)
-out.freeIfNeeded()
+// Allocate from the session's bufferFactory (the connection's native-memory factory).
+session.bufferFactory.allocate(5).use { out ->
+    out.writeString("hello", Charset.UTF8)
+    out.resetForRead()
+    stream.write(out)
+}
 stream.shutdownSend()
 
 val reply = when (val r = stream.read()) {
@@ -99,11 +100,11 @@ val msg = when (val r = stream.read()) {
     is ReadResult.Data -> r.buffer.readString(r.buffer.remaining(), Charset.UTF8).also { r.buffer.freeIfNeeded() }
     ReadResult.End, ReadResult.Reset -> ""
 }
-val out = BufferFactory.Default.allocate(64)
-out.writeString("echo:$msg", Charset.UTF8)
-out.resetForRead()
-stream.write(out)
-out.freeIfNeeded()
+session.bufferFactory.allocate(64).use { out ->
+    out.writeString("echo:$msg", Charset.UTF8)
+    out.resetForRead()
+    stream.write(out)
+}
 stream.close()
 ```
 
@@ -118,11 +119,11 @@ the underlying connection:
 
 ```kotlin
 // Send.
-val dgram = BufferFactory.Default.allocate(4)
-dgram.writeString("ping", Charset.UTF8)
-dgram.resetForRead()
-session.sendDatagram(dgram)
-dgram.freeIfNeeded()
+session.bufferFactory.allocate(4).use { dgram ->
+    dgram.writeString("ping", Charset.UTF8)
+    dgram.resetForRead()
+    session.sendDatagram(dgram)
+}
 
 // Receive — you own each emitted buffer.
 val incoming = session.datagrams.first()

--- a/docs/docs/quic/connection.md
+++ b/docs/docs/quic/connection.md
@@ -15,9 +15,9 @@ carries unreliable datagrams.
 connection on exit:
 
 ```kotlin
-import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.use
 import kotlin.time.Duration.Companion.seconds
 
 val reply = withQuicConnection(
@@ -28,17 +28,18 @@ val reply = withQuicConnection(
 ) {
     val stream = openStream()
 
-    // Write — buffers are written zero-copy; reset for read before handing them off.
-    val out = BufferFactory.Default.allocate(11)
-    out.writeString("hello quic!", Charset.UTF8)
-    out.resetForRead()
-    stream.write(out, 5.seconds)
-    out.freeIfNeeded()
+    // Write — buffers are written zero-copy; you retain ownership, so free it when done.
+    // Allocate from the scope's `bufferFactory` and let `use { }` free it even if write() throws.
+    bufferFactory.allocate(11).use { out ->
+        out.writeString("hello quic!", Charset.UTF8)
+        out.resetForRead()
+        stream.write(out, 5.seconds)
+    }
 
-    // The peer is done sending us nothing more on the write side — half-close it (FIN).
+    // We won't send anything more — half-close the write side (FIN); the read side stays open.
     stream.shutdownSend()
 
-    // Read the response.
+    // Read the response. The buffer in `Data` is yours to free.
     val text = when (val r = stream.read(5.seconds)) {
         is ReadResult.Data -> {
             val s = r.buffer.readString(r.buffer.remaining(), Charset.UTF8)
@@ -47,7 +48,7 @@ val reply = withQuicConnection(
         }
         ReadResult.End, ReadResult.Reset -> ""
     }
-    stream.close()
+    stream.close() // optional here — the scope would reclaim it — but sends a prompt FIN.
     text
 }
 ```
@@ -65,12 +66,20 @@ withQuicServer(
 ) {
     connections {
         // `this` is the per-connection QuicScope. Accept a peer-opened stream and echo it.
+        // A server connection is long-lived and may handle many streams, so release each one as
+        // you finish it — `try/finally` guarantees the close even if the body throws.
         val stream = acceptStream()
-        when (val r = stream.read(5.seconds)) {
-            is ReadResult.Data -> stream.write(r.buffer, 5.seconds) // echo (zero-copy)
-            ReadResult.End, ReadResult.Reset -> {}
+        try {
+            when (val r = stream.read(5.seconds)) {
+                is ReadResult.Data -> {
+                    stream.write(r.buffer, 5.seconds) // echo (zero-copy)
+                    r.buffer.freeIfNeeded()           // you own the read buffer
+                }
+                ReadResult.End, ReadResult.Reset -> {}
+            }
+        } finally {
+            stream.close()
         }
-        stream.close()
     }
 }
 ```
@@ -111,11 +120,11 @@ val opts = QuicOptions(alpnProtocols = listOf("h3"), datagrams = DatagramOptions
 
 withQuicConnection("example.com", 443, opts) {
     // Send.
-    val dgram = BufferFactory.Default.allocate(4)
-    dgram.writeString("ping", Charset.UTF8)
-    dgram.resetForRead()
-    sendDatagram(dgram)
-    dgram.freeIfNeeded()
+    bufferFactory.allocate(4).use { dgram ->
+        dgram.writeString("ping", Charset.UTF8)
+        dgram.resetForRead()
+        sendDatagram(dgram)
+    }
 
     // Receive — the buffer's ownership transfers to you.
     when (val r = receiveDatagram()) {
@@ -127,6 +136,29 @@ withQuicConnection("example.com", 443, opts) {
 
 `maxDatagramSize()` reports the current sendable size (`MaxDatagramSize.Bytes(n)` or `Unavailable`),
 and `datagrams(): Flow<ReadBuffer>` is a flow form of the receive loop.
+
+## Buffers: `BufferFactory.network()`
+
+Closing a stream is about *promptness* — the connection scope reclaims it on exit anyway (see
+[the overview](./intro#who-closes-what)). The thing you must not drop is a **buffer**: it isn't owned
+by the scope. Allocate it inside `use { }`, and free the `ReadBuffer` you get back from `read()`.
+
+Allocate from the scope's `bufferFactory`, not a global. Every QUIC backend hands buffer addresses
+straight to native code — quiche over FFM/JNI, quiche cinterop on Linux, Network.framework on Apple —
+so QUIC buffers must be **native memory**. `bufferFactory` defaults to `BufferFactory.network()`, the
+factory that guarantees this on every platform:
+
+```kotlin
+import com.ditchoom.socket.quic.network
+
+// The QUIC default — what `QuicScope.bufferFactory` returns unless you override it.
+val factory = BufferFactory.network()
+```
+
+To override (JVM only — native always requires `network()`), pass
+`ConnectionOptions(bufferFactory = …)` to `withQuicConnection`. Whatever the connection ends up with
+is what `bufferFactory` reports inside the block, so `bufferFactory.allocate(n).use { }` always
+matches the connection.
 
 ## Error Handling
 

--- a/docs/docs/quic/intro.md
+++ b/docs/docs/quic/intro.md
@@ -53,6 +53,30 @@ withQuicConnection("example.com", 443, QuicOptions(alpnProtocols = listOf("h3"))
 `QuicOptions.alpnProtocols` is the one required field — QUIC always negotiates an application
 protocol during the TLS handshake.
 
+## Who closes what
+
+The **connection scope is the resource boundary.** When the block exits, the connection — and every
+stream opened on it — is torn down, so a stream you forget to close is reclaimed, not leaked. You
+still call `stream.close()` / `shutdownSend()` to send the peer a prompt FIN, and to release streams
+as you finish them in a **long-lived** connection that opens many.
+
+**Buffers are the exception** — they aren't owned by the scope, so always pair an allocation with
+`use { }` (it frees even if the body throws). Allocate from the scope's own `bufferFactory` rather
+than a global, so your buffers match the connection's allocation strategy:
+
+```kotlin
+withQuicConnection("example.com", 443, QuicOptions(alpnProtocols = listOf("h3"))) {
+    bufferFactory.allocate(11).use { out ->  // `bufferFactory` is a QuicScope member
+        out.writeString("hello quic!", Charset.UTF8)
+        out.resetForRead()
+        openStream().write(out)
+    }
+}
+```
+
+`bufferFactory` defaults to [`BufferFactory.network()`](./connection#buffers-bufferfactorynetwork) —
+the native-memory factory QUIC needs — unless you override `ConnectionOptions.bufferFactory`.
+
 ## Next Steps
 
 - [Connections & Streams](./connection) — client, server, the `QuicByteStream` lifecycle, and datagrams

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.socket.http3
 
+import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.codec.EncodeContext
@@ -105,6 +106,14 @@ class Http3Connection private constructor(
     // SETTINGS at bootstrap; [WebTransportOptions.maxSessions] is the inbound accept limit.
     private val webTransport: WebTransportOptions?,
 ) {
+    /**
+     * The [BufferFactory] this connection allocates from — the underlying QUIC connection's factory
+     * (see [com.ditchoom.socket.quic.QuicScope.bufferFactory] /
+     * [com.ditchoom.socket.quic.network]). Allocate request/response and WebTransport buffers from
+     * here, paired with `use { }`, so they match the connection's native-memory allocation strategy.
+     */
+    val bufferFactory: BufferFactory get() = scope.bufferFactory
+
     private val peerSettingsDeferred = CompletableDeferred<Http3Settings>()
     private val _goAway = MutableStateFlow<Long?>(null)
     private val connectionErrorDeferred = CompletableDeferred<Http3StreamException>()

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportMux.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportMux.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.socket.http3
 
+import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ByteOrder
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.codec.DecodeContext
@@ -43,6 +44,9 @@ internal class WebTransportMux(
 ) {
     private val sessions = mutableMapOf<Long, WebTransportSession>()
     private val mutex = Mutex()
+
+    /** The connection's buffer factory — surfaced to [WebTransportSession.bufferFactory]. */
+    val bufferFactory: BufferFactory get() = scope.bufferFactory
 
     /**
      * Create a session for a CONNECT stream and table it immediately by id, before the handshake

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportSession.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/WebTransportSession.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.socket.http3
 
+import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.freeIfNeeded
 import com.ditchoom.socket.quic.QuicByteStream
@@ -46,6 +47,13 @@ class WebTransportSession internal constructor(
     internal val connectStream: QuicByteStream,
     private val mux: WebTransportMux,
 ) {
+    /**
+     * The connection's buffer factory (the underlying QUIC connection's native-memory factory; see
+     * [com.ditchoom.socket.quic.network]). Allocate stream/datagram buffers from here, paired with
+     * `use { }`.
+     */
+    val bufferFactory: BufferFactory get() = mux.bufferFactory
+
     @Volatile
     private var _closeInfo: WebTransportCloseInfo? = null
 

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3ConnectionTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3ConnectionTests.kt
@@ -121,6 +121,7 @@ class Http3ConnectionTests {
         private val bidi: ArrayDeque<QuicByteStream> = ArrayDeque(),
     ) : QuicScope,
         CoroutineScope by delegate {
+        override val bufferFactory: BufferFactory = BufferFactory.Default
         val remainingUniStreams get() = outgoing.size
 
         override suspend fun openUniStream(): QuicByteStream = outgoing.removeFirst()

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicConnection.apple.kt
@@ -259,7 +259,7 @@ private suspend fun <R> connectQuicGroup(
             group,
             datagramFlow,
             incomingStreams,
-            connectionOptions.bufferFactory,
+            connectionOptions.quicBufferFactory(),
             keepAliveSeconds = quicOptions.keepAliveInterval?.inWholeSeconds?.toInt() ?: 0,
         )
     return try {
@@ -295,7 +295,7 @@ internal class AppleQuicGroupConnection(
     private val datagramFlow: nw_connection_t?,
     // Peer-initiated streams, fed by the group's new-connection handler wired in connectQuicGroup.
     private val incomingStreams: Channel<QuicByteStream>,
-    private val bufferFactory: BufferFactory,
+    override val bufferFactory: BufferFactory,
     private val keepAliveSeconds: Int = 0,
     private val scope: CoroutineScope = CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default),
 ) : QuicConnection,

--- a/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
+++ b/socket-quic/src/appleNativeImpl/kotlin/com/ditchoom/socket/quic/WithQuicServer.apple.kt
@@ -4,7 +4,6 @@ package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
-import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.flow.ByteStream
 import com.ditchoom.buffer.flow.BytesWritten
 import com.ditchoom.buffer.flow.ReadResult
@@ -191,7 +190,7 @@ actual suspend fun <R> withQuicServer(
             boundPort = boundPort,
             acceptedGroups = acceptedGroups,
             datagramsEnabled = datagramsEnabled,
-            bufferFactory = BufferFactory.deterministic(),
+            bufferFactory = BufferFactory.network(),
             keepAliveSeconds = keepAliveSeconds,
             scope = serverScope,
         )

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicConnection.kt
@@ -38,7 +38,7 @@ internal suspend fun <R> commonJvmWithQuicConnection(
     val parentScope = CoroutineScope(parentJob + Dispatchers.IO)
     try {
         return withTimeout(timeout) {
-            val bufferFactory = connectionOptions.bufferFactory
+            val bufferFactory = connectionOptions.quicBufferFactory()
 
             // 1. Create quiche config
             val config = api.configNew(QUICHE_PROTOCOL_VERSION)

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -2,7 +2,6 @@ package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Charset
-import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.bufferHashCode
 import com.ditchoom.buffer.managed
 import com.ditchoom.buffer.nativeMemoryAccess
@@ -55,7 +54,8 @@ internal suspend fun <R> commonJvmWithQuicServer(
     val parentJob = SupervisorJob()
     val parentScope = CoroutineScope(parentJob + Dispatchers.IO)
     try {
-        val bufferFactory = BufferFactory.Default
+        // QUIC I/O needs native-memory buffers (quiche FFI); see BufferFactory.network().
+        val bufferFactory = BufferFactory.network()
 
         val config = api.configNew(QUICHE_PROTOCOL_VERSION)
 
@@ -271,7 +271,7 @@ internal class JvmQuicServer(
                 launch(Dispatchers.IO) {
                     val connJob = SupervisorJob(coroutineContext[Job])
                     val connScope = CoroutineScope(coroutineContext + connJob)
-                    val conn = DriverQuicConnection(driver, connScope)
+                    val conn = DriverQuicConnection(driver, bufferFactory, connScope)
                     try {
                         conn.state.first { it !is QuicConnectionState.Handshaking }
                         if (conn.state.value is QuicConnectionState.Established) {
@@ -665,12 +665,11 @@ internal class ConnectionIdKey private constructor(
  */
 internal class DriverQuicConnection(
     private val driver: QuicheDriver,
+    override val bufferFactory: BufferFactory,
     connectionScope: CoroutineScope,
 ) : QuicConnection,
     CoroutineScope by connectionScope {
     override val state: StateFlow<QuicConnectionState> = driver.state
-
-    private val bufferFactory = BufferFactory.Default
 
     private val datagramAdapter = DriverDatagramAdapter(driver, bufferFactory)
 

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/JvmQuicConnection.kt
@@ -20,7 +20,7 @@ import kotlin.time.Duration
  */
 internal class JvmQuicConnection(
     private val driver: QuicheDriver,
-    private val bufferFactory: BufferFactory,
+    override val bufferFactory: BufferFactory,
     private val scope: CoroutineScope,
 ) : QuicConnection,
     CoroutineScope by scope {

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicBufferFactory.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicBufferFactory.kt
@@ -1,0 +1,39 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Default
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.socket.ConnectionOptions
+
+/**
+ * The platform-correct buffer factory for QUIC I/O: native-memory buffers with explicit cleanup.
+ *
+ * Every QUIC backend hands buffer addresses straight to native code — quiche over FFM/JNI on the
+ * JVM, quiche over cinterop on Linux, Network.framework on Apple — so the read/write hot paths need
+ * native memory, not a managed heap buffer that would force a copy at the boundary. `network()` is
+ * that factory (currently [BufferFactory.deterministic]); it is the default for
+ * [withQuicConnection]/[withQuicServer] and is what [QuicScope.bufferFactory] reports.
+ *
+ * Allocate your own send buffers and datagrams from [QuicScope.bufferFactory] (which is this, unless
+ * you overrode [ConnectionOptions.bufferFactory]) so they share the connection's allocation strategy:
+ *
+ * ```kotlin
+ * withQuicConnection(host, port, quicOptions) {
+ *     bufferFactory.allocate(11).use { out ->
+ *         out.writeString("hello quic!", Charset.UTF8)
+ *         out.resetForRead()
+ *         stream.write(out)
+ *     }
+ * }
+ * ```
+ */
+fun BufferFactory.Companion.network(): BufferFactory = BufferFactory.deterministic()
+
+/**
+ * Resolve the factory a QUIC connection should allocate from. A caller that left
+ * [ConnectionOptions.bufferFactory] at its default ([BufferFactory.Default]) gets [network] — the
+ * native-memory factory QUIC needs — instead of the managed default. An explicit override is honored
+ * as-is (the caller opted in and owns the consequences; see [network] for why native memory matters).
+ */
+internal fun ConnectionOptions.quicBufferFactory(): BufferFactory =
+    if (bufferFactory === BufferFactory.Default) BufferFactory.network() else bufferFactory

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicScope.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicScope.kt
@@ -1,5 +1,6 @@
 package com.ditchoom.socket.quic
 
+import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -24,6 +25,23 @@ import kotlinx.coroutines.flow.emptyFlow
  * There is no connection state to check — if you're in the block, it's established.
  */
 interface QuicScope : CoroutineScope {
+    /**
+     * The [BufferFactory] this connection allocates from — the one passed via
+     * [ConnectionOptions.bufferFactory][com.ditchoom.socket.ConnectionOptions.bufferFactory] (default
+     * [BufferFactory.Default]). Allocate your send buffers and datagrams from here so they share the
+     * connection's allocation strategy (e.g. a pooled or deterministic factory) instead of reaching
+     * for a global. Pair the allocation with `use { }` so it's freed even if the write throws:
+     *
+     * ```kotlin
+     * bufferFactory.allocate(11).use { out ->
+     *     out.writeString("hello quic!", Charset.UTF8)
+     *     out.resetForRead()
+     *     stream.write(out)
+     * }
+     * ```
+     */
+    val bufferFactory: BufferFactory
+
     /** Open a new locally-initiated bidirectional stream. Caller should close() when done (sends FIN). */
     suspend fun openStream(): QuicByteStream
 

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/MockQuicConnection.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/MockQuicConnection.kt
@@ -26,6 +26,7 @@ class MockQuicConnection(
 ) : QuicConnection {
     private val mockScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     override val coroutineContext: CoroutineContext = mockScope.coroutineContext
+    override val bufferFactory: BufferFactory = BufferFactory.Default
     private val _state = MutableStateFlow<QuicConnectionState>(initialState)
     override val state: StateFlow<QuicConnectionState> = _state
 

--- a/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicStreamMuxCommonTests.kt
+++ b/socket-quic/src/commonTest/kotlin/com/ditchoom/socket/quic/QuicStreamMuxCommonTests.kt
@@ -75,6 +75,7 @@ private class FakeQuicScope(
     private val incomingStreams: ArrayDeque<QuicByteStream>,
 ) : QuicScope,
     CoroutineScope by scope {
+    override val bufferFactory: BufferFactory = BufferFactory.Default
     private val incomingChannel = Channel<QuicByteStream>(Channel.UNLIMITED)
 
     init {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicConnection.linux.kt
@@ -4,7 +4,6 @@ package com.ditchoom.socket.quic
 
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.ReadBuffer
-import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.ConnectionOptions
 import com.ditchoom.socket.SocketConnectionException
@@ -76,9 +75,7 @@ actual suspend fun <R> withQuicConnection(
     val parentScope = CoroutineScope(parentJob + Dispatchers.Default)
     try {
         return withTimeout(timeout) {
-            val bufferFactory =
-                com.ditchoom.buffer.BufferFactory
-                    .deterministic()
+            val bufferFactory = connectionOptions.quicBufferFactory()
 
             val config =
                 quiche_config_new(QUICHE_PROTOCOL_VERSION.convert())
@@ -251,7 +248,7 @@ actual suspend fun <R> withQuicConnection(
  */
 private class LinuxQuicConnection(
     private val driver: QuicheDriver,
-    private val bufferFactory: BufferFactory,
+    override val bufferFactory: BufferFactory,
     private val scope: CoroutineScope,
 ) : QuicConnection,
     CoroutineScope by scope {

--- a/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
+++ b/socket-quic/src/linuxMain/kotlin/com/ditchoom/socket/quic/WithQuicServer.linux.kt
@@ -7,7 +7,6 @@ import com.ditchoom.buffer.Charset
 import com.ditchoom.buffer.PlatformBuffer
 import com.ditchoom.buffer.ReadBuffer
 import com.ditchoom.buffer.bufferHashCode
-import com.ditchoom.buffer.deterministic
 import com.ditchoom.buffer.managed
 import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.linux.socket_getsockname
@@ -68,7 +67,7 @@ actual suspend fun <R> withQuicServer(
     val parentJob = SupervisorJob()
     val parentScope = CoroutineScope(parentJob + Dispatchers.Default)
     try {
-        val bufferFactory = BufferFactory.deterministic()
+        val bufferFactory = BufferFactory.network()
 
         val config = api.configNew(QUICHE_PROTOCOL_VERSION)
 
@@ -637,7 +636,7 @@ private class ConnectionIdKey private constructor(
  */
 private class LinuxServerQuicConnection(
     private val driver: QuicheDriver,
-    private val bufferFactory: BufferFactory,
+    override val bufferFactory: BufferFactory,
     connectionScope: CoroutineScope,
 ) : QuicConnection,
     CoroutineScope by connectionScope {


### PR DESCRIPTION
Supersedes #148's follow-up #149 (closing that — its docs are folded in here, now using the real exposed API instead of a global).

## Motivation
Review feedback: the examples reached for the global `BufferFactory.Default`, and `withQuicServer` silently ignored any configured factory. Digging in surfaced that **the configured factory was only ever honored on JVM** — native (client *and* server) forces `deterministic()` because the quiche FFI / Network.framework / io_uring paths need native-memory buffers. So a configurable common-API factory would be half-honored. The honest fix is a platform-correct default + truthful exposure.

## What changed
- **`BufferFactory.network()`** (commonMain, = `deterministic()`): the native-memory factory every QUIC backend needs. Now the default for `withQuicConnection`/`withQuicServer` via `quicBufferFactory()` (resolves to `network()` unless the caller overrode `ConnectionOptions.bufferFactory`).
- **`QuicScope.bufferFactory` exposed** (all 5 platform connections), plus **`Http3Connection` / `WebTransportSession` / `WebTransportMux`** (delegating to the scope). Callers do `bufferFactory.allocate(n).use { }` against the connection's *own* factory.
- **Server bug fix:** the JVM server connection (`DriverQuicConnection`) allocated its *own* second `BufferFactory.Default`, ignoring the server's factory. It now uses the server's, so `scope.bufferFactory` is truthful server-side.
- Client/server entries (JVM/Linux/Apple) source the factory through `network()`/`quicBufferFactory()` instead of inline `deterministic()`/`Default` literals. **Native default behavior is unchanged** (`network() == deterministic()`); JVM QUIC now defaults to native-memory I/O buffers (matches the documented 'I/O paths use deterministic' guidance).
- **Docs** rewritten to allocate from `bufferFactory` inside `use { }`, with a 'Who closes what' + 'Buffers: BufferFactory.network()' explanation (the scope reclaims streams on exit; buffers are yours to free). Server accept loop models `try/finally`.

## Validation
- `:socket-quic:jvmTest` ✅ (full suite — echo, loopback, resource-leak, harness integration)
- `:socket-http3:jvmTest` ✅ (full suite, threads the new default through)
- `:socket-quic:linuxX64Test --tests QuicEchoServerTests` ✅ (native runtime)
- ktlint ✅ both modules; `docs && npm run build` ✅ (links + anchors)

## Deliberately deferred
`withQuicServer` does **not** take `ConnectionOptions` — native always uses `network()` regardless, so a configurable server factory is JVM-only and would be a half-honored common-API param. Left as a documented JVM-only follow-up if a high-throughput JVM server ever needs a custom pool.