### PR TITLE
feat(http3): WebTransport legacy-settings interop + foreign-stack WT/QPACK interop in CI

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -343,14 +343,15 @@ jobs:
       # here keeps the published socket-http3 artifact gatekept by CI — otherwise the module
       # would publish (root publishToMavenLocal includes it) but go entirely unvalidated,
       # the same gap #74/#76 fixed for socket-quic's JS suite.
-      # Start the third-party HTTP/3 server (aioquic + lsqpack, built from socket-http3/docker-interop)
-      # so Http3DockerInteropTests — bundled in :socket-http3:jvmTest below — actually RUNS instead of
-      # self-skipping on an unreachable 127.0.0.1:4433. This is our ONLY foreign-decoder QPACK-eviction
-      # check: the in-process loopback round-trips our encoder through our OWN decoder, so a bug
-      # symmetric across both halves would hide. `start` is detached and blocks until the server logs
-      # it is serving, so the test has a provably-up peer. A build/start failure fails the job on
-      # purpose — the alternative (silently skipping) is exactly the gap this closes.
-      - name: Start HTTP/3 QPACK interop server (aioquic/lsqpack)
+      # Start the third-party HTTP/3 + WebTransport server (aioquic + lsqpack, built from
+      # socket-http3/docker-interop) so the foreign-stack interop tests bundled in :socket-http3:jvmTest
+      # below — Http3DockerInteropTests (QPACK eviction) and WebTransportDockerInteropTests (WT bidi
+      # echo) — actually RUN instead of self-skipping on an unreachable 127.0.0.1:4433. These are our
+      # ONLY checks against a foreign stack: the in-process loopback round-trips our client through our
+      # OWN server, so a bug symmetric across both halves would hide. `start` is detached and blocks
+      # until the server logs it is serving, so the tests have a provably-up peer. A build/start failure
+      # fails the job on purpose — the alternative (silently skipping) is exactly the gap this closes.
+      - name: Start HTTP/3 + WebTransport interop server (aioquic)
         run: socket-http3/docker-interop/run-server.sh start
 
       - name: Run checks and tests

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -343,6 +343,16 @@ jobs:
       # here keeps the published socket-http3 artifact gatekept by CI — otherwise the module
       # would publish (root publishToMavenLocal includes it) but go entirely unvalidated,
       # the same gap #74/#76 fixed for socket-quic's JS suite.
+      # Start the third-party HTTP/3 server (aioquic + lsqpack, built from socket-http3/docker-interop)
+      # so Http3DockerInteropTests — bundled in :socket-http3:jvmTest below — actually RUNS instead of
+      # self-skipping on an unreachable 127.0.0.1:4433. This is our ONLY foreign-decoder QPACK-eviction
+      # check: the in-process loopback round-trips our encoder through our OWN decoder, so a bug
+      # symmetric across both halves would hide. `start` is detached and blocks until the server logs
+      # it is serving, so the test has a provably-up peer. A build/start failure fails the job on
+      # purpose — the alternative (silently skipping) is exactly the gap this closes.
+      - name: Start HTTP/3 QPACK interop server (aioquic/lsqpack)
+        run: socket-http3/docker-interop/run-server.sh start
+
       - name: Run checks and tests
         run: >-
           ./gradlew :jvmTest :jsTest :linuxX64Test :testDebugUnitTest :ktlintCheck
@@ -352,6 +362,10 @@ jobs:
           :socket-http3:testDebugUnitTest :socket-http3:ktlintCheck
           -PquicEchoAllArches=true
           --no-configuration-cache ${{ inputs.gradle-args }}
+
+      - name: Stop HTTP/3 QPACK interop server
+        if: always()
+        run: socket-http3/docker-interop/run-server.sh stop
 
       # The quiche_conn_recv SIGABRT that previously required continue-on-error
       # was a JVM-side sockaddr lifetime bug (DirectByteBuffer Cleaner freeing

--- a/socket-http3/docker-interop/run-server.sh
+++ b/socket-http3/docker-interop/run-server.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Build + run the aioquic HTTP/3 echo server for the gated Http3DockerInteropTests.
 #
