### PR TITLE
quic: native-memory BufferFactory guard + http3: composable request filters

### DIFF
--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Filters.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Filters.kt
@@ -1,0 +1,41 @@
+package com.ditchoom.socket.http3
+
+/*
+ * Composable server-side middleware for withHttp3Server, in the http4k `Filter` style but fitted to
+ * this library's imperative, zero-copy request handling.
+ *
+ * Http3RequestHandler is EXACTLY the type withHttp3Server's onRequest already takes — a suspend lambda
+ * with Http3ServerExchange as receiver — so a composed chain is handed straight to onRequest with no
+ * adapter. A Http3RequestFilter wraps one handler to produce another, so cross-cutting concerns (auth,
+ * logging, metrics, error mapping) are written once and stacked with `then`:
+ *
+ *   val timing: Http3RequestFilter = { next -> {
+ *       val start = monotonicNow()         // this: Http3ServerExchange
+ *       try { next(this) } finally { record(request.path, monotonicNow() - start) }
+ *   } }
+ *   val requireApiKey: Http3RequestFilter = { next -> {
+ *       if (request.headers.none { it.name == "x-api-key" }) response.send(401)  // short-circuit: skip next
+ *       else next(this)
+ *   } }
+ *
+ *   withHttp3Server(..., onRequest = timing.then(requireApiKey).then { response.send(200) }) { ... }
+ *
+ * Because handlers write to Http3ServerExchange.response IMPERATIVELY (zero-copy — there is no
+ * materialized response *value* to transform), a filter runs *around* the inner handler. It can act
+ * before/after it, catch its exceptions, or short-circuit by sending a response and NOT calling `next`.
+ * It deliberately CANNOT post-edit headers/body the inner handler already wrote to the wire — that's the
+ * trade for streaming, and the reason this is a filter set rather than a value-oriented (Request)->Response
+ * API. The same `(H) -> H` shape works for onWebTransport if you need WebTransport-side middleware.
+ */
+
+/** The request-handler shape [withHttp3Server] already accepts for `onRequest`. */
+typealias Http3RequestHandler = suspend Http3ServerExchange.() -> Unit
+
+/** Wraps a [Http3RequestHandler] to produce another. Compose with [then]; apply by [then]-ing a handler. */
+typealias Http3RequestFilter = (Http3RequestHandler) -> Http3RequestHandler
+
+/** Compose two filters: `a.then(b)` runs `a`'s wrapping OUTSIDE `b`'s (outermost-first). */
+infix fun Http3RequestFilter.then(next: Http3RequestFilter): Http3RequestFilter = { handler -> this(next(handler)) }
+
+/** Apply this filter (chain) to the terminal [handler], yielding the value to hand to `onRequest`. */
+fun Http3RequestFilter.then(handler: Http3RequestHandler): Http3RequestHandler = this(handler)

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3LoopbackTestSuite.kt
@@ -1428,6 +1428,86 @@ abstract class Http3LoopbackTestSuite {
                 }
             }
         }
