### PR TITLE
ci(android): split AVD cache restore/save — stop caching post-test userdata

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -104,8 +104,18 @@ jobs:
       - name: Bring up quic-echo via the docker harness
         run: cd test-harness && docker compose up -d --wait quic-echo
 
-      - name: AVD cache
-        uses: actions/cache@v5
+      # restore/save are deliberately SPLIT (not the unified actions/cache):
+      # the unified action saves at job END — after `run tests` — so every
+      # cache-miss run caches AVD userdata WITH the test APKs installed,
+      # possibly torn from the emulator teardown mid-write. The next run then
+      # fails before any test: the stale install can neither be uninstalled
+      # (DELETE_FAILED_INTERNAL_ERROR on old API levels) nor reinstalled over
+      # (INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES). Saving explicitly
+      # right after the create-AVD step caches the PRISTINE snapshot — no
+      # package ever installed. (Root-caused in DitchOoM/buffer#186 where the
+      # API-21 lane was failing this way on every second run.)
+      - name: AVD cache (restore)
+        uses: actions/cache/restore@v5
         id: avd-cache
         with:
           path: |
@@ -124,6 +134,15 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
+
+      - name: AVD cache (save pristine snapshot)
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-x86_64-${{ matrix.api-level }}
 
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
The unified `actions/cache` saves at job end — **after** `connectedAndroidTest` — so every cache-miss run cached the AVD userdata **with the test APKs installed**, possibly torn from emulator teardown. The next run restores that and dies before any test runs: the stale install can neither be uninstalled (`DELETE_FAILED_INTERNAL_ERROR`) nor reinstalled over (`INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES`). Each green run poisons the next.

Root-caused on DitchOoM/buffer#186, where the Android API-21 lane hit exactly this on every second run (an eviction + rerun went green, then the green run's job-end save re-poisoned the cache and the next commit failed again). Socket has the identical construct on `avd-x86_64-29`.

Fix: `actions/cache/restore` + an explicit `actions/cache/save` immediately after the create-AVD step, so only the pristine snapshot (no packages ever installed) is cached. The two existing `avd-x86_64-29` cache entries are evicted.

Label: skip-release (CI-only).