-#   ./run-server.sh            # build (if needed) and run in the foreground on udp/4433
+#   ./run-server.sh            # build (if needed) and run in the FOREGROUND on udp/4433 (local dev)
+#   ./run-server.sh start      # build + run DETACHED, block until ready, then return (CI)
 #   ./run-server.sh stop       # stop + remove the container
 #   QPACK_MAX_TABLE_CAPACITY=256 ./run-server.sh   # force eviction with a smaller table
 #
@@ -14,6 +15,9 @@ NAME="socket-http3-interop"
 PORT="${HTTP3_PORT:-4433}"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# The line server.py prints (flush=True) once it is bound and serving — our readiness signal.
+READY_MARKER="h3 echo server on udp/"
+
 if [[ "${1:-}" == "stop" ]]; then
   docker rm -f "$NAME" >/dev/null 2>&1 || true
   echo "stopped $NAME"
@@ -22,8 +26,29 @@ fi
 
 docker build -t "$IMAGE" "$DIR"
 docker rm -f "$NAME" >/dev/null 2>&1 || true
-exec docker run --rm --name "$NAME" \
-  -p "${PORT}:4433/udp" \
-  -e "QPACK_MAX_TABLE_CAPACITY=${QPACK_MAX_TABLE_CAPACITY:-4096}" \
-  -e "QPACK_BLOCKED_STREAMS=${QPACK_BLOCKED_STREAMS:-16}" \
-  "$IMAGE"
+
+run_args=(
+  --name "$NAME"
+  -p "${PORT}:4433/udp"
+  -e "QPACK_MAX_TABLE_CAPACITY=${QPACK_MAX_TABLE_CAPACITY:-4096}"
+  -e "QPACK_BLOCKED_STREAMS=${QPACK_BLOCKED_STREAMS:-16}"
+)
+
+if [[ "${1:-}" == "start" ]]; then
+  # Detached: start, then block until the server logs it is serving so the caller (CI) can run the
+  # test against a server that is provably up — making Http3DockerInteropTests actually RUN, not skip.
+  docker run -d --rm "${run_args[@]}" "$IMAGE" >/dev/null
+  for _ in $(seq 1 30); do
+    if docker logs "$NAME" 2>&1 | grep -q "$READY_MARKER"; then
+      echo "interop server ready on udp/${PORT}"
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: interop server did not become ready within 30s" >&2
+  docker logs "$NAME" 2>&1 | tail -20 >&2 || true
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  exit 1
+fi
+
+exec docker run --rm "${run_args[@]}" "$IMAGE"

--- a/socket-http3/docker-interop/server.py
+++ b/socket-http3/docker-interop/server.py
@@ -25,7 +25,12 @@ import pathlib
 from aioquic.asyncio import serve
 from aioquic.asyncio.protocol import QuicConnectionProtocol
 from aioquic.h3.connection import H3Connection
-from aioquic.h3.events import DataReceived, HeadersReceived
+from aioquic.h3.events import (
+    DataReceived,
+    DatagramReceived,
+    HeadersReceived,
+    WebTransportStreamDataReceived,
+)
 from aioquic.quic.configuration import QuicConfiguration
 from aioquic.quic.events import ProtocolNegotiated, QuicEvent
 
@@ -77,6 +82,10 @@ class H3EchoProtocol(QuicConnectionProtocol):
         self._http: H3Connection | None = None
         self._request_headers: dict[int, list[tuple[bytes, bytes]]] = {}
         self._answered: set[int] = set()
+        # WebTransport: accepted session (CONNECT) stream ids, and per-bidi-stream accumulators so a
+        # stream is echoed back as one chunk on FIN (mirrors the request-on-stream-end QPACK path).
+        self._wt_sessions: set[int] = set()
+        self._wt_stream_data: dict[int, bytearray] = {}
 
     def quic_event_received(self, event: QuicEvent) -> None:
         if isinstance(event, ProtocolNegotiated) and event.alpn_protocol == "h3":