+
+    // --- Composable server middleware (Http3RequestFilter + then) over the existing onRequest handler ---
+
+    @Test
+    fun requestFilters_composeAroundHandlerAndShortCircuit() =
+        runHttp3LoopbackTest {
+            wrapTestBody {
+                // Two filters composed in front of the real handler, handed straight to onRequest:
+                //  - `observe` is an AROUND filter — it records the path then calls the inner handler.
+                //  - `requireToken` SHORT-CIRCUITS — no x-token header ⇒ it sends 401 and never calls next,
+                //    so the handler doesn't run. With the header it delegates through.
+                // Observations cross coroutine/thread boundaries, so they go through a Channel (thread-safe),
+                // not a shared var. The wire-observed status/body alone prove the short-circuit.
+                val observed = Channel<String>(Channel.UNLIMITED)
+                val observe: Http3RequestFilter = { next ->
+                    {
+                        observed.trySend(request.path)
+                        next(this)
+                    }
+                }
+                val requireToken: Http3RequestFilter = { next ->
+                    {
+                        if (request.headers.any { it.name == "x-token" }) {
+                            next(this)
+                        } else {
+                            response.send(401) // short-circuit: inner handler never runs
+                        }
+                    }
+                }
+                val handler: Http3RequestHandler = {
+                    val body = textBuffer("ok:${request.path}")
+                    try {
+                        response.send(200, body = body)
+                    } finally {
+                        body.freeIfNeeded()
+                    }
+                }
+
+                withHttp3Server(
+                    port = 0,
+                    tlsConfig = testTlsConfig(),
+                    quicOptions = serverQuicOptions,
+                    connectionOptions = connectionOptions,
+                    onRequest = observe.then(requireToken).then(handler),
+                ) {
+                    delay(100)
+                    val result =
+                        withHttp3Connection("localhost", port, clientQuicOptions, connectionOptions, 15.seconds) {
+                            // 1) with the token → passes both filters → handler → 200 + body.
+                            val ok =
+                                request(
+                                    Http3Request(
+                                        method = "GET",
+                                        authority = "localhost",
+                                        path = "/ok",
+                                        headers = listOf(QpackHeaderField("x-token", "secret")),
+                                    ),
+                                )
+                            val okBody = ok.readFullBody()
+                            val okText = okBody.readString(okBody.remaining(), Charset.UTF8)
+                            okBody.freeIfNeeded()
+                            val okStatus = ok.status
+                            ok.close()
+                            // 2) without the token → auth filter short-circuits → 401, handler skipped.
+                            val denied = request(Http3Request(method = "GET", authority = "localhost", path = "/denied"))
+                            denied.readFullBody().freeIfNeeded()
+                            val deniedStatus = denied.status
+                            denied.close()
+                            Triple(okStatus, okText, deniedStatus)
+                        }
+                    assertEquals(200, result.first, "authed request reached the handler")
+                    assertEquals("ok:/ok", result.second)
+                    assertEquals(401, result.third, "auth filter short-circuited the missing-token request")
+                    // The AROUND filter ran for BOTH requests (even the short-circuited one, since it wraps
+                    // the auth filter) — proving composition order outer→inner.
+                    val seen = setOf(withTimeout(2.seconds) { observed.receive() }, withTimeout(2.seconds) { observed.receive() })
+                    assertEquals(setOf("/ok", "/denied"), seen, "observe filter saw both requests")
+                }
+            }
+        }
 }
 
 /** Read a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */

--- a/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
+++ b/socket-quic/src/commonJvmMain/kotlin/com/ditchoom/socket/quic/CommonJvmWithQuicServer.kt
@@ -54,7 +54,10 @@ internal suspend fun <R> commonJvmWithQuicServer(
     val parentJob = SupervisorJob()
     val parentScope = CoroutineScope(parentJob + Dispatchers.IO)
     try {
-        // QUIC I/O needs native-memory buffers (quiche FFI); see BufferFactory.network().
+        // QUIC I/O needs native-memory buffers (quiche FFI); see BufferFactory.network(). This is not a
+        // caller-configurable knob: the quiche JNI/FFM binding dereferences buffer addresses everywhere
+        // (cert/key load, header_info out-params, recv buffers, sockaddrs), so a managed/heap factory
+        // can't back a QUIC server on ANY platform — including the JVM. See requireNativeMemory().
         val bufferFactory = BufferFactory.network()
 
         val config = api.configNew(QUICHE_PROTOCOL_VERSION)

--- a/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicBufferFactory.kt
+++ b/socket-quic/src/commonMain/kotlin/com/ditchoom/socket/quic/QuicBufferFactory.kt
@@ -3,6 +3,8 @@ package com.ditchoom.socket.quic
 import com.ditchoom.buffer.BufferFactory
 import com.ditchoom.buffer.Default
 import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.buffer.nativeMemoryAccess
 import com.ditchoom.socket.ConnectionOptions
 
 /**
@@ -30,10 +32,34 @@ import com.ditchoom.socket.ConnectionOptions
 fun BufferFactory.Companion.network(): BufferFactory = BufferFactory.deterministic()
 
 /**
- * Resolve the factory a QUIC connection should allocate from. A caller that left
- * [ConnectionOptions.bufferFactory] at its default ([BufferFactory.Default]) gets [network] — the
- * native-memory factory QUIC needs — instead of the managed default. An explicit override is honored
- * as-is (the caller opted in and owns the consequences; see [network] for why native memory matters).
+ * Fail fast if [this] doesn't allocate native-memory buffers. Every QUIC backend hands buffer
+ * *addresses* straight to native code — quiche over FFM/JNI/cinterop, Network.framework — so a
+ * managed/heap factory ([BufferFactory.Default] / [BufferFactory.managed]) can't back QUIC I/O on
+ * **any** platform, the JVM included: it would NPE deep in the binding on the first
+ * `nativeMemoryAccess` dereference (cert/key load, recv buffers, sockaddrs, …). This turns that latent
+ * crash into an explanatory error at connection/server setup. [network]/[deterministic] always pass.
+ *
+ * Cost is one throwaway 1-byte probe allocation per connection setup — negligible, and the only way
+ * to ask an opaque factory whether it backs its buffers with native memory.
+ */
+internal fun BufferFactory.requireNativeMemory(): BufferFactory {
+    val probe = allocate(1)
+    val isNative = probe.nativeMemoryAccess != null
+    probe.freeIfNeeded()
+    require(isNative) {
+        "QUIC requires a native-memory BufferFactory: it hands buffer addresses to native code " +
+            "(quiche / Network.framework). BufferFactory.Default and BufferFactory.managed() allocate " +
+            "on the heap and can't be used here — pass BufferFactory.network() (the default) or " +
+            "BufferFactory.deterministic()."
+    }
+    return this
+}
+
+/**
+ * Resolve the factory a QUIC connection should allocate from, and verify it is native-memory-backed.
+ * A caller that left [ConnectionOptions.bufferFactory] at its default ([BufferFactory.Default]) gets
+ * [network] — the native-memory factory QUIC needs. An explicit override is honored as-is but still
+ * checked by [requireNativeMemory], so a heap factory fails with a clear message instead of a deep NPE.
  */
 internal fun ConnectionOptions.quicBufferFactory(): BufferFactory =
-    if (bufferFactory === BufferFactory.Default) BufferFactory.network() else bufferFactory
+    (if (bufferFactory === BufferFactory.Default) BufferFactory.network() else bufferFactory).requireNativeMemory()

--- a/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicBufferFactoryGuardTest.kt
+++ b/socket-quic/src/jvmTest/kotlin/com/ditchoom/socket/quic/QuicBufferFactoryGuardTest.kt
@@ -1,0 +1,59 @@
+package com.ditchoom.socket.quic
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.managed
+import com.ditchoom.socket.ConnectionOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Spike (hardening): [ConnectionOptions.quicBufferFactory] / [requireNativeMemory] reject a heap factory
+ * with a clear message instead of letting it NPE deep inside the quiche binding.
+ *
+ * QUIC hands buffer *addresses* to native code on every platform (the JVM included — the FFM/JNI binding
+ * is address-based, not array-based), so a managed/heap factory was never usable; before this guard the
+ * failure was a raw `NullPointerException` on `nativeMemoryAccess!!`. Pure + fast: no native lib, no I/O.
+ */
+class QuicBufferFactoryGuardTest {
+    @Test
+    fun defaultResolvesToNativeNetworkFactory() {
+        // The untouched default must keep working — it resolves the Default sentinel to network().
+        val resolved = ConnectionOptions().quicBufferFactory()
+        assertSame(BufferFactory.network(), resolved, "Default must resolve to the native network() factory")
+    }
+
+    @Test
+    fun explicitNativeFactoryIsHonored() {
+        val native = BufferFactory.deterministic()
+        assertSame(native, ConnectionOptions(bufferFactory = native).quicBufferFactory())
+    }
+
+    @Test
+    fun managedHeapFactoryFailsFastWithExplanatoryMessage() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                ConnectionOptions(bufferFactory = BufferFactory.managed()).quicBufferFactory()
+            }
+        assertTrue(
+            ex.message!!.contains("native-memory", ignoreCase = true) &&
+                ex.message!!.contains("network()"),
+            "guard message should name the constraint and the fix: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun requireNativeMemoryReturnsTheReceiverWhenNative() {
+        val native = BufferFactory.deterministic()
+        assertSame(native, native.requireNativeMemory())
+    }
+
+    @Test
+    fun networkFactoryIsItselfNative() {
+        // Sanity: the QUIC default must satisfy its own guard.
+        assertEquals(BufferFactory.network(), BufferFactory.network().requireNativeMemory())
+    }
+}


### PR DESCRIPTION
Two independent, PR-ready commits that close out the two deferred threads from #150. Draft because they began as exploratory spikes; both are now green and documented. They touch different modules and can be reviewed (or split) independently.

## 1. `quic`: fail-fast guard rejecting a non-native `BufferFactory` (`a75b74d`)

Probing the deferred "JVM-only configurable server factory" with `BufferFactory.managed()` NPE'd at `CommonJvmWithQuicServer.kt` on `keyBuf.nativeMemoryAccess!!`. **The premise was false:** the quiche FFM/JNI binding is *address-based everywhere* (cert/key/ALPN load, `header_info` out-params, recv buffers, sockaddrs, generated SCIDs all dereference `nativeMemoryAccess!!`), so a managed/heap factory can't back a QUIC connection on **any** platform — the JVM included. The "FFI copies managed→native at the boundary" intuition applies to `SSL_write(byte[])`-style bindings, not to this zero-copy address-based one. There is no heap-vs-native knob to expose.

So instead of an overload, this hardens the existing path:

- `internal fun BufferFactory.requireNativeMemory()` — a one-byte probe (`nativeMemoryAccess != null` → `require`) that turns the latent deep NPE into an explanatory error at connection setup.
- `quicBufferFactory()` now validates the resolved factory. `Default → network()` still passes; an explicit `managed()` override fails with *"QUIC requires a native-memory BufferFactory … use BufferFactory.network()."*

This is a real bug-class fix: a user passing `ConnectionOptions(bufferFactory = managed())` to `withQuicConnection` previously got a raw `NullPointerException` deep in the binding.

**Tests:** `QuicBufferFactoryGuardTest` (jvmTest, 5/5). Not in commonTest because JS `deterministic()` isn't native and QUIC is unsupported on JS anyway. The Linux-native loopback test exercises the guard's happy path on the real client connection path.

## 2. `http3`: composable server-side request middleware (`4e84704`)

The deferred http4k idea, distilled to the one genuinely-transferable part — composable filters — extracted onto the **existing** `onRequest` handler, with no parallel API:

```kotlin
typealias Http3RequestHandler = suspend Http3ServerExchange.() -> Unit   // == onRequest's type
typealias Http3RequestFilter  = (Http3RequestHandler) -> Http3RequestHandler
infix fun Http3RequestFilter.then(next): Http3RequestFilter      // compose
fun       Http3RequestFilter.then(handler): Http3RequestHandler  // terminate → hand to onRequest

withHttp3Server(..., onRequest = logging.then(requireApiKey).then(myHandler)) { ... }
```

A composed chain **is** the `onRequest` value (no adapter). The one real constraint is documented: filters run *around* the imperative, zero-copy handler — act before/after, catch, or short-circuit (send a response and don't call `next`) — but cannot post-edit a response the handler already streamed. That's the deliberate trade vs a value-based `(Request)→Response` API, and the reason this is a filter set rather than a routes facade.

### What was tried and dropped

An earlier spike built a full `withHttp3Routes` facade (sealed `Http3Outcome { Respond | Upgrade }`, `Http3RequestView`, `Http3BodyWriter`-over-sink, one unified handler bridging requests + WebTransport). It didn't earn a second public API: it adds zero capability; zero-copy undercuts http4k's value-oriented model (the body is a streaming writer, not a materialized value); there's no routing DSL (the actual http4k ergonomic win); and the sealed `Http3Outcome` "unification" is mostly cosmetic because the framework already demuxes Extended CONNECT at the wire layer, so the handler's arm choice is pre-constrained by what the client sent. That facade is **not** in this PR.

**Tests:** loopback test composing an around-filter (`observe`) + a short-circuiting filter (`requireToken`) in front of a handler — green on JVM + linuxX64.

## Validation

- `:socket-quic:jvmTest --tests QuicBufferFactoryGuardTest` — 5/5 green
- `:socket-http3:jvmTest` + `:socket-http3:linuxX64Test` — filter test green on both
- Both modules compile on JVM + linuxX64; ktlint clean. Apple is commonMain-only here, so CI covers `build-apple`.

No public API removed; the guard only rejects inputs that already crashed. Apple/Windows/Android lanes left to CI.