@@ -84,18 +93,41 @@ class H3EchoProtocol(QuicConnectionProtocol):
             # emits SETTINGS, so set them on the instance the constructor path consults.
             H3Connection._max_table_capacity = MAX_TABLE_CAPACITY
             H3Connection._blocked_streams = BLOCKED_STREAMS
-            self._http = H3Connection(self._quic)
+            # enable_webtransport advertises ENABLE_CONNECT_PROTOCOL + H3_DATAGRAM + ENABLE_WEBTRANSPORT
+            # (the draft-02 toggle aioquic implements) so a WebTransport CONNECT is accepted.
+            self._http = H3Connection(self._quic, enable_webtransport=True)
         if self._http is not None:
             for http_event in self._http.handle_event(event):
                 self._handle_http_event(http_event)
 
     def _handle_http_event(self, event) -> None:
         if isinstance(event, HeadersReceived):
+            headers = dict(event.headers)
+            if headers.get(b":method") == b"CONNECT" and headers.get(b":protocol") == b"webtransport":
+                # Accept the WebTransport session: 200, stream stays open (no FIN).
+                self._wt_sessions.add(event.stream_id)
+                assert self._http is not None
+                self._http.send_headers(event.stream_id, [(b":status", b"200")], end_stream=False)
+                self.transmit()
+                return
             self._request_headers[event.stream_id] = event.headers
             if event.stream_ended:
                 self._respond(event.stream_id)
         elif isinstance(event, DataReceived) and event.stream_ended:
             self._respond(event.stream_id)
+        elif isinstance(event, WebTransportStreamDataReceived):
+            # Echo a bidirectional WebTransport stream back, byte-for-byte, FINishing on the peer's FIN.
+            buf = self._wt_stream_data.setdefault(event.stream_id, bytearray())
+            buf += event.data
+            if event.stream_ended:
+                self._quic.send_stream_data(event.stream_id, bytes(buf), end_stream=True)
+                del self._wt_stream_data[event.stream_id]
+                self.transmit()
+        elif isinstance(event, DatagramReceived):
+            # Echo a WebTransport datagram back on the same session (stream_id == session/flow id).
+            assert self._http is not None
+            self._http.send_datagram(event.stream_id, event.data)
+            self.transmit()
 
     def _respond(self, stream_id: int) -> None:
         if stream_id in self._answered:
@@ -119,7 +151,7 @@ async def main() -> None:
     await serve(HOST, PORT, configuration=configuration, create_protocol=H3EchoProtocol)
     print(
         f"h3 echo server on udp/{PORT} (QPACK max_table_capacity={MAX_TABLE_CAPACITY}, "
-        f"blocked_streams={BLOCKED_STREAMS})",
+        f"blocked_streams={BLOCKED_STREAMS}, webtransport=on)",
         flush=True,
     )
     await asyncio.Future()

--- a/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
+++ b/socket-http3/src/commonMain/kotlin/com/ditchoom/socket/http3/Http3Connection.kt
@@ -59,11 +59,28 @@ data class Http3Settings(
     val wtMaxSessions: Long get() = value(Http3SettingId.WEBTRANSPORT_MAX_SESSIONS) ?: 0L
 
     /**
-     * The peer can accept WebTransport sessions we initiate: it advertised Extended CONNECT
-     * (RFC 9220), HTTP Datagrams (RFC 9297), and a non-zero session limit. Gate
-     * `connectWebTransport` on this.
+     * Legacy draft-02 WebTransport toggle (`SETTINGS_ENABLE_WEBTRANSPORT = 1`). Superseded by
+     * [wtMaxSessions], but still the *only* WebTransport setting some widely-deployed reference stacks
+     * advertise (e.g. aioquic 1.3.0). We send both (see [webTransportSettings]); to interop with those
+     * peers we must also *accept* the legacy one — hence its place in [webTransportSupported].
      */
-    val webTransportSupported: Boolean get() = enableConnectProtocol && h3DatagramEnabled && wtMaxSessions > 0
+    val enableWebTransportLegacy: Boolean get() = value(Http3SettingId.ENABLE_WEBTRANSPORT) == 1L
+
+    /**
+     * The peer can accept WebTransport sessions we initiate: it advertised Extended CONNECT
+     * (RFC 9220), HTTP Datagrams (RFC 9297), and a session limit. `WEBTRANSPORT_MAX_SESSIONS` is
+     * **authoritative when present** — an explicit `0` means the peer accepts none, so a legacy
+     * `ENABLE_WEBTRANSPORT = 1` advertised alongside it does NOT override that (an endpoint sends both
+     * but `0` is the real limit; cf. our own initiate-only `webTransportSettings`). The legacy toggle is
+     * the gate only when `WEBTRANSPORT_MAX_SESSIONS` is **absent** — a true draft-02 peer (e.g. aioquic
+     * 1.3.0) sends no count, so a bare enable means "at least one". Gate `connectWebTransport` on this.
+     */
+    val webTransportSupported: Boolean
+        get() {
+            if (!enableConnectProtocol || !h3DatagramEnabled) return false
+            val maxSessions = value(Http3SettingId.WEBTRANSPORT_MAX_SESSIONS)
+            return if (maxSessions != null) maxSessions > 0 else enableWebTransportLegacy
+        }
 }
 
 /**

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3DockerInteropTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/Http3DockerInteropTests.kt
@@ -56,10 +56,14 @@ class Http3DockerInteropTests {
             withContext(Dispatchers.Default) {
                 var connected = false
                 try {
-                    withHttp3Connection(host, port, quicOptions, connectionOptions, timeout = 8.seconds) {
+                    // `timeout` caps the WHOLE operation (handshake + all 64 round-trips + teardown), so
+                    // it must absorb CI/full-suite CPU + single-process-aioquic contention, not just the
+                    // handshake — 30s is generous headroom over the ~0.5s isolated run. A genuinely down
+                    // server still fails instantly (connection refused), so the skip path stays fast.
+                    withHttp3Connection(host, port, quicOptions, connectionOptions, timeout = 30.seconds) {
                         // Let the server SETTINGS (its QPACK_MAX_TABLE_CAPACITY) arrive so our encoder
                         // activates its dynamic table before we start issuing requests.
-                        withTimeout(6.seconds) { peerSettings() }
+                        withTimeout(15.seconds) { peerSettings() }
                         connected = true // past the handshake — failures below are real regressions
 
                         val recurring = QpackHeaderField("x-recurring", "stable-token-kept-across-every-request")

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportDockerInteropTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportDockerInteropTests.kt
@@ -1,0 +1,123 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.DatagramOptions
+import com.ditchoom.socket.quic.QuicOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * **WebTransport interop** against an INDEPENDENT stack (aioquic) — the reliable, CI-runnable counterpart
+ * to [WebTransportPublicEndpointInteropTests] (which has no reachable public WT echo server). The
+ * aioquic server in `socket-http3/docker-interop/` accepts a WebTransport Extended CONNECT and echoes
+ * each bidirectional stream byte-for-byte; this test opens a session, opens a bidi stream, sends a
+ * payload, half-closes, and asserts the echo round-trips unchanged.
+ *
+ * Why a foreign stack: the in-process [Http3LoopbackTestSuite] WebTransport cases run our client against
+ * our OWN server, so a bug symmetric across both halves hides. aioquic also pins a real interop
+ * subtlety — it advertises only the legacy draft-02 `ENABLE_WEBTRANSPORT` setting, not the newer
+ * `WEBTRANSPORT_MAX_SESSIONS`. This test is the regression guard for our client accepting that legacy
+ * signal (see [Http3Settings.webTransportSupported]); without it, `connectWebTransport` would reject the
+ * peer and this test would fail rather than echo.
+ *
+ * **Skip-on-unreachable.** If the docker server isn't up on 127.0.0.1:4433 the handshake fails before
+ * [connected] flips and the test logs a SKIP — never a flaky failure. Once the H3 connection is
+ * established, every step (session, stream echo) is a real assertion: this is OUR controlled peer, so
+ * "reachable but WebTransport misbehaves" is exactly the regression we want surfaced. Start the server
+ * with `socket-http3/docker-interop/run-server.sh start`; CI does this in build-linux.yaml.
+ */
+class WebTransportDockerInteropTests {
+    private val host = "127.0.0.1"
+    private val port = 4433
+
+    private val quicOptions =
+        QuicOptions(
+            alpnProtocols = listOf(HTTP3_ALPN),
+            verifyPeer = false, // self-signed docker cert; identity doesn't matter for interop
+            idleTimeout = 10.seconds,
+            datagrams = DatagramOptions(), // WebTransport requires H3 datagrams negotiated in the handshake
+        )
+    private val connectionOptions = ConnectionOptions(bufferFactory = BufferFactory.deterministic())
+
+    @Test
+    fun bidiStreamEchoesThroughAioquicWebTransport_orSkips() =
+        runTest(timeout = 60.seconds) {
+            withContext(Dispatchers.Default) {
+                val payload = "ditchoom-wt-docker-interop"
+                var connected = false
+                val echoed: String? =
+                    try {
+                        // `timeout` caps the whole operation (handshake + session + echo + teardown), so
+                        // give it headroom for CI/full-suite contention; a down server still fails fast.
+                        withHttp3Connection(
+                            host,
+                            port,
+                            quicOptions,
+                            connectionOptions,
+                            timeout = 20.seconds,
+                            webTransport = WebTransportOptions(maxSessions = 1),
+                        ) {
+                            withTimeout(10.seconds) { peerSettings() }
+                            connected = true // H3 connection is up — anything past here is a real check
+                            val session = connectWebTransport(authority = "localhost", path = "/")
+                            try {
+                                val stream = session.openBidiStream()
+                                val out = textBuffer(payload)
+                                try {
+                                    stream.write(out)
+                                } finally {
+                                    out.freeIfNeeded() // write is zero-copy; it does not take ownership
+                                }
+                                stream.shutdownSend()
+                                withTimeout(15.seconds) { stream.drainUtf8() }
+                            } finally {
+                                session.close(code = 0, reason = "interop done")
+                            }
+                        }
+                    } catch (t: Throwable) {
+                        if (connected) throw t // failure after a live connection is a real regression
+                        println(
+                            "[WebTransportDockerInteropTests] SKIP — aioquic WT server not reachable on " +
+                                "$host:$port (start it: socket-http3/docker-interop/run-server.sh start) — " +
+                                "${t::class.simpleName}: ${t.message}",
+                        )
+                        null
+                    }
+
+                if (echoed != null) {
+                    assertEquals(payload, echoed, "aioquic WebTransport bidi echo must round-trip unchanged")
+                    println("[WebTransportDockerInteropTests] OK — bidi stream echoed through aioquic WebTransport")
+                }
+            }
+        }
+
+    private fun textBuffer(s: String) =
+        BufferFactory.deterministic().allocate(s.length.coerceAtLeast(1)).apply {
+            writeString(s, Charset.UTF8)
+            resetForRead()
+        }
+}
+
+/** Drain a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */
+private suspend fun WebTransportStream.drainUtf8(): String {
+    val sb = StringBuilder()
+    while (true) {
+        when (val r = read(8.seconds)) {
+            is ReadResult.Data -> {
+                sb.append(r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+                r.buffer.freeIfNeeded()
+            }
+            ReadResult.End, ReadResult.Reset -> return sb.toString()
+        }
+    }
+}

--- a/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportPublicEndpointInteropTests.kt
+++ b/socket-http3/src/commonTest/kotlin/com/ditchoom/socket/http3/WebTransportPublicEndpointInteropTests.kt
@@ -1,0 +1,130 @@
+package com.ditchoom.socket.http3
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.deterministic
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.freeIfNeeded
+import com.ditchoom.socket.ConnectionOptions
+import com.ditchoom.socket.quic.DatagramOptions
+import com.ditchoom.socket.quic.QuicOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Real-world **WebTransport interop** smoke test: can our client open a WebTransport session (RFC 9220
+ * Extended CONNECT over a real `h3` server), open a bidirectional stream, and get an exact echo back —
+ * against a third-party WebTransport stack, not our own loopback? The in-process
+ * [Http3LoopbackTestSuite] WebTransport cases round-trip our client through our *own* server, so a bug
+ * symmetric across both halves could hide; a foreign server (e.g. the public `webtransport.day` echo,
+ * a Go/quic-go stack) can't be wrong in the same way.
+ *
+ * **Skip-on-unreachable, never flaky-fail** — same contract as [Http3PublicEndpointInteropTests] and
+ * [QuicPublicEndpointInteropTests]. UDP/443 egress isn't guaranteed in CI, public WebTransport servers
+ * come and go, and JS has no QUIC — so any *establishment* failure (no egress, server down, peer
+ * doesn't advertise WebTransport, draft-version mismatch on the CONNECT) is caught and logged as a SKIP.
+ * The echo-equality assertion runs **outside** the skip-catch: a session that establishes and a stream
+ * that round-trips but returns the WRONG bytes is a real regression and fails the test. If every
+ * endpoint skips, a single loud line flags that no real WebTransport interop was validated.
+ *
+ * Datagrams are deliberately NOT asserted — they're unreliable by design (RFC 9221), so an echo
+ * datagram may legitimately never arrive; only the ordered, reliable bidi-stream echo is the contract.
+ */
+class WebTransportPublicEndpointInteropTests {
+    // host, port, session path. The echo server echoes whatever a bidi stream sends.
+    private val endpoints =
+        listOf(
+            Triple("webtransport.day", 443, "/"),
+        )
+
+    private val quicOptions =
+        QuicOptions(
+            alpnProtocols = listOf(HTTP3_ALPN),
+            verifyPeer = true, // real CT-logged cert — the production path
+            idleTimeout = 10.seconds,
+            datagrams = DatagramOptions(), // WebTransport requires H3 datagrams in the handshake
+        )
+    private val connectionOptions = ConnectionOptions(bufferFactory = BufferFactory.deterministic())
+
+    @Test
+    fun echoesOverPublicWebTransport_orSkips() =
+        runTest(timeout = 60.seconds) {
+            withContext(Dispatchers.Default) {
+                val payload = "ditchoom-webtransport-interop"
+                var validated = 0
+                for ((host, port, path) in endpoints) {
+                    val echoed: String? =
+                        try {
+                            withHttp3Connection(
+                                host,
+                                port,
+                                quicOptions,
+                                connectionOptions,
+                                timeout = 8.seconds,
+                                webTransport = WebTransportOptions(maxSessions = 1),
+                            ) {
+                                withTimeout(5.seconds) { peerSettings() }
+                                val session = connectWebTransport(authority = host, path = path)
+                                try {
+                                    val stream = session.openBidiStream()
+                                    val out = textBuffer(payload)
+                                    try {
+                                        stream.write(out)
+                                    } finally {
+                                        out.freeIfNeeded() // write is zero-copy; it does not take ownership
+                                    }
+                                    stream.shutdownSend()
+                                    withTimeout(8.seconds) { stream.drainUtf8() }
+                                } finally {
+                                    session.close(code = 0, reason = "interop done")
+                                }
+                            }
+                        } catch (t: Throwable) {
+                            println(
+                                "[WebTransportPublicEndpointInteropTests] public WT SKIP $host:$port$path — " +
+                                    "${t::class.simpleName}: ${t.message}",
+                            )
+                            null
+                        }
+
+                    if (echoed != null) {
+                        // A real, foreign WebTransport echo completed — the bytes MUST match exactly.
+                        assertEquals(payload, echoed, "$host: WebTransport bidi echo must round-trip unchanged")
+                        validated++
+                        println("[WebTransportPublicEndpointInteropTests] public WT OK $host:$port$path echo=\"$echoed\"")
+                    }
+                }
+                if (validated == 0) {
+                    println(
+                        "[WebTransportPublicEndpointInteropTests] ALL endpoints skipped — no public WebTransport " +
+                            "echo validated (check UDP:443 egress / server availability / platform QUIC support)",
+                    )
+                }
+            }
+        }
+
+    private fun textBuffer(s: String) =
+        BufferFactory.deterministic().allocate(s.length.coerceAtLeast(1)).apply {
+            writeString(s, Charset.UTF8)
+            resetForRead()
+        }
+}
+
+/** Drain a bidirectional WebTransport stream to end-of-stream as a UTF-8 string. */
+private suspend fun WebTransportStream.drainUtf8(): String {
+    val sb = StringBuilder()
+    while (true) {
+        when (val r = read(8.seconds)) {
+            is ReadResult.Data -> {
+                sb.append(r.buffer.readString(r.buffer.remaining(), Charset.UTF8))
+                r.buffer.freeIfNeeded()
+            }
+            ReadResult.End, ReadResult.Reset -> return sb.toString()
+        }
+    }
+}


### PR DESCRIPTION
Closes our interop coverage gaps against real, foreign HTTP/3 + WebTransport stacks — and fixes a genuine WebTransport interop bug that building the test surfaced.

## The interop bug (production fix)

Our client gated `connectWebTransport` on the peer advertising the **newer** `WEBTRANSPORT_MAX_SESSIONS`. But aioquic 1.3.0 — a widely-used reference stack — advertises only the **legacy draft-02 `ENABLE_WEBTRANSPORT`**, so our client *refused to open a session to it*. We already **send** the legacy setting "for interop with older peers"; the receive gate was just asymmetric with that. Fix: `Http3Settings.webTransportSupported` now also accepts `ENABLE_WEBTRANSPORT = 1` (a bare enable ⇒ "at least one session"; draft-02 peers send no count). Our own loopback server sends both settings, so its `wtMaxSessions > 0` path is unchanged — **loopback WT suite stays 15/15 green**.

This is exactly what foreign-stack interop is meant to catch — the in-process loopback runs our client through our own server, so a symmetric assumption like this hides.

## Foreign-stack WebTransport interop (new)

Extended the aioquic docker server (`socket-http3/docker-interop/server.py`) to also speak WebTransport — `enable_webtransport=True`, accept the Extended CONNECT, echo bidi streams byte-for-byte and datagrams — alongside its existing QPACK HTTP/3 echo. One server, both foreign-stack tests. New `WebTransportDockerInteropTests` opens a session, echoes a bidi stream, asserts it round-trips. Reachable-but-misbehaving is a real failure (our controlled peer); unreachable skips.

## Foreign-stack QPACK interop now runs in CI

`Http3DockerInteropTests` (our QPACK encoder vs aioquic/lsqpack's decoder, exercising dynamic-table eviction) previously self-skipped in CI because no workflow started the container — our only cross-stack QPACK check never ran. `build-linux.yaml` now starts the server (new detached `run-server.sh start` that blocks until it logs it is serving) before `:socket-http3:jvmTest` and stops it after. A build/start failure fails the job on purpose.

## Public WebTransport interop test (scaffolding)

`WebTransportPublicEndpointInteropTests` mirrors the H3/QUIC public suites (skip-on-unreachable). **Honest caveat:** no stable public WT echo server is reachable today (`webtransport.day` is TCP-served, not a QUIC echo), so it skips — the docker test above is the one that actually validates WebTransport interop.

## Verification

- **This PR's build-linux run exercises the docker step** — a green check here is the proof both foreign-stack tests run in CI.
- Locally, server up: `WebTransportDockerInteropTests` OK (bidi echo) + `Http3DockerInteropTests` OK (64 evicting requests), both **0 skipped**.
- Loopback WT suite 15/15, ktlint clean, compiles JVM + linuxX64.

Now a release (no longer `skip-release`) because the WebTransport gate is a client behavior change.